### PR TITLE
feat: serve TikTok domain-ownership verification file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,9 @@ QUEUE_ADMIN_PASSWORD=change-me-in-prod
 # TikTok app audit gate — set to "true" only after TikTok approves the Direct Post API audit
 TIKTOK_APP_AUDITED=false
 
+# TikTok domain-ownership verification file body (served at /tiktok<token>.txt).
+# Optional — defaults to the committed token. Set only to rotate without a code change.
+# TIKTOK_SITE_VERIFICATION=tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi
+
 # Public base URL of the backend (used for TikTok PULL_FROM_URL proxy)
 API_PUBLIC_URL=https://api.schedura.ai

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { SiteVerificationController } from './site-verification/site-verification.controller';
 import { SocialMediaModule } from './social-media/social-media.module';
 import { PostsModule } from './posts/posts.module';
 import { AiModule } from './ai/ai.module';
@@ -78,7 +79,7 @@ import { QUEUES } from './queue/queue.module';
       { name: QUEUES.INBOX_POLLING, adapter: BullMQAdapter },
     ),
   ],
-  controllers: [AppController],
+  controllers: [AppController, SiteVerificationController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/src/site-verification/site-verification.controller.spec.ts
+++ b/src/site-verification/site-verification.controller.spec.ts
@@ -1,0 +1,32 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { SiteVerificationController } from './site-verification.controller';
+
+describe('SiteVerificationController', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [SiteVerificationController],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('serves the TikTok verification file at the domain root as plain text', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/tiktokBWGOXBTMJ4RXb76i56qZc99OfEZIAzIi.txt')
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.text).toBe(
+      'tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi',
+    );
+  });
+});

--- a/src/site-verification/site-verification.controller.ts
+++ b/src/site-verification/site-verification.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Header } from '@nestjs/common';
+
+/**
+ * Serves platform domain-ownership verification files at the domain root.
+ *
+ * These are public, well-known files that third-party platforms fetch to
+ * confirm we control this domain. They must be served verbatim as
+ * `text/plain` at a fixed root path (no global prefix, no auth, no redirect).
+ *
+ * TikTok (URL-prefix / signature-file method):
+ *   The TikTok for Developers portal issues a file named
+ *   `tiktok<token>.txt` whose body is `tiktok-developers-site-verification=<token>`.
+ *   It must resolve at `https://<domain>/tiktok<token>.txt`.
+ *   Docs: TikTok for Developers → URL properties → "Verify with a file".
+ *
+ * The verification token is not a secret (the file is publicly served), but it
+ * is overridable via env so it can be rotated without a code change.
+ */
+@Controller()
+export class SiteVerificationController {
+  private static readonly TIKTOK_VERIFICATION =
+    process.env.TIKTOK_SITE_VERIFICATION ??
+    'tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi';
+
+  @Get('tiktokBWGOXBTMJ4RXb76i56qZc99OfEZIAzIi.txt')
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=3600')
+  getTikTokVerification(): string {
+    return SiteVerificationController.TIKTOK_VERIFICATION;
+  }
+}


### PR DESCRIPTION
Adds a dedicated SiteVerificationController that serves the TikTok URL-prefix verification file at the domain root:

  GET /tiktokBWGOXBTMJ4RXb76i56qZc99OfEZIAzIi.txt
  -> tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi

Served as text/plain with no global prefix/auth, which is exactly what TikTok's fetcher expects. Token is overridable via TIKTOK_SITE_VERIFICATION env (documented in .env.example) so it can be rotated without a code change. Adds an e2e spec locking the route path and exact body.