### PR TITLE
feat(inbox/telegram): author avatars on DM ingest + group-threading spec

### DIFF
--- a/docs/superpowers/specs/2026-06-16-telegram-group-threading-design.md
+++ b/docs/superpowers/specs/2026-06-16-telegram-group-threading-design.md
@@ -1,0 +1,90 @@
+# Telegram Group Threading — Next-Phase Design
+
+**Status:** Planned (not implemented). Captured 2026-06-16 alongside the Telegram
+inbox enablement (DM + media + avatars). Group threading was explicitly deferred
+to a later phase but **must be done**.
+
+## Problem
+
+Telegram groups/supergroups can already be bound to a workspace (via the bot
+being added → inline-keyboard workspace pick → `telegram_chat_bindings` row with
+`chatType` = `group` | `supergroup`). Messages from those groups **are ingested**
+through the same webhook path as DMs (`TelegramIngestProcessor.ingestPlainMessage`).
+
+The gap: a group is currently surfaced in the inbox as if it were a 1:1 DM
+conversation. All members' messages collapse into one flat `conversationId`
+(the chat id) with no notion of:
+
+- **Who is who** beyond per-message author labels (we now store
+  `authorDisplayName` + `authorAvatarUrl` per message, so multi-sender
+  attribution already renders via `DmMessageBubble`'s `showSenderHeader`).
+- **Topics / forum threads** — supergroups with "Topics" enabled
+  (`message_thread_id`) are not modelled at all.
+- **Reply chains** — `reply_to_message` is stored as `platformParentId` but the
+  UI renders a flat list, not nested reply context.
+
+## Scope of the next phase
+
+1. **Forum topics (supergroup "Topics").** Telegram sends `message_thread_id` on
+   messages in topic-enabled supergroups. Model each topic as its own
+   conversation/sub-thread so the inbox doesn't merge unrelated topics.
+   - Ingest: capture `message.message_thread_id` (and `is_topic_message`).
+   - Storage: extend the DM conversation key for telegram groups from
+     `<channelId>:<chatId>` to `<channelId>:<chatId>:<threadId>` (threadId
+     optional — absent for non-topic groups, preserving current behaviour).
+   - Topic name: `forum_topic_created` service messages carry the topic name;
+     ingest and store it as the conversation display name.
+
+2. **Reply-context rendering.** Use the already-stored `platformParentId`
+   (`reply_to_message.message_id`) to show a quoted snippet of the parent
+   message above a reply bubble (Telegram/Slack pattern). Backend already has
+   the data; this is mostly a frontend `dm-thread` enhancement.
+
+3. **Group conversation metadata.** Replace the adapter's hardcoded
+   `"Telegram group"` participant label with the real group title (available on
+   `my_chat_member` / message `chat.title`). Store group title on the binding
+   row or channel metadata; surface in `listConversations` + the conversation
+   header.
+
+4. **Outbound replies in topics.** When replying into a topic-threaded
+   supergroup, pass `message_thread_id` to `sendMessage` so the reply lands in
+   the correct topic, not the General channel.
+   `TelegramService.sendMessage` already accepts an options object — add
+   `messageThreadId`.
+
+5. **(Optional) reply-to a specific message.** Wire the existing
+   `replyToMessageId` option through `TelegramDmAdapter.sendDm` so inbox replies
+   can quote a specific group message.
+
+## Out of scope (explicit)
+
+- Reactions ingest/send (Bot API reaction support is limited).
+- Typing/presence indicators (not exposed to bots).
+- Per-member read receipts (not exposed).
+- Channel (broadcast) support — only group/supergroup, matching the binding
+  schema which excludes `channel`.
+
+## Data model changes (anticipated)
+
+- `telegram_chat_bindings`: add `title varchar` (group display name) — nullable,
+  backfilled from the next message's `chat.title`.
+- No new table needed for topics if the conversationId composite key approach is
+  used; if topics need richer metadata (name, icon), consider a
+  `telegram_group_topics` table keyed by `(binding_id, message_thread_id)`.
+
+## Risks / notes
+
+- Composite conversationId change must stay backward compatible: existing group
+  rows have `conversationId = <chatId>`; the migration/logic should treat a
+  missing threadId as the group's "General" topic so no history is orphaned.
+- Topic detection requires the supergroup to have Topics enabled; most groups
+  don't. The non-topic path must remain the default and unchanged.
+- Frontend `INBOX_DM_PLATFORMS` already includes `telegram`; group threading is
+  additive rendering, no gating change.
+
+## References
+
+- Current ingest: `src/inbox/processors/telegram-ingest.processor.ts`
+- Adapter: `src/inbox/adapters/telegram-dm.adapter.ts`
+- Bot API: `getUpdates` message fields `message_thread_id`, `is_topic_message`,
+  `forum_topic_created`; `sendMessage` param `message_thread_id`.

--- a/src/channels/services/telegram.service.ts
+++ b/src/channels/services/telegram.service.ts
@@ -181,6 +181,30 @@ export class TelegramService {
     return this.callJson('getFile', { file_id: fileId });
   }
 
+  /** Returns the `file_id` of the largest resolution of a user's current
+   *  profile photo, or null when the user has no photo / hides it via privacy
+   *  settings. Never throws — avatar resolution is best-effort and must not
+   *  block message ingest. */
+  async getUserProfilePhotoFileId(
+    userId: number | string,
+  ): Promise<string | null> {
+    try {
+      const res = await this.callJson<{
+        total_count: number;
+        photos: Array<Array<{ file_id: string; file_size?: number }>>;
+      }>('getUserProfilePhotos', { user_id: userId, limit: 1 });
+      const firstPhoto = res.photos?.[0];
+      if (!firstPhoto || firstPhoto.length === 0) return null;
+      // Telegram orders sizes ascending — last entry is the largest.
+      return firstPhoto[firstPhoto.length - 1].file_id;
+    } catch (err) {
+      this.logger.warn(
+        `getUserProfilePhotos failed for user ${userId}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
   /** No auth header needed — the bot token is embedded in `fileBaseUrl` per
    *  Telegram's file API spec. */
   async downloadFile(

--- a/src/inbox/processors/telegram-ingest.processor.ts
+++ b/src/inbox/processors/telegram-ingest.processor.ts
@@ -1,9 +1,10 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNotNull } from 'drizzle-orm';
 import { db } from '../../drizzle/db';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
+import { inboxItems } from '../../drizzle/schema/inbox.schema';
 import { workspace } from '../../drizzle/schema/workspace.schema';
 import { telegramChatBindings } from '../../drizzle/schema/telegram-bindings.schema';
 import { QUEUES } from '../../queue/queue.module';
@@ -17,6 +18,11 @@ export class TelegramIngestProcessor extends WorkerHost {
   private readonly logger = new Logger(TelegramIngestProcessor.name);
   /** Cached bot user — populated lazily so we can recognise our own messages. */
   private botId: number | null = null;
+  /** Per-author avatar cache (telegram user id → R2 url | null). Avoids
+   *  re-fetching + re-uploading a profile photo for every message. null is
+   *  cached too, so photo-less / privacy-restricted users aren't re-queried
+   *  for the process lifetime. Survives restarts via the DB-reuse path. */
+  private readonly avatarCache = new Map<string, string | null>();
 
   constructor(
     private readonly inbox: InboxService,
@@ -157,6 +163,14 @@ export class TelegramIngestProcessor extends WorkerHost {
       message.entities ?? message.caption_entities,
     );
 
+    const authorAvatarUrl = from
+      ? await this.resolveAuthorAvatar(
+          String(from.id),
+          binding.workspaceId,
+          channel.id,
+        )
+      : null;
+
     // Phase 1.B media rehost — Slack-parity pattern: download from Telegram
     // CDN with bot token, upload to R2, store the durable public URL.
     type RehostedAttachment = {
@@ -227,7 +241,7 @@ export class TelegramIngestProcessor extends WorkerHost {
       authorPlatformId: from ? String(from.id) : null,
       authorHandle: from?.username ?? null,
       authorDisplayName: displayName,
-      authorAvatarUrl: null,
+      authorAvatarUrl,
       text: resolvedText,
       fromMe: false,
       platformCreatedAt: new Date(message.date * 1000),
@@ -444,6 +458,80 @@ export class TelegramIngestProcessor extends WorkerHost {
       this.logger.warn(
         `editMessageText after bind failed (non-blocking): ${(err as Error).message}`,
       );
+    }
+  }
+
+  /** Resolve an author's avatar to a durable R2 URL, cheaply.
+   *
+   *  Resolution order (each step avoids the next, more expensive one):
+   *    1. in-memory cache (this process)
+   *    2. reuse the avatar URL from a prior ingested message by the same
+   *       author on this channel (survives restarts, no Telegram API hit)
+   *    3. fetch the profile photo from Telegram → rehost to R2
+   *
+   *  Best-effort: any failure resolves to null and the UI falls back to an
+   *  initials avatar. Never throws — must not block message ingest. */
+  private async resolveAuthorAvatar(
+    authorId: string,
+    workspaceId: string,
+    channelId: number,
+  ): Promise<string | null> {
+    if (this.avatarCache.has(authorId)) {
+      return this.avatarCache.get(authorId) ?? null;
+    }
+
+    // Step 2 — reuse a previously rehosted avatar for this author.
+    try {
+      const [prior] = await db
+        .select({ url: inboxItems.authorAvatarUrl })
+        .from(inboxItems)
+        .where(
+          and(
+            eq(inboxItems.channelId, channelId),
+            eq(inboxItems.authorPlatformId, authorId),
+            isNotNull(inboxItems.authorAvatarUrl),
+          ),
+        )
+        .orderBy(desc(inboxItems.createdAt))
+        .limit(1);
+      if (prior?.url) {
+        this.avatarCache.set(authorId, prior.url);
+        return prior.url;
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Avatar DB-reuse lookup failed for author ${authorId}: ${(err as Error).message}`,
+      );
+    }
+
+    // Step 3 — fetch from Telegram and rehost to R2.
+    try {
+      const fileId = await this.telegram.getUserProfilePhotoFileId(authorId);
+      if (!fileId) {
+        this.avatarCache.set(authorId, null);
+        return null;
+      }
+      const file = await this.telegram.getFile(fileId);
+      if (!file.file_path) {
+        this.avatarCache.set(authorId, null);
+        return null;
+      }
+      const downloaded = await this.telegram.downloadFile(file.file_path);
+      const { publicUrl } = await this.r2.uploadBuffer({
+        kind: 'image',
+        workspaceId,
+        buffer: downloaded.buffer,
+        contentType: downloaded.contentType,
+        filename: `tg-avatar-${authorId}.jpg`,
+      });
+      this.avatarCache.set(authorId, publicUrl);
+      return publicUrl;
+    } catch (err) {
+      this.logger.warn(
+        `Avatar fetch/rehost failed for author ${authorId}: ${(err as Error).message}`,
+      );
+      this.avatarCache.set(authorId, null);
+      return null;
     }
   }
 


### PR DESCRIPTION
Resolve Telegram author avatars and store them on inbox_items so the inbox renders real profile pics instead of initials. Three-tier low-overhead resolution: in-memory cache -> reuse prior message's avatar (restart-safe, no API hit) -> fetch profile photo from Bot API + rehost to R2. Best-effort: any failure resolves to null and the UI falls back to initials; never blocks ingest. In group chats each author is fetched once.

- telegram.service.ts: getUserProfilePhotoFileId() (never-throws, no-photo->null)
- telegram-ingest.processor.ts: resolveAuthorAvatar() + per-author cache; populate authorAvatarUrl (was hardcoded null)
- docs: next-phase Telegram group/forum-topic threading design spec