### PR TITLE
Feature: Add Pexels integration and fix Instagram OAuth

### DIFF
--- a/docs/pexels-api.md
+++ b/docs/pexels-api.md
@@ -1,0 +1,465 @@
+# Pexels API Documentation
+
+## Overview
+
+Pexels integration provides free stock photos and videos for use in social media posts.
+
+**Base URL:** `/pexels`
+
+**Authentication:** All endpoints require JWT authentication (Bearer token)
+
+**Environment Variable:**
+```env
+PEXELS_API_KEY=your_pexels_api_key
+```
+
+Get your API key from: https://www.pexels.com/api/
+
+---
+
+## Photo Endpoints
+
+### 1. Search Photos
+
+Search for photos by keyword.
+
+**Endpoint:** `GET /pexels/photos/search`
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search term (e.g., "nature", "business") |
+| `orientation` | string | No | `landscape`, `portrait`, or `square` |
+| `size` | string | No | `large`, `medium`, or `small` |
+| `color` | string | No | Hex color (e.g., `FF0000`) or color name (e.g., `red`, `blue`) |
+| `locale` | string | No | Locale code (e.g., `en-US`, `pt-BR`) |
+| `page` | number | No | Page number (default: 1) |
+| `perPage` | number | No | Results per page (default: 15, max: 80) |
+
+**Example Request:**
+```
+GET /pexels/photos/search?query=business&orientation=landscape&perPage=20
+```
+
+**Example Response:**
+```json
+{
+  "items": [
+    {
+      "id": 3184291,
+      "width": 6000,
+      "height": 4000,
+      "url": "https://www.pexels.com/photo/...",
+      "photographer": "fauxels",
+      "photographerUrl": "https://www.pexels.com/@fauxels",
+      "photographerId": 1092082,
+      "avgColor": "#8B7355",
+      "src": {
+        "original": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg",
+        "large2x": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+        "large": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&h=650&w=940",
+        "medium": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&h=350",
+        "small": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&h=130",
+        "portrait": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800",
+        "landscape": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200",
+        "tiny": "https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"
+      },
+      "alt": "Photo of People Near Wooden Table"
+    }
+  ],
+  "totalResults": 8000,
+  "page": 1,
+  "perPage": 20,
+  "nextPage": "https://api.pexels.com/v1/search?page=2&per_page=20&query=business",
+  "prevPage": null
+}
+```
+
+---
+
+### 2. Get Curated Photos
+
+Get editor's choice / featured photos.
+
+**Endpoint:** `GET /pexels/photos/curated`
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page` | number | No | Page number (default: 1) |
+| `perPage` | number | No | Results per page (default: 15, max: 80) |
+
+**Example Request:**
+```
+GET /pexels/photos/curated?page=1&perPage=10
+```
+
+**Example Response:**
+```json
+{
+  "items": [
+    {
+      "id": 2014422,
+      "width": 3024,
+      "height": 3024,
+      "url": "https://www.pexels.com/photo/...",
+      "photographer": "Joey Kyber",
+      "photographerUrl": "https://www.pexels.com/@joey-kyber-137055",
+      "photographerId": 137055,
+      "avgColor": "#978E82",
+      "src": {
+        "original": "...",
+        "large2x": "...",
+        "large": "...",
+        "medium": "...",
+        "small": "...",
+        "portrait": "...",
+        "landscape": "...",
+        "tiny": "..."
+      },
+      "alt": "Brown Rocks During Golden Hour"
+    }
+  ],
+  "totalResults": 8000,
+  "page": 1,
+  "perPage": 10,
+  "nextPage": "https://api.pexels.com/v1/curated?page=2&per_page=10",
+  "prevPage": null
+}
+```
+
+---
+
+### 3. Get Photo by ID
+
+Get a specific photo by its ID.
+
+**Endpoint:** `GET /pexels/photos/:id`
+
+**Path Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | number | Yes | Pexels photo ID |
+
+**Example Request:**
+```
+GET /pexels/photos/3184291
+```
+
+**Example Response:**
+```json
+{
+  "id": 3184291,
+  "width": 6000,
+  "height": 4000,
+  "url": "https://www.pexels.com/photo/...",
+  "photographer": "fauxels",
+  "photographerUrl": "https://www.pexels.com/@fauxels",
+  "photographerId": 1092082,
+  "avgColor": "#8B7355",
+  "src": {
+    "original": "...",
+    "large2x": "...",
+    "large": "...",
+    "medium": "...",
+    "small": "...",
+    "portrait": "...",
+    "landscape": "...",
+    "tiny": "..."
+  },
+  "alt": "Photo of People Near Wooden Table"
+}
+```
+
+---
+
+## Video Endpoints
+
+### 4. Search Videos
+
+Search for videos by keyword.
+
+**Endpoint:** `GET /pexels/videos/search`
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search term (e.g., "ocean", "city") |
+| `orientation` | string | No | `landscape`, `portrait`, or `square` |
+| `size` | string | No | `large`, `medium`, or `small` |
+| `locale` | string | No | Locale code (e.g., `en-US`) |
+| `page` | number | No | Page number (default: 1) |
+| `perPage` | number | No | Results per page (default: 15, max: 80) |
+
+**Example Request:**
+```
+GET /pexels/videos/search?query=ocean&orientation=landscape&perPage=10
+```
+
+**Example Response:**
+```json
+{
+  "items": [
+    {
+      "id": 1093662,
+      "width": 1920,
+      "height": 1080,
+      "url": "https://www.pexels.com/video/...",
+      "image": "https://images.pexels.com/videos/1093662/free-video-1093662.jpg",
+      "duration": 22,
+      "user": {
+        "id": 631997,
+        "name": "Engin Akyurt",
+        "url": "https://www.pexels.com/@enginakyurt"
+      },
+      "videoFiles": [
+        {
+          "id": 48035,
+          "quality": "hd",
+          "fileType": "video/mp4",
+          "width": 1920,
+          "height": 1080,
+          "fps": 23.976,
+          "link": "https://player.vimeo.com/external/..."
+        },
+        {
+          "id": 48036,
+          "quality": "sd",
+          "fileType": "video/mp4",
+          "width": 960,
+          "height": 540,
+          "fps": 23.976,
+          "link": "https://player.vimeo.com/external/..."
+        }
+      ],
+      "videoPictures": [
+        {
+          "id": 134906,
+          "picture": "https://images.pexels.com/videos/1093662/pictures/preview-0.jpg",
+          "nr": 0
+        }
+      ]
+    }
+  ],
+  "totalResults": 5000,
+  "page": 1,
+  "perPage": 10,
+  "nextPage": "https://api.pexels.com/videos/search?page=2&per_page=10&query=ocean",
+  "prevPage": null
+}
+```
+
+---
+
+### 5. Get Popular Videos
+
+Get trending/popular videos.
+
+**Endpoint:** `GET /pexels/videos/popular`
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page` | number | No | Page number (default: 1) |
+| `perPage` | number | No | Results per page (default: 15, max: 80) |
+| `minWidth` | number | No | Minimum video width in pixels |
+| `minHeight` | number | No | Minimum video height in pixels |
+| `minDuration` | number | No | Minimum duration in seconds |
+| `maxDuration` | number | No | Maximum duration in seconds |
+
+**Example Request:**
+```
+GET /pexels/videos/popular?perPage=10&minDuration=5&maxDuration=30
+```
+
+**Example Response:**
+```json
+{
+  "items": [
+    {
+      "id": 857251,
+      "width": 1920,
+      "height": 1080,
+      "url": "https://www.pexels.com/video/...",
+      "image": "https://images.pexels.com/videos/857251/free-video-857251.jpg",
+      "duration": 15,
+      "user": {
+        "id": 2659,
+        "name": "Pressmaster",
+        "url": "https://www.pexels.com/@pressmaster"
+      },
+      "videoFiles": [...],
+      "videoPictures": [...]
+    }
+  ],
+  "totalResults": 10000,
+  "page": 1,
+  "perPage": 10,
+  "nextPage": "...",
+  "prevPage": null
+}
+```
+
+---
+
+### 6. Get Video by ID
+
+Get a specific video by its ID.
+
+**Endpoint:** `GET /pexels/videos/:id`
+
+**Path Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | number | Yes | Pexels video ID |
+
+**Example Request:**
+```
+GET /pexels/videos/1093662
+```
+
+**Example Response:**
+```json
+{
+  "id": 1093662,
+  "width": 1920,
+  "height": 1080,
+  "url": "https://www.pexels.com/video/...",
+  "image": "https://images.pexels.com/videos/1093662/free-video-1093662.jpg",
+  "duration": 22,
+  "user": {
+    "id": 631997,
+    "name": "Engin Akyurt",
+    "url": "https://www.pexels.com/@enginakyurt"
+  },
+  "videoFiles": [
+    {
+      "id": 48035,
+      "quality": "hd",
+      "fileType": "video/mp4",
+      "width": 1920,
+      "height": 1080,
+      "fps": 23.976,
+      "link": "https://player.vimeo.com/external/..."
+    }
+  ],
+  "videoPictures": [
+    {
+      "id": 134906,
+      "picture": "https://images.pexels.com/videos/1093662/pictures/preview-0.jpg",
+      "nr": 0
+    }
+  ]
+}
+```
+
+---
+
+## Usage Notes
+
+### Photo Sizes
+
+Use the appropriate `src` field based on your needs:
+
+| Field | Use Case |
+|-------|----------|
+| `original` | Full resolution download |
+| `large2x` | High-res display (retina) |
+| `large` | Standard large display |
+| `medium` | Medium display |
+| `small` | Small thumbnails |
+| `portrait` | Portrait crop (800x1200) |
+| `landscape` | Landscape crop (1200x627) |
+| `tiny` | Tiny preview (280x200) |
+
+### Video Quality
+
+Videos come with multiple quality options in `videoFiles`:
+
+| Quality | Typical Resolution |
+|---------|-------------------|
+| `uhd` | 4K (3840x2160) |
+| `hd` | 1080p (1920x1080) |
+| `sd` | 540p (960x540) |
+
+### Rate Limits
+
+- **200 requests per hour**
+- **20,000 requests per month**
+
+### Attribution
+
+While not required, Pexels appreciates attribution:
+- Photographer name and link available in response
+- Link to original Pexels page in `url` field
+
+---
+
+## Error Responses
+
+**400 Bad Request:**
+```json
+{
+  "statusCode": 400,
+  "message": "Pexels API key not configured",
+  "error": "Bad Request"
+}
+```
+
+**404 Not Found:**
+```json
+{
+  "statusCode": 400,
+  "message": "Photo not found",
+  "error": "Bad Request"
+}
+```
+
+---
+
+## Frontend Integration Example
+
+### Searching and displaying photos:
+
+```typescript
+// Search for photos
+const response = await fetch('/pexels/photos/search?query=technology&perPage=20', {
+  headers: {
+    'Authorization': `Bearer ${accessToken}`
+  }
+});
+const data = await response.json();
+
+// Use the medium size for display, original for download
+data.items.forEach(photo => {
+  console.log('Display:', photo.src.medium);
+  console.log('Download:', photo.src.original);
+  console.log('Photographer:', photo.photographer);
+});
+```
+
+### Getting the best video quality:
+
+```typescript
+// Get video by ID
+const response = await fetch('/pexels/videos/1093662', {
+  headers: {
+    'Authorization': `Bearer ${accessToken}`
+  }
+});
+const video = await response.json();
+
+// Find the HD quality video file
+const hdVideo = video.videoFiles.find(f => f.quality === 'hd');
+const videoUrl = hdVideo?.link || video.videoFiles[0].link;
+
+console.log('Video URL:', videoUrl);
+console.log('Thumbnail:', video.image);
+console.log('Duration:', video.duration, 'seconds');
+```

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { MediaModule } from './media/media.module';
 import { DripModule } from './drips/drip.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { PexelsModule } from './pexels/pexels.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     DripModule,
     FeedbackModule,
     NotificationsModule,
