### PR TITLE
fix(analytics): fetch profile snapshot inline on channel connect

### DIFF
--- a/src/channels/analytics/handlers/channel-initial-backfill.handler.ts
+++ b/src/channels/analytics/handlers/channel-initial-backfill.handler.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { DRIZZLE } from '../../../drizzle/drizzle.module';
 import { socialMediaChannels, type SupportedPlatform } from '../../../drizzle/schema/channels.schema';
 import { channelSnapshots } from '../../../drizzle/schema/channel-snapshots.schema';
@@ -42,28 +42,51 @@ export class ChannelInitialBackfillHandler {
     const adapter = this.registry.get(channel.platform as SupportedPlatform);
     const channelForAdapter = { ...channel, accessToken: decrypt(channel.accessToken) };
 
-    // 1. Profile snapshot
-    const profileCost = adapter.estimateQuotaCost('fetchProfileSnapshot');
-    const pq = await this.quota.tryConsume(channel.platform as SupportedPlatform, profileCost);
-    if (pq.allowed) {
-      const profile = await adapter.fetchProfileSnapshot(channelForAdapter);
-      if (profile.status !== 'failed') {
-        await this.db
-          .insert(channelSnapshots)
-          .values({
-            channelId,
-            snapshotDate: new Date().toISOString().slice(0, 10),
-            followersCount: profile.data.followersCount ?? null,
-            followingCount: profile.data.followingCount ?? null,
-            totalPostsCount: profile.data.totalPostsCount ?? null,
-            platformMetrics: profile.data.platformMetrics ?? {},
-            metricsSchemaVersion: 1,
-            fetchedAt: new Date(),
-            syncStatus: profile.status,
-            syncError: null,
-          })
-          .onConflictDoNothing();
+    // 1. Profile snapshot — skip if connect already wrote today's snapshot
+    //    synchronously (ChannelSyncLifecycleService.onChannelConnected runs the
+    //    full ChannelProfileSnapshotHandler inline). That path also updates
+    //    channels.metadata + emits realtime events, so re-fetching here would
+    //    only burn quota. If the inline fetch failed, no row exists for today
+    //    and we run the fetch here as the fallback.
+    const today = new Date().toISOString().slice(0, 10);
+    const existingToday = await this.db
+      .select({ channelId: channelSnapshots.channelId })
+      .from(channelSnapshots)
+      .where(
+        and(
+          eq(channelSnapshots.channelId, channelId),
+          eq(channelSnapshots.snapshotDate, today),
+        ),
+      )
+      .limit(1);
+
+    if (existingToday.length === 0) {
+      const profileCost = adapter.estimateQuotaCost('fetchProfileSnapshot');
+      const pq = await this.quota.tryConsume(channel.platform as SupportedPlatform, profileCost);
+      if (pq.allowed) {
+        const profile = await adapter.fetchProfileSnapshot(channelForAdapter);
+        if (profile.status !== 'failed') {
+          await this.db
+            .insert(channelSnapshots)
+            .values({
+              channelId,
+              snapshotDate: today,
+              followersCount: profile.data.followersCount ?? null,
+              followingCount: profile.data.followingCount ?? null,
+              totalPostsCount: profile.data.totalPostsCount ?? null,
+              platformMetrics: profile.data.platformMetrics ?? {},
+              metricsSchemaVersion: 1,
+              fetchedAt: new Date(),
+              syncStatus: profile.status,
+              syncError: null,
+            })
+            .onConflictDoNothing();
+        }
       }
+    } else {
+      this.logger.log(
+        `Backfill: today's snapshot already present for channelId=${channelId} (inline connect fetch) — skipping profile re-fetch`,
+      );
     }
 
     // 2. Recent posts — delegate to ChannelRecentPostsSyncHandler for full persistence.

--- a/src/channels/analytics/services/channel-sync-lifecycle.service.ts
+++ b/src/channels/analytics/services/channel-sync-lifecycle.service.ts
@@ -7,6 +7,7 @@ import { DRIZZLE } from '../../../drizzle/drizzle.module';
 import { channelSyncState } from '../../../drizzle/schema/channel-sync-state.schema';
 import { socialMediaChannels } from '../../../drizzle/schema/channels.schema';
 import { YouTubePubSubHubbubService } from './youtube-pubsubhubbub.service';
+import { ChannelProfileSnapshotHandler } from '../handlers/channel-profile-snapshot.handler';
 
 /**
  * Handles channel lifecycle transitions that affect analytics:
@@ -23,6 +24,7 @@ export class ChannelSyncLifecycleService {
     @InjectQueue(QUEUES.CHANNEL_SNAPSHOTS) private readonly queue: Queue,
     @Inject(DRIZZLE) private readonly db: any,
     private readonly pubsub: YouTubePubSubHubbubService,
+    private readonly profileSnapshot: ChannelProfileSnapshotHandler,
   ) {}
 
   async onChannelDisconnected(channelId: number): Promise<void> {
@@ -61,6 +63,23 @@ export class ChannelSyncLifecycleService {
           initialBackfillStatus: 'pending',
         },
       });
+
+    // Synchronously fetch the profile snapshot (followers/views/post count)
+    // BEFORE returning from connect, so the UI header chips show real numbers
+    // immediately instead of the OAuth-time frozen zeros. This handler writes
+    // both channel_snapshots AND channels.metadata (the source the header reads)
+    // and emits realtime events. Best-effort: any failure (API down, quota,
+    // timeout) must NOT block the connect — the enqueued backfill + the daily
+    // job remain the fallback, and the backfill skips re-fetch if this succeeds.
+    try {
+      await this.profileSnapshot.handle({ channelId, workspaceId });
+    } catch (err) {
+      this.logger.warn(
+        `Connect for channelId=${channelId}: inline profile snapshot failed (non-blocking) — ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
 
     await this.queue.add('channel-initial-backfill', { channelId, workspaceId });
     this.logger.log(`Connect for channelId=${channelId}: sync state initialized + backfill enqueued`);


### PR DESCRIPTION
Connect now runs ChannelProfileSnapshotHandler synchronously before returning, so the UI header chips show real followers/views/post counts immediately instead of the OAuth-time frozen zeros. This handler writes both channel_snapshots and channels.metadata (the source the header reads) and emits realtime events. Best-effort: any failure is logged and does not block connect — the enqueued backfill + daily job remain the fallback.

The initial-backfill handler now skips the profile re-fetch when today's snapshot already exists (the inline connect fetch wrote it), saving a redundant quota-consuming API call. Falls back to fetching only if no row exists for today.