### PR TITLE
fix(inbox): Threads @mentions in both Comments and Mentions tabs (realtime)

### DIFF
--- a/src/channels/webhooks.controller.ts
+++ b/src/channels/webhooks.controller.ts
@@ -612,6 +612,20 @@ export class WebhooksController {
     const fromMe =
       !!authorUsername && authorUsername === (rootPost.username as string);
 
+    // A reply on our post that literally @mentions our handle is BOTH a comment
+    // and a mention. Detect it here so it reaches the Mentions tab instantly on
+    // the webhook, instead of waiting for the (≤30s) mentions poll to flag it.
+    const ourUsername = (rootPost.username as string | undefined)
+      ?.replace(/^@+/, '')
+      .trim();
+    const isMention =
+      !fromMe &&
+      !!ourUsername &&
+      new RegExp(
+        `@${ourUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9_.])`,
+        'i',
+      ).test((value?.text as string | undefined) ?? '');
+
     const createdAt = value?.timestamp
       ? new Date(value.timestamp as string)
       : new Date();
@@ -630,6 +644,7 @@ export class WebhooksController {
         (value?.profile_picture_url as string | undefined) ?? null,
       text: (value?.text as string | undefined) ?? '',
       fromMe,
+      isMention,
       platformCreatedAt: createdAt,
       metadata: {
         permalink: value?.permalink,
@@ -638,7 +653,7 @@ export class WebhooksController {
     });
 
     this.logger.log(
-      `Threads reply webhook ingested: reply=${platformItemId} post=${platformPostId} fromMe=${fromMe}`,
+      `Threads reply webhook ingested: reply=${platformItemId} post=${platformPostId} fromMe=${fromMe} isMention=${isMention}`,
     );
   }
 

--- a/src/drizzle/schema/inbox.schema.ts
+++ b/src/drizzle/schema/inbox.schema.ts
@@ -90,6 +90,11 @@ export const inboxItems = pgTable(
     // Platform-side hidden state for a reply we moderated (Threads manage_reply).
     isHidden: boolean('is_hidden').default(false).notNull(),
 
+    // True when this item @mentions our connected account (Threads mentions
+    // API). Decoupled from `type` so one row can be BOTH a comment on our post
+    // AND a mention — the Mentions tab filters on this flag, not on `type`.
+    isMention: boolean('is_mention').default(false).notNull(),
+
     // Time the comment was created on the platform.
     platformCreatedAt: timestamp('platform_created_at', {
       withTimezone: true,

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -198,6 +198,11 @@ export interface UpsertCommentInput {
   authorAvatarUrl?: string | null;
   text: string;
   fromMe?: boolean;
+  /** Explicit @mention flag. When omitted, defaults to true only for the
+   *  mention-poll path (itemType==='mention'). The Threads reply webhook sets
+   *  this true when the reply text @mentions our handle, so a reply-mention
+   *  reaches the Mentions tab instantly instead of waiting for the poll. */
+  isMention?: boolean;
   /** Platform-reported like count — stored under metadata.likeCount. */
   likeCount?: number;
   platformCreatedAt: Date;
@@ -1439,7 +1444,7 @@ export class InboxService {
       text: input.text,
       status: input.fromMe ? 'replied' : 'unread',
       fromMe: input.fromMe ?? false,
-      isMention: itemType === 'mention',
+      isMention: input.isMention ?? itemType === 'mention',
       platformCreatedAt: input.platformCreatedAt,
       metadata,
     };
@@ -1501,7 +1506,12 @@ export class InboxService {
     // equals updatedAt within a few ms means it was just inserted.
     const wasNewInsert =
       Math.abs(row.createdAt.getTime() - row.updatedAt.getTime()) < 1000;
-    if (!wasNewInsert) return null;
+    // Emit for brand-new items, and also when the mentions poll re-attaches an
+    // is_mention flag to an already-ingested comment row (an UPDATE, not a new
+    // insert). Without the latter, a reply we only learned was a @mention from
+    // the poll would never nudge the Mentions tab to refetch. getMentions is
+    // since-based, so a given mention flips ~once — no re-emit spam.
+    if (!wasNewInsert && itemType !== 'mention') return null;
 
     this.emitter.emit(input.workspaceId, 'inbox.item.created', {
       id: row.id,

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -1446,17 +1446,25 @@ export class InboxService {
     // without needing a manual cleanup. Status / text are NOT overwritten —
     // those are user-mutable, first writer wins.
     //
-    // `platformPostId` IS overwritten on conflict — adapters can re-canonicalize
-    // it (e.g. Bluesky remapping a chained-reply URI to the root). Without
-    // this, comments ingested before the canonical-root fix would stay stuck
-    // under the wrong post id forever.
+    // `platformPostId` prefers a non-null EXCLUDED value (COALESCE) so adapters
+    // can re-canonicalize it (e.g. Bluesky remapping a chained-reply URI to the
+    // root) while a linkage-less mentions re-poll can't null out a comment's
+    // post id. `type` upgrades toward 'comment' — see the set clause below.
     const inserted = await db
       .insert(inboxItems)
       .values(values)
       .onConflictDoUpdate({
         target: [inboxItems.channelId, inboxItems.platformItemId],
         set: {
-          platformPostId: sql`EXCLUDED.platform_post_id`,
+          // A Threads reply that @mentions us is returned by BOTH the comment
+          // poll (type='comment', post-linked) and the mentions poll
+          // (type='mention', no linkage) under ONE platform_item_id, so they
+          // collapse into a single row. The comment classification wins — it
+          // carries the post thread context — so `type` only upgrades toward
+          // 'comment', never downgrades. A pure mention the comment poll never
+          // sees stays type='mention' and surfaces only in the Mentions tab.
+          type: sql`CASE WHEN EXCLUDED."type" = 'comment' THEN 'comment' ELSE ${inboxItems.type} END`,
+          platformPostId: sql`COALESCE(EXCLUDED.platform_post_id, ${inboxItems.platformPostId})`,
           platformParentId: sql`COALESCE(EXCLUDED.platform_parent_id, ${inboxItems.platformParentId})`,
           authorPlatformId: sql`COALESCE(${inboxItems.authorPlatformId}, EXCLUDED.author_platform_id)`,
           authorHandle: sql`COALESCE(${inboxItems.authorHandle}, EXCLUDED.author_handle)`,

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -451,9 +451,9 @@ export class InboxService {
   }
 
   // ==========================================================================
-  // List mentions (flat — @mentions ingest as account-level items, not tied
-  // to a post, so there's no thread to group them into. Same filter/cursor
-  // shape as `listCommentThreads` above, minus the grouping step.)
+  // List mentions (flat — every item flagged is_mention, whether it's a pure
+  // account-level mention or a comment on our post that also @mentions us.
+  // Same filter/cursor shape as `listCommentThreads`, minus the grouping step.)
   // ==========================================================================
 
   async listMentions(
@@ -472,7 +472,10 @@ export class InboxService {
     const limit = Math.min(options.limit ?? 20, 100);
     const conditions = [
       eq(inboxItems.workspaceId, workspaceId),
-      eq(inboxItems.type, 'mention'),
+      // Flag-based, not type-based: a reply on our post that @mentions us is a
+      // comment (type='comment') AND a mention (is_mention=true), so it surfaces
+      // in BOTH tabs. Pure mentions (type='mention') are also is_mention=true.
+      eq(inboxItems.isMention, true),
       isNull(inboxItems.archivedAt),
     ];
 
@@ -1397,9 +1400,10 @@ export class InboxService {
 
   /**
    * Upsert an @mention row (Threads mentions API). Identical dedup + merge
-   * behavior to `upsertComment`, but stored as type='mention' with no post
-   * linkage — mentions surface as account-level inbox items, not grouped
-   * under a post thread.
+   * behavior to `upsertComment`, but flagged is_mention=true and inserted as
+   * type='mention' with no post linkage. If the same platform item was already
+   * ingested as a comment on our post, the conflict merge keeps type='comment'
+   * (post grouping) while setting is_mention=true — so it shows in both tabs.
    */
   async upsertMention(input: UpsertMentionInput): Promise<InboxItem | null> {
     return this.upsertInboxItem(
@@ -1435,6 +1439,7 @@ export class InboxService {
       text: input.text,
       status: input.fromMe ? 'replied' : 'unread',
       fromMe: input.fromMe ?? false,
+      isMention: itemType === 'mention',
       platformCreatedAt: input.platformCreatedAt,
       metadata,
     };
@@ -1473,6 +1478,10 @@ export class InboxService {
           // fromMe can only upgrade false→true (never downgrade): if a later
           // poll discovers it's actually our reply, mark it as such.
           fromMe: sql`${inboxItems.fromMe} OR EXCLUDED.from_me`,
+          // mention-ness only upgrades false→true: once the mentions poll flags
+          // an item as @mentioning us it stays flagged, even when the comment
+          // poll re-ingests the same row with is_mention=false.
+          isMention: sql`${inboxItems.isMention} OR EXCLUDED.is_mention`,
           // jsonb `||` does a shallow merge with the right side winning on
           // duplicate keys — so likeCount (and any other transient counters)
           // refresh every poll, while post snapshot survives because the new


### PR DESCRIPTION
## Problem
On Threads a reply that @mentions us is ONE object with ONE id, returned by
both the comment poll (type='comment') and the /mentions poll (type='mention').
The dedup key (channel_id, platform_item_id) collapsed them and the upsert
never updated `type`, so mentions landed in the wrong tab (or neither).

## Changes
- Decouple mention-ness from `type` via a new `is_mention` boolean column — one
  row can be BOTH a comment and a mention. Comments tab filters `type='comment'`,
  Mentions tab filters `is_mention=true`.
- Upsert now upgrades `type` to 'comment' (never downgrades) and OR-merges
  `is_mention`; COALESCE protects `platform_post_id`.
- Webhook-time @mention detection + emit on the mention-poll flip, so a
  reply-mention appears in BOTH tabs instantly (no manual refresh).

## ⚠️ Deploy note
Adds the `is_mention` column. Run this additive migration BEFORE deploy
(destructive db:push not needed):

    ALTER TABLE inbox_items ADD COLUMN IF NOT EXISTS is_mention boolean NOT NULL DEFAULT false;

Without it, listMentions / listDmConversations will 500 (SELECT * includes the
new column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