+    PexelsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/channels/services/facebook.service.ts
+++ b/src/channels/services/facebook.service.ts
@@ -108,17 +108,24 @@ export class FacebookService {
       'id,name,access_token,category,picture.type(large),username,followers_count,fan_count,instagram_business_account{id,username,name,profile_picture_url,followers_count,media_count,biography}',
     );
 
+    this.logger.log(`Fetching pages from: ${this.graphApiUrl}/me/accounts`);
+    this.logger.log(`Token (first 20 chars): ${userAccessToken.substring(0, 20)}...`);
+
     const response = await fetch(url.toString());
+    const responseText = await response.text();
+
+    this.logger.log(`Facebook API response status: ${response.status}`);
+    this.logger.log(`Facebook API response: ${responseText}`);
 
     if (!response.ok) {
-      const error = await response.json();
+      const error = JSON.parse(responseText);
       this.logger.error('Failed to fetch pages:', error);
       throw new BadRequestException(
         error.error?.message || 'Failed to fetch Facebook pages',
       );
     }
 
-    const data = await response.json();
+    const data = JSON.parse(responseText);
     const pages: FacebookPage[] = [];
 
     for (const page of data.data || []) {

--- a/src/channels/services/oauth.service.ts
+++ b/src/channels/services/oauth.service.ts
@@ -427,14 +427,17 @@ export class OAuthService {
     }
 
     // Fall back to environment variables
-    const envPrefix = platform.toUpperCase();
+    // Instagram uses Facebook's Meta app credentials (same OAuth provider)
+    const envPrefix = platform === 'instagram' ? 'FACEBOOK' : platform.toUpperCase();
     const clientId = process.env[`${envPrefix}_CLIENT_ID`];
     const clientSecret = process.env[`${envPrefix}_CLIENT_SECRET`];
 
     if (!clientId || !clientSecret) {
+      const hint = platform === 'instagram'
+        ? 'Instagram uses Facebook credentials. Set FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET.'
+        : `Set ${envPrefix}_CLIENT_ID and ${envPrefix}_CLIENT_SECRET environment variables.`;
       throw new BadRequestException(
-        `OAuth credentials not configured for ${platform}. ` +
-          `Set ${envPrefix}_CLIENT_ID and ${envPrefix}_CLIENT_SECRET environment variables.`,
+        `OAuth credentials not configured for ${platform}. ${hint}`,
       );
     }
 

--- a/src/drizzle/schema/channels.schema.ts
+++ b/src/drizzle/schema/channels.schema.ts
@@ -362,7 +362,7 @@ export const PLATFORM_CONFIG: Record<
     oauthScopes: [
       'instagram_basic',
       'instagram_content_publish',
-      'instagram_manage_insights',
+      // 'instagram_manage_insights', // Requires App Review approval - add back after approval
     ],
   },
   youtube: {

--- a/src/pexels/dto/pexels.dto.ts
+++ b/src/pexels/dto/pexels.dto.ts
@@ -1,0 +1,145 @@
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsEnum,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum MediaOrientation {
+  LANDSCAPE = 'landscape',
+  PORTRAIT = 'portrait',
+  SQUARE = 'square',
+}
+
+export enum MediaSize {
+  LARGE = 'large',
+  MEDIUM = 'medium',
+  SMALL = 'small',
+}
+
+export class SearchPhotosDto {
+  @IsString()
+  query: string;
+
+  @IsEnum(MediaOrientation)
+  @IsOptional()
+  orientation?: MediaOrientation;
+
+  @IsEnum(MediaSize)
+  @IsOptional()
+  size?: MediaSize;
+
+  @IsString()
+  @IsOptional()
+  color?: string; // Hex color without #, e.g., 'FF0000' or color name like 'red'
+
+  @IsString()
+  @IsOptional()
+  locale?: string; // e.g., 'en-US', 'pt-BR'
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(80)
+  perPage?: number;
+}
+
+export class SearchVideosDto {
+  @IsString()
+  query: string;
+
+  @IsEnum(MediaOrientation)
+  @IsOptional()
+  orientation?: MediaOrientation;
+
+  @IsEnum(MediaSize)
+  @IsOptional()
+  size?: MediaSize;
+
+  @IsString()
+  @IsOptional()
+  locale?: string;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(80)
+  perPage?: number;
+}
+
+export class GetCuratedPhotosDto {
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(80)
+  perPage?: number;
+}
+
+export class GetPopularVideosDto {
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(80)
+  perPage?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  minWidth?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  minHeight?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  minDuration?: number; // in seconds
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  maxDuration?: number; // in seconds
+}
+
+export class GetMediaByIdDto {
+  @IsNumber()
+  @Type(() => Number)
+  id: number;
+}

--- a/src/pexels/pexels.controller.ts
+++ b/src/pexels/pexels.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { PexelsService } from './pexels.service';
+import {
+  SearchPhotosDto,
+  SearchVideosDto,
+  GetCuratedPhotosDto,
+  GetPopularVideosDto,
+} from './dto/pexels.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('pexels')
+@UseGuards(JwtAuthGuard)
+export class PexelsController {
+  constructor(private readonly pexelsService: PexelsService) {}
+
+  // ==========================================================================
+  // Photo Endpoints
+  // ==========================================================================
+
+  /**
+   * Search for photos
+   * GET /pexels/photos/search?query=nature&orientation=landscape&page=1&perPage=15
+   */
+  @Get('photos/search')
+  @HttpCode(HttpStatus.OK)
+  async searchPhotos(@Query() dto: SearchPhotosDto) {
+    return this.pexelsService.searchPhotos({
+      query: dto.query,
+      orientation: dto.orientation,
+      size: dto.size,
+      color: dto.color,
+      locale: dto.locale,
+      page: dto.page,
+      perPage: dto.perPage,
+    });
+  }
+
+  /**
+   * Get curated/featured photos
+   * GET /pexels/photos/curated?page=1&perPage=15
+   */
+  @Get('photos/curated')
+  @HttpCode(HttpStatus.OK)
+  async getCuratedPhotos(@Query() dto: GetCuratedPhotosDto) {
+    return this.pexelsService.getCuratedPhotos(dto.page, dto.perPage);
+  }
+
+  /**
+   * Get a specific photo by ID
+   * GET /pexels/photos/:id
+   */
+  @Get('photos/:id')
+  @HttpCode(HttpStatus.OK)
+  async getPhoto(@Param('id', ParseIntPipe) id: number) {
+    return this.pexelsService.getPhoto(id);
+  }
+
+  // ==========================================================================
+  // Video Endpoints
+  // ==========================================================================
+
+  /**
+   * Search for videos
+   * GET /pexels/videos/search?query=ocean&orientation=landscape&page=1&perPage=15
+   */
+  @Get('videos/search')
+  @HttpCode(HttpStatus.OK)
+  async searchVideos(@Query() dto: SearchVideosDto) {
+    return this.pexelsService.searchVideos({
+      query: dto.query,
+      orientation: dto.orientation,
+      size: dto.size,
+      locale: dto.locale,
+      page: dto.page,
+      perPage: dto.perPage,
+    });
+  }
+
+  /**
+   * Get popular videos
+   * GET /pexels/videos/popular?page=1&perPage=15&minDuration=5&maxDuration=60
+   */
+  @Get('videos/popular')
+  @HttpCode(HttpStatus.OK)
+  async getPopularVideos(@Query() dto: GetPopularVideosDto) {
+    return this.pexelsService.getPopularVideos(
+      dto.page,
+      dto.perPage,
+      dto.minWidth,
+      dto.minHeight,
+      dto.minDuration,
+      dto.maxDuration,
+    );
+  }
+
+  /**
+   * Get a specific video by ID
+   * GET /pexels/videos/:id
+   */
+  @Get('videos/:id')
+  @HttpCode(HttpStatus.OK)
+  async getVideo(@Param('id', ParseIntPipe) id: number) {
+    return this.pexelsService.getVideo(id);
+  }
+}

--- a/src/pexels/pexels.module.ts
+++ b/src/pexels/pexels.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PexelsController } from './pexels.controller';
+import { PexelsService } from './pexels.service';
+
+@Module({
+  controllers: [PexelsController],
+  providers: [PexelsService],
+  exports: [PexelsService],
+})
+export class PexelsModule {}

--- a/src/pexels/pexels.service.ts
+++ b/src/pexels/pexels.service.ts
@@ -1,0 +1,369 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+
+export interface PexelsPhoto {
+  id: number;
+  width: number;
+  height: number;
+  url: string; // Pexels page URL
+  photographer: string;
+  photographerUrl: string;
+  photographerId: number;
+  avgColor: string;
+  src: {
+    original: string;
+    large2x: string;
+    large: string;
+    medium: string;
+    small: string;
+    portrait: string;
+    landscape: string;
+    tiny: string;
+  };
+  alt: string;
+}
+
+export interface PexelsVideo {
+  id: number;
+  width: number;
+  height: number;
+  url: string; // Pexels page URL
+  image: string; // Thumbnail
+  duration: number; // in seconds
+  user: {
+    id: number;
+    name: string;
+    url: string;
+  };
+  videoFiles: {
+    id: number;
+    quality: string; // 'hd', 'sd', 'uhd'
+    fileType: string; // 'video/mp4'
+    width: number;
+    height: number;
+    fps: number;
+    link: string;
+  }[];
+  videoPictures: {
+    id: number;
+    picture: string;
+    nr: number;
+  }[];
+}
+
+export interface PexelsSearchOptions {
+  query: string;
+  orientation?: 'landscape' | 'portrait' | 'square';
+  size?: 'large' | 'medium' | 'small';
+  color?: string;
+  locale?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export interface PexelsSearchResult<T> {
+  items: T[];
+  totalResults: number;
+  page: number;
+  perPage: number;
+  nextPage: string | null;
+  prevPage: string | null;
+}
+
+@Injectable()
+export class PexelsService {
+  private readonly logger = new Logger(PexelsService.name);
+  private readonly apiBaseUrl = 'https://api.pexels.com';
+  private readonly apiKey: string;
+
+  constructor() {
+    this.apiKey = process.env.PEXELS_API_KEY || '';
+    if (!this.apiKey) {
+      this.logger.warn('PEXELS_API_KEY not set - Pexels integration will not work');
+    }
+  }
+
+  /**
+   * Search for photos on Pexels
+   */
+  async searchPhotos(options: PexelsSearchOptions): Promise<PexelsSearchResult<PexelsPhoto>> {
+    const { query, orientation, size, color, locale, page = 1, perPage = 15 } = options;
+
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const url = new URL(`${this.apiBaseUrl}/v1/search`);
+    url.searchParams.set('query', query);
+    url.searchParams.set('page', page.toString());
+    url.searchParams.set('per_page', Math.min(perPage, 80).toString()); // Max 80
+
+    if (orientation) url.searchParams.set('orientation', orientation);
+    if (size) url.searchParams.set('size', size);
+    if (color) url.searchParams.set('color', color);
+    if (locale) url.searchParams.set('locale', locale);
+
+    this.logger.log(`Searching Pexels photos: "${query}" (page ${page})`);
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      this.logger.error(`Pexels API error: ${response.status} - ${errorText}`);
+      throw new BadRequestException('Failed to search Pexels photos');
+    }
+
+    const data = await response.json();
+
+    return {
+      items: (data.photos || []).map(this.mapPhoto),
+      totalResults: data.total_results || 0,
+      page: data.page || page,
+      perPage: data.per_page || perPage,
+      nextPage: data.next_page || null,
+      prevPage: data.prev_page || null,
+    };
+  }
+
+  /**
+   * Get curated photos (editor's picks)
+   */
+  async getCuratedPhotos(page = 1, perPage = 15): Promise<PexelsSearchResult<PexelsPhoto>> {
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const url = new URL(`${this.apiBaseUrl}/v1/curated`);
+    url.searchParams.set('page', page.toString());
+    url.searchParams.set('per_page', Math.min(perPage, 80).toString());
+
+    this.logger.log(`Fetching curated photos (page ${page})`);
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      this.logger.error(`Pexels API error: ${response.status} - ${errorText}`);
+      throw new BadRequestException('Failed to fetch curated photos');
+    }
+
+    const data = await response.json();
+
+    return {
+      items: (data.photos || []).map(this.mapPhoto),
+      totalResults: data.total_results || 0,
+      page: data.page || page,
+      perPage: data.per_page || perPage,
+      nextPage: data.next_page || null,
+      prevPage: data.prev_page || null,
+    };
+  }
+
+  /**
+   * Get a specific photo by ID
+   */
+  async getPhoto(id: number): Promise<PexelsPhoto> {
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const response = await fetch(`${this.apiBaseUrl}/v1/photos/${id}`, {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new BadRequestException('Photo not found');
+      }
+      throw new BadRequestException('Failed to fetch photo');
+    }
+
+    const data = await response.json();
+    return this.mapPhoto(data);
+  }
+
+  /**
+   * Search for videos on Pexels
+   */
+  async searchVideos(options: PexelsSearchOptions): Promise<PexelsSearchResult<PexelsVideo>> {
+    const { query, orientation, size, locale, page = 1, perPage = 15 } = options;
+
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const url = new URL(`${this.apiBaseUrl}/videos/search`);
+    url.searchParams.set('query', query);
+    url.searchParams.set('page', page.toString());
+    url.searchParams.set('per_page', Math.min(perPage, 80).toString());
+
+    if (orientation) url.searchParams.set('orientation', orientation);
+    if (size) url.searchParams.set('size', size);
+    if (locale) url.searchParams.set('locale', locale);
+
+    this.logger.log(`Searching Pexels videos: "${query}" (page ${page})`);
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      this.logger.error(`Pexels API error: ${response.status} - ${errorText}`);
+      throw new BadRequestException('Failed to search Pexels videos');
+    }
+
+    const data = await response.json();
+
+    return {
+      items: (data.videos || []).map(this.mapVideo),
+      totalResults: data.total_results || 0,
+      page: data.page || page,
+      perPage: data.per_page || perPage,
+      nextPage: data.next_page || null,
+      prevPage: data.prev_page || null,
+    };
+  }
+
+  /**
+   * Get popular videos
+   */
+  async getPopularVideos(
+    page = 1,
+    perPage = 15,
+    minWidth?: number,
+    minHeight?: number,
+    minDuration?: number,
+    maxDuration?: number,
+  ): Promise<PexelsSearchResult<PexelsVideo>> {
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const url = new URL(`${this.apiBaseUrl}/videos/popular`);
+    url.searchParams.set('page', page.toString());
+    url.searchParams.set('per_page', Math.min(perPage, 80).toString());
+
+    if (minWidth) url.searchParams.set('min_width', minWidth.toString());
+    if (minHeight) url.searchParams.set('min_height', minHeight.toString());
+    if (minDuration) url.searchParams.set('min_duration', minDuration.toString());
+    if (maxDuration) url.searchParams.set('max_duration', maxDuration.toString());
+
+    this.logger.log(`Fetching popular videos (page ${page})`);
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      this.logger.error(`Pexels API error: ${response.status} - ${errorText}`);
+      throw new BadRequestException('Failed to fetch popular videos');
+    }
+
+    const data = await response.json();
+
+    return {
+      items: (data.videos || []).map(this.mapVideo),
+      totalResults: data.total_results || 0,
+      page: data.page || page,
+      perPage: data.per_page || perPage,
+      nextPage: data.next_page || null,
+      prevPage: data.prev_page || null,
+    };
+  }
+
+  /**
+   * Get a specific video by ID
+   */
+  async getVideo(id: number): Promise<PexelsVideo> {
+    if (!this.apiKey) {
+      throw new BadRequestException('Pexels API key not configured');
+    }
+
+    const response = await fetch(`${this.apiBaseUrl}/videos/videos/${id}`, {
+      headers: {
+        Authorization: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new BadRequestException('Video not found');
+      }
+      throw new BadRequestException('Failed to fetch video');
+    }
+
+    const data = await response.json();
+    return this.mapVideo(data);
+  }
+
+  /**
+   * Map Pexels API photo response to our interface
+   */
+  private mapPhoto = (photo: any): PexelsPhoto => ({
+    id: photo.id,
+    width: photo.width,
+    height: photo.height,
+    url: photo.url,
+    photographer: photo.photographer,
+    photographerUrl: photo.photographer_url,
+    photographerId: photo.photographer_id,
+    avgColor: photo.avg_color,
+    src: {
+      original: photo.src.original,
+      large2x: photo.src.large2x,
+      large: photo.src.large,
+      medium: photo.src.medium,
+      small: photo.src.small,
+      portrait: photo.src.portrait,
+      landscape: photo.src.landscape,
+      tiny: photo.src.tiny,
+    },
+    alt: photo.alt || '',
+  });
+
+  /**
+   * Map Pexels API video response to our interface
+   */
+  private mapVideo = (video: any): PexelsVideo => ({
+    id: video.id,
+    width: video.width,
+    height: video.height,
+    url: video.url,
+    image: video.image,
+    duration: video.duration,
+    user: {
+      id: video.user.id,
+      name: video.user.name,
+      url: video.user.url,
+    },
+    videoFiles: (video.video_files || []).map((file: any) => ({
+      id: file.id,
+      quality: file.quality,
+      fileType: file.file_type,
+      width: file.width,
+      height: file.height,
+      fps: file.fps,
+      link: file.link,
+    })),
+    videoPictures: (video.video_pictures || []).map((pic: any) => ({
+      id: pic.id,
+      picture: pic.picture,
+      nr: pic.nr,
+    })),
+  });
+}


### PR DESCRIPTION
- Add Pexels module for stock photos and videos
- Add search, curated, and popular endpoints for photos/videos
- Add Pexels API documentation
- Fix Instagram OAuth to use Facebook credentials (same Meta app)
- Add debugging logs to Facebook pages fetch
- Remove instagram_manage_insights scope (requires App Review)