### PR TITLE
feat(whatsapp): Embedded Signup onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ META_WEBHOOK_VERIFY_TOKEN=
 META_APP_SECRET=
 # Meta app id (public) — needed for WhatsApp Embedded Signup code exchange
 META_APP_ID=
+# Facebook Login for Business configuration id for WhatsApp Embedded Signup
+WHATSAPP_ES_CONFIG_ID=
 
 # Threads (Meta) OAuth app credentials — from the Threads use-case in your Meta app.
 THREADS_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ META_WEBHOOK_VERIFY_TOKEN=
 # Meta App Secret — verifies POST webhook signatures (X-Hub-Signature-256).
 # REQUIRED for WhatsApp webhooks; without it every POST is rejected (fail-closed).
 META_APP_SECRET=
+# Meta app id (public) — needed for WhatsApp Embedded Signup code exchange
+META_APP_ID=
 
 # Threads (Meta) OAuth app credentials — from the Threads use-case in your Meta app.
 THREADS_CLIENT_ID=

--- a/docs/meta-app-review-permissions.md
+++ b/docs/meta-app-review-permissions.md
@@ -1,0 +1,176 @@
+# Meta App Review — Permissions Inventory (app-wise)
+
+Source of truth for what the **code actually requests** vs what is queued in
+**Meta App Console → App Review → "Not submitted" / New requests**.
+
+Legend:
+- **Code?** — is the permission in `PLATFORM_CONFIG.<platform>.oauthScopes`
+  (`src/drizzle/schema/channels.schema.ts`)?
+- **AR** = needs App Review (Advanced Access) to work for non-role users
+- **BV** = also needs **Business Verification** (app-level, do this once)
+- Default = granted without review; works in production
+
+> **Rule:** never submit a permission the code doesn't request. Every permission
+> needs its own use-case + screencast, and the reviewer must be able to
+> reproduce it. Un-demonstrable permissions get rejected and can bounce the
+> whole use case.
+
+---
+
+## ⚠️ Two warnings before you touch the console
+
+### 1. The trash icon is SAFE
+The trash icon in **App Review → New requests** removes the item from the
+**submission only** — not from your app. Threads / FB / IG will keep working in
+development because app admins, developers and testers always get **Standard
+Access** to every permission the app has.
+
+Only **"customize use cases"** removes a permission from the app itself. Do
+**not** use that to clean up the submission, or the OAuth consent screen will
+stop granting those scopes and connected channels will break.
+
+### 2. 🚨 WhatsApp is NOT demo-able as currently built (submission blocker)
+`POST /workspaces/:workspaceId/whatsapp/connect` is a **manual token connect**
+(`channels.controller.ts:5362`). The user pastes their own `phoneNumberId`,
+`wabaId` and `accessToken` (`dto/connect-whatsapp.dto.ts`). There is **no
+Facebook Login / Embedded Signup consent screen** that grants
+`whatsapp_business_messaging` to *our* app.
+
+App Review for the `whatsapp_*` permissions requires a screencast showing **our
+app's Facebook Login consent dialog** requesting those scopes. With the manual
+flow there is nothing to show → **rejection**.
+
+Two valid paths:
+
+| Path | What it means | App Review needed? |
+|---|---|---|
+| **A. Keep manual token paste** | Each customer creates their own Meta app + WABA + permanent token and pastes it. Token belongs to *their* app, not ours. | ❌ **No `whatsapp_*` App Review needed at all.** Bad UX, doesn't scale. |
+| **B. Embedded Signup (Tech Provider)** | Business grants *our* app access to *their* WABA via Facebook Login. The real multi-tenant SaaS model. | ✅ `whatsapp_business_messaging` + `whatsapp_business_management` + **Business Verification** + **Tech Provider** verification |
+
+**Decide A vs B before submitting.** If B → implement Embedded Signup first,
+then record the screencast. Business Verification (2–5 days) can start now
+regardless; it gates every BV row below.
+
+---
+
+## WhatsApp — 3 in console, 2 used
+
+| Permission | Code? | Needs | Action |
+|---|---|---|---|
+| `whatsapp_business_messaging` | ✅ | AR + **BV** | **Keep** (blocked on Embedded Signup — see above) |
+| `whatsapp_business_management` | ✅ | AR + **BV** | **Keep** (same) |
+| `whatsapp_business_manage_events` | ❌ | AR | **Remove** — unused |
+
+> "Human Agent" is **not** a WhatsApp permission — it's a Messenger / Instagram
+> messaging feature (extends the reply window to 7 days for human agents).
+> WhatsApp Cloud API has no `human_agent`.
+
+---
+
+## Facebook / Pages — 16 in console, 12 used
+
+| Permission | Code? | Needs | Action |
+|---|---|---|---|
+| `public_profile` | ✅ | Default | Keep |
+| `email` | ❌ | Default | Keep (harmless, no review burden) |
+| `pages_show_list` | ✅ | AR | Keep |
+| `pages_read_engagement` | ✅ | AR | Keep |
+| `pages_manage_posts` | ✅ | AR | Keep |
+| `pages_manage_metadata` | ✅ | AR | Keep |
+| `pages_manage_engagement` | ✅ | AR | Keep — first-comment feature |
+| `pages_read_user_content` | ✅ | AR | Keep — inbox comments |
+| `pages_manage_ads` | ✅ | AR | Keep — Boost |
+| `ads_management` | ✅ | AR + **BV** | Keep — Boost |
+| `ads_read` | ✅ | AR + **BV** | Keep — Boost |
+| `leads_retrieval` | ✅ | AR + **BV** | Keep — Lead Ads |
+| `business_management` | ✅ | AR + **BV** | Keep — Boost / ad accounts |
+| `pages_messaging` | ❌ | AR | **Remove** — FB DM inbox is Phase 2 |
+| `read_insights` | ❌ | AR | **Remove** — unless you demo FB Page insights (then add to code first) |
+| `catalog_management` | ❌ | AR | **Remove** — no catalog/commerce feature |
+
+---
+
+## Instagram — 8 in console, but two different API generations 🚨
+
+The code uses the **new** *Instagram API with Instagram Login* (`instagram_business_*`).
+The console also has the **legacy** *Instagram API with Facebook Login*
+(`instagram_*`). Submit **one generation only** — mixing both confuses reviewers.
+
+### Keep — new (Instagram Business Login)
+| Permission | Code? | Needs | Action |
+|---|---|---|---|
+| `instagram_business_basic` | ✅ | AR | Keep |
+| `instagram_business_manage_messages` | ✅ | AR | Keep |
+| `instagram_business_manage_comments` | ✅ | AR | Keep |
+| `instagram_business_content_publish` | ✅ | AR | Keep |
+| `instagram_business_manage_insights` | ⚠️ mismatch | AR | Keep — **fix code** (see below) |
+
+### Remove — legacy (Instagram Graph API via Facebook Login)
+| Permission | Action |
+|---|---|
+| `instagram_basic` | **Remove** — legacy dup of `instagram_business_basic` |
+| `instagram_manage_comments` | **Remove** — legacy dup |
+| `instagram_manage_messages` | **Remove** — legacy dup |
+
+### 🔧 Code fix required
+`channels.schema.ts` requests the **legacy** `instagram_manage_insights` while
+every other IG scope is the new `instagram_business_*` generation:
+
+```
+instagram_manage_insights  →  instagram_business_manage_insights
+```
+
+Changing this is a scope change — **existing Instagram channels must reconnect**
+(tokens never gain scopes retroactively).
+
+---
+
+## Threads — 7 in console, 6 used
+
+| Permission | Code? | Needs | Action |
+|---|---|---|---|
+| `threads_basic` | ✅ | AR | Keep |
+| `threads_content_publish` | ✅ | AR | Keep |
+| `threads_read_replies` | ✅ | AR | Keep |
+| `threads_manage_replies` | ✅ | AR | Keep — hide/unhide |
+| `threads_manage_insights` | ✅ | AR | Keep — insights |
+| `threads_manage_mentions` | ✅ | AR | Keep — mentions tab |
+| `threads_delete` | ❌ | AR | **Remove** — no delete feature |
+
+---
+
+## Features (not permissions)
+
+| Feature | What it's for | Action |
+|---|---|---|
+| **Human Agent** | Messenger / IG messaging — 7-day human-agent reply window | Keep only if FB/IG DM human handoff ships. **Not WhatsApp.** |
+| **Marketing API Access Tier** | Higher ads API volume (Boost) | Keep — needs **BV** |
+| **Business Asset User Profile Access** | Read business-asset user profiles in ads flows | Verify need; remove if unused |
+
+---
+
+## Recommended submission batches
+
+Don't submit everything at once — one bad item can bounce a whole use case.
+
+1. **Batch 1 — Threads (6)** — built, live-tested, screencasts in progress. Fastest win.
+2. **Batch 2 — FB/IG Pages** — `pages_*` + `instagram_business_*` (posting + inbox).
+3. **Batch 3 — Ads / Leads** — `ads_management`, `ads_read`, `leads_retrieval`, `business_management`, `pages_manage_ads`. Needs **Business Verification**.
+4. **Batch 4 — WhatsApp** — only after deciding path A vs B above. If B, ship Embedded Signup first.
+
+**Start Business Verification now** — it's app-level, takes 2–5 days, and gates
+every BV row.
+
+---
+
+## Per-permission App Review checklist
+
+For each submitted permission Meta wants:
+- A clear **use-case description** (what data, why, how it benefits the user)
+- A **screencast**: log in → **consent screen showing that exact permission** →
+  the feature using the data. 1080p, English, no audio needed.
+- **Step-by-step repro instructions** the reviewer can follow
+- **Test credentials** (a working account in the app)
+
+App-level prerequisites: Privacy Policy URL, Data Deletion instructions/callback,
+app icon + category, valid OAuth redirect URIs, app in **Live** mode.

--- a/docs/superpowers/plans/2026-07-09-whatsapp-embedded-signup.md
+++ b/docs/superpowers/plans/2026-07-09-whatsapp-embedded-signup.md
@@ -1,0 +1,1167 @@
+# WhatsApp Embedded Signup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connect a WhatsApp Business Account through our app's Facebook Login for Business consent dialog (Embedded Signup v4) so the `whatsapp_business_messaging` + `whatsapp_business_management` permissions are demo-able for Meta App Review, while keeping the manual token connect as a hidden "Advanced" fallback.
+
+**Architecture:** The browser loads the Facebook JS SDK on demand and calls `FB.login` with our `config_id`; a `WA_EMBEDDED_SIGNUP` `message` event yields `waba_id` + `phone_number_id` and the callback yields a 30-second `code`. The frontend POSTs these to a new backend endpoint, which exchanges the code for a business token, registers the phone number, subscribes our app to the WABA, guards against cross-workspace duplicates, then persists via the existing `createChannel` (which fires the analytics/backfill lifecycle).
+
+**Tech Stack:** Backend NestJS + Drizzle + Jest (`socialmedia-workspace`). Frontend Vite + React 19 + shadcn (`socialmedia-frontend`, no unit-test runner — verify via `npm run build` + manual smoke).
+
+## Global Constraints
+
+- Graph API version pinned to `v21.0` via a single `GRAPH_API_VERSION` const in `whatsapp.service.ts`; all new WhatsApp Graph calls derive from it. Do NOT touch `facebook.service.ts`'s v18 (out of scope).
+- Access token encrypted at rest via the existing `createChannel` path (`encrypt()` in `common/utils/encryption.util.ts`). Never log the token or the exchange `code`.
+- Frontend UI is shadcn-only with theme tokens (`bg-background`, `text-muted-foreground`, etc.). No hard-coded colors except the existing WhatsApp brand accent already in the dialog (`bg-emerald-500/10`).
+- Client-side only ever sees the public `META_APP_ID` and `config_id`.
+- Webhook signature verification stays fail-closed — not touched by this plan.
+- Keep the existing manual connect endpoint `POST /channels/workspaces/:workspaceId/whatsapp/connect` and its dialog form working.
+- Backend TDD (Jest). Frontend has no test runner: each frontend task's verification step is `npm run build` (tsc) plus a stated manual check.
+
+---
+
+## File Structure
+
+**Backend (`socialmedia-workspace`):**
+- Modify `src/channels/services/whatsapp.service.ts` — add `GRAPH_API_VERSION` const + 3 Graph methods.
+- Modify `src/channels/services/channel.service.ts` — add cross-workspace lookup helper.
+- Modify `src/inbox/inbox.service.ts` — make `findChannelByPlatformAccount` deterministic + warn on multi-row.
+- Create `src/channels/dto/embedded-signup-whatsapp.dto.ts` — request DTO.
+- Create `src/channels/services/whatsapp-onboarding.service.ts` — Embedded Signup orchestration.
+- Modify `src/channels/channels.controller.ts` — thin `POST .../whatsapp/embedded-signup` endpoint.
+- Modify `src/channels/channels.module.ts` — register `WhatsAppOnboardingService`.
+- Modify `.env.example` — document `META_APP_ID`.
+- Tests: `whatsapp.service.spec.ts`, `whatsapp-onboarding.service.spec.ts`, `inbox.service`'s existing spec (or a focused new spec).
+
+**Frontend (`socialmedia-frontend`):**
+- Modify `src/features/channels/api/whatsapp.api.ts` — add `embeddedSignup`.
+- Create `src/features/channels/utils/load-facebook-sdk.ts` — lazy SDK loader + FB types.
+- Create `src/features/channels/hooks/use-whatsapp-embedded-signup.ts` — orchestration hook.
+- Create `src/features/channels/components/whatsapp-embedded-signup-button.tsx` — the CTA.
+- Modify `src/features/channels/components/whatsapp-connect-dialog.tsx` — primary ES button + Collapsible manual form.
+- Modify `.env.example` — `VITE_META_APP_ID`, `VITE_WHATSAPP_ES_CONFIG_ID`.
+
+---
+
+## Task 1: Backend — WhatsApp Graph methods for Embedded Signup
+
+**Files:**
+- Modify: `src/channels/services/whatsapp.service.ts`
+- Test: `src/channels/services/whatsapp.service.spec.ts`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Consumes: existing `WhatsAppService` (methods `sendText`, `subscribeWaba`, etc.), `process.env.META_APP_ID`, `process.env.META_APP_SECRET`.
+- Produces:
+  - `GRAPH_API_VERSION = 'v21.0'` (exported const)
+  - `exchangeCodeForBusinessToken(code: string): Promise<{ accessToken: string; expiresIn: number | null }>`
+  - `registerPhoneNumber(accessToken: string, phoneNumberId: string, pin: string): Promise<void>` (treats "already registered" as success)
+  - `getWabaPhoneNumbers(accessToken: string, wabaId: string): Promise<Array<{ id: string; displayPhoneNumber: string | null; verifiedName: string | null }>>`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `src/channels/services/whatsapp.service.spec.ts` (create the file if it does not exist, following the existing service-spec style; mock `global.fetch`):
+
+```ts
+import { WhatsAppService, GRAPH_API_VERSION } from './whatsapp.service';
+
+describe('WhatsAppService — Embedded Signup Graph methods', () => {
+  let service: WhatsAppService;
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    service = new WhatsAppService();
+    process.env = { ...OLD_ENV, META_APP_ID: 'app123', META_APP_SECRET: 'secret456' };
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetAllMocks();
+  });
+
+  it('pins Graph API version to v21.0', () => {
+    expect(GRAPH_API_VERSION).toBe('v21.0');
+  });
+
+  it('exchangeCodeForBusinessToken hits oauth/access_token with app creds + code', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'biz-token', expires_in: 5184000 }),
+    });
+    const res = await service.exchangeCodeForBusinessToken('the-code');
+    expect(res).toEqual({ accessToken: 'biz-token', expiresIn: 5184000 });
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(url).toContain(`/${GRAPH_API_VERSION}/oauth/access_token`);
+    expect(url).toContain('client_id=app123');
+    expect(url).toContain('client_secret=secret456');
+    expect(url).toContain('code=the-code');
+  });
+
+  it('exchangeCodeForBusinessToken returns null expiresIn when Meta omits it (never-expiring config)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'biz-token' }),
+    });
+    const res = await service.exchangeCodeForBusinessToken('c');
+    expect(res).toEqual({ accessToken: 'biz-token', expiresIn: null });
+  });
+
+  it('exchangeCodeForBusinessToken throws the Meta error message on failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Invalid code' } }),
+    });
+    await expect(service.exchangeCodeForBusinessToken('bad')).rejects.toThrow('Invalid code');
+  });
+
+  it('registerPhoneNumber posts messaging_product + pin', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await service.registerPhoneNumber('tok', '111', '123456');
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`https://graph.facebook.com/${GRAPH_API_VERSION}/111/register`);
+    expect(JSON.parse((init as any).body)).toEqual({ messaging_product: 'whatsapp', pin: '123456' });
+  });
+
+  it('registerPhoneNumber treats "already registered" as success', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Phone number already registered', code: 100 } }),
+    });
+    await expect(service.registerPhoneNumber('tok', '111', '123456')).resolves.toBeUndefined();
+  });
+
+  it('registerPhoneNumber throws on a genuine failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Two-step verification pin mismatch' } }),
+    });
+    await expect(service.registerPhoneNumber('tok', '111', '000000')).rejects.toThrow(
+      'Two-step verification pin mismatch',
+    );
+  });
+
+  it('getWabaPhoneNumbers maps the Graph response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: '111', display_phone_number: '+1 555', verified_name: 'Acme' },
+          { id: '222', display_phone_number: null, verified_name: null },
+        ],
+      }),
+    });
+    const res = await service.getWabaPhoneNumbers('tok', 'waba1');
+    expect(res).toEqual([
+      { id: '111', displayPhoneNumber: '+1 555', verifiedName: 'Acme' },
+      { id: '222', displayPhoneNumber: null, verifiedName: null },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd socialmedia-workspace && npm run test -- whatsapp.service`
+Expected: FAIL — `GRAPH_API_VERSION` / new methods are undefined.
+
+- [ ] **Step 3: Implement the methods**
+
+In `src/channels/services/whatsapp.service.ts`, replace the top const and add the methods. Change line 3:
+
+```ts
+export const GRAPH_API_VERSION = 'v21.0';
+export const WHATSAPP_GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+```
+
+Add these methods inside the `WhatsAppService` class (e.g. after `subscribeWaba`):
+
+```ts
+  /**
+   * Exchange the short-lived Embedded Signup code (valid ~30s) for a
+   * customer-scoped business access token. Tech Provider server-to-server call.
+   */
+  async exchangeCodeForBusinessToken(
+    code: string,
+  ): Promise<{ accessToken: string; expiresIn: number | null }> {
+    const appId = process.env.META_APP_ID;
+    const appSecret = process.env.META_APP_SECRET;
+    if (!appId || !appSecret) {
+      throw new Error('META_APP_ID / META_APP_SECRET are not configured');
+    }
+    const url =
+      `${WHATSAPP_GRAPH_BASE}/oauth/access_token` +
+      `?client_id=${encodeURIComponent(appId)}` +
+      `&client_secret=${encodeURIComponent(appSecret)}` +
+      `&code=${encodeURIComponent(code)}`;
+    const res = await fetch(url);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data?.access_token) {
+      const msg = data?.error?.message || `Code exchange failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return {
+      accessToken: data.access_token as string,
+      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : null,
+    };
+  }
+
+  /**
+   * Register the customer's business phone number for Cloud API use. `pin` is
+   * the 6-digit two-step-verification PIN. If the number is already registered
+   * (idempotent re-run) we treat it as success.
+   */
+  async registerPhoneNumber(
+    accessToken: string,
+    phoneNumberId: string,
+    pin: string,
+  ): Promise<void> {
+    const res = await fetch(`${WHATSAPP_GRAPH_BASE}/${phoneNumberId}/register`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ messaging_product: 'whatsapp', pin }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) return;
+    const msg = (data?.error?.message as string) || '';
+    if (/already\s+registered/i.test(msg)) return; // idempotent
+    throw new Error(msg || `Phone number register failed (${res.status})`);
+  }
+
+  /**
+   * List the phone numbers on a WABA — fallback when the Embedded Signup
+   * message event omits the phone_number_id, and to read verified_name.
+   */
+  async getWabaPhoneNumbers(
+    accessToken: string,
+    wabaId: string,
+  ): Promise<
+    Array<{ id: string; displayPhoneNumber: string | null; verifiedName: string | null }>
+  > {
+    const res = await fetch(
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/phone_numbers?fields=id,display_phone_number,verified_name`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg = data?.error?.message || `WABA phone lookup failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return ((data?.data as any[]) ?? []).map((p) => ({
+      id: String(p.id),
+      displayPhoneNumber: p.display_phone_number ?? null,
+      verifiedName: p.verified_name ?? null,
+    }));
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd socialmedia-workspace && npm run test -- whatsapp.service`
+Expected: PASS (all cases green).
+
+- [ ] **Step 5: Document env**
+
+In `.env.example`, near `META_APP_SECRET`, add:
+
+```
+# Meta app id (public) — needed for WhatsApp Embedded Signup code exchange
+META_APP_ID=
+```
+
+- [ ] **Step 6: Build + commit**
+
+Run: `cd socialmedia-workspace && npm run build`
+Expected: no errors.
+
+```bash
+git add src/channels/services/whatsapp.service.ts src/channels/services/whatsapp.service.spec.ts .env.example
+git commit -m "feat(whatsapp): Graph methods for Embedded Signup (exchange/register/list phones)"
+```
+
+---
+
+## Task 2: Backend — multi-tenant correctness (cross-workspace guard + deterministic lookup)
+
+**Files:**
+- Modify: `src/channels/services/channel.service.ts` — add `findChannelsByPlatformAccountAllWorkspaces`.
+- Modify: `src/inbox/inbox.service.ts:1842` — make `findChannelByPlatformAccount` deterministic + warn.
+- Test: `src/channels/services/channel.service.spec.ts` (create/extend, focused).
+
+**Interfaces:**
+- Consumes: `db`, `socialMediaChannels`, `SupportedPlatform`.
+- Produces on `ChannelService`:
+  - `findChannelsByPlatformAccountAllWorkspaces(platform: SupportedPlatform, platformAccountId: string): Promise<Array<{ id: number; workspaceId: string }>>`
+- `InboxService.findChannelByPlatformAccount` unchanged signature, now deterministic (lowest `id` first) and logs a warning when more than one row matches.
+
+- [ ] **Step 1: Write failing test (channel.service)**
+
+Create `src/channels/services/channel.service.spec.ts` (or add a `describe` block if it exists) that mocks the drizzle `db` used by the service and asserts the query filters on `(platform, platformAccountId)` across workspaces. Because the service imports a module-level `db`, mock it via `jest.mock`:
+
+```ts
+import { ChannelService } from './channel.service';
+
+// Minimal fake db that records the query builder chain and returns canned rows.
+const rows = [
+  { id: 7, workspaceId: 'ws-A' },
+  { id: 3, workspaceId: 'ws-B' },
+];
+jest.mock('../../drizzle/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => Promise.resolve(rows),
+        }),
+      }),
+    }),
+  },
+}));
+
+describe('ChannelService.findChannelsByPlatformAccountAllWorkspaces', () => {
+  it('returns every workspace holding this platform account', async () => {
+    // Construct the service with its other deps stubbed as needed for this method.
+    const service = new ChannelService({} as any, {} as any, {} as any);
+    const res = await service.findChannelsByPlatformAccountAllWorkspaces(
+      'whatsapp',
+      '111',
+    );
+    expect(res).toEqual(rows);
+  });
+});
+```
+
+> Note: match the actual `db` import path used in `channel.service.ts` (check the import at the top — it may be `../../drizzle/drizzle.module` or a `db` export). Adjust the `jest.mock` target and the `ChannelService` constructor arguments to the real dependency list. Keep the assertion (returns all matching rows) intact.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd socialmedia-workspace && npm run test -- channel.service`
+Expected: FAIL — method undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `ChannelService` (use the same `db` + `asc` import style already in the file; import `asc` from `drizzle-orm` if not present):
+
+```ts
+  /**
+   * Every channel row (across ALL workspaces) that holds this platform account.
+   * Used by WhatsApp Embedded Signup to reject connecting a phone number that
+   * another workspace already owns (webhook routing is keyed on the account id).
+   */
+  async findChannelsByPlatformAccountAllWorkspaces(
+    platform: SupportedPlatform,
+    platformAccountId: string,
+  ): Promise<Array<{ id: number; workspaceId: string }>> {
+    return db
+      .select({
+        id: socialMediaChannels.id,
+        workspaceId: socialMediaChannels.workspaceId,
+      })
+      .from(socialMediaChannels)
+      .where(
+        and(
+          eq(socialMediaChannels.platform, platform),
+          eq(socialMediaChannels.platformAccountId, platformAccountId),
+        ),
+      )
+      .orderBy(asc(socialMediaChannels.id));
+  }
+```
+
+- [ ] **Step 4: Make the inbox lookup deterministic**
+
+In `src/inbox/inbox.service.ts`, replace `findChannelByPlatformAccount` (line ~1842):
+
+```ts
+  async findChannelByPlatformAccount(
+    platform: SupportedPlatform,
+    platformAccountId: string,
+  ) {
+    const matches = await db.query.socialMediaChannels.findMany({
+      where: and(
+        eq(socialMediaChannels.platform, platform),
+        eq(socialMediaChannels.platformAccountId, platformAccountId),
+      ),
+      orderBy: (c, { asc }) => asc(c.id),
+    });
+    if (matches.length > 1) {
+      this.logger.warn(
+        `findChannelByPlatformAccount: ${matches.length} rows for ${platform}/${platformAccountId} — routing to the lowest channel id (${matches[0].id}). This should not happen; a cross-workspace duplicate slipped past the connect guard.`,
+      );
+    }
+    return matches[0];
+  }
+```
+
+> Confirm `InboxService` has a `private readonly logger` (Nest `Logger`). If not, add `private readonly logger = new Logger(InboxService.name);` and import `Logger` from `@nestjs/common`.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cd socialmedia-workspace && npm run test -- channel.service && npm run build`
+Expected: PASS + no build errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/channels/services/channel.service.ts src/channels/services/channel.service.spec.ts src/inbox/inbox.service.ts
+git commit -m "fix(whatsapp): cross-workspace lookup + deterministic channel routing"
+```
+
+---
+
+## Task 3: Backend — Embedded Signup orchestration service + endpoint
+
+**Files:**
+- Create: `src/channels/dto/embedded-signup-whatsapp.dto.ts`
+- Create: `src/channels/services/whatsapp-onboarding.service.ts`
+- Test: `src/channels/services/whatsapp-onboarding.service.spec.ts`
+- Modify: `src/channels/channels.controller.ts` — add endpoint.
+- Modify: `src/channels/channels.module.ts` — register the service.
+
+**Interfaces:**
+- Consumes: `WhatsAppService` (Task 1), `ChannelService` (Task 2 helper + `createChannel`), `InboxService.assertWorkspaceAccessPublic`.
+- Produces:
+  - DTO `EmbeddedSignupWhatsAppDto { code: string; wabaId: string; phoneNumberId: string; pin?: string }`
+  - `WhatsAppOnboardingService.completeEmbeddedSignup(workspaceId: string, userId: string, input: { code: string; wabaId: string; phoneNumberId: string; pin?: string }): Promise<ChannelResponseDto>`
+  - `POST /channels/workspaces/:workspaceId/whatsapp/embedded-signup`
+
+- [ ] **Step 1: Write the DTO**
+
+Create `src/channels/dto/embedded-signup-whatsapp.dto.ts`:
+
+```ts
+import { IsString, IsNotEmpty, IsOptional, Matches } from 'class-validator';
+
+export class EmbeddedSignupWhatsAppDto {
+  // Short-lived exchangeable code from the Embedded Signup callback (~30s TTL).
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+$/, { message: 'wabaId must be a numeric id' })
+  wabaId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+$/, { message: 'phoneNumberId must be a numeric id' })
+  phoneNumberId!: string;
+
+  // 6-digit two-step-verification PIN used to register the number. Defaults to
+  // '000000' when the number has no two-step PIN set.
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{6}$/, { message: 'pin must be 6 digits' })
+  pin?: string;
+}
+```
+
+- [ ] **Step 2: Write failing tests for the orchestration service**
+
+Create `src/channels/services/whatsapp-onboarding.service.spec.ts`:
+
+```ts
+import { ConflictException, BadRequestException } from '@nestjs/common';
+import { WhatsAppOnboardingService } from './whatsapp-onboarding.service';
+
+function makeService(overrides: {
+  whatsapp?: Partial<any>;
+  channels?: Partial<any>;
+  inbox?: Partial<any>;
+} = {}) {
+  const whatsapp = {
+    exchangeCodeForBusinessToken: jest.fn().mockResolvedValue({ accessToken: 'biz', expiresIn: 5184000 }),
+    getWabaPhoneNumbers: jest.fn().mockResolvedValue([
+      { id: '111', displayPhoneNumber: '+1 555', verifiedName: 'Acme' },
+    ]),
+    registerPhoneNumber: jest.fn().mockResolvedValue(undefined),
+    subscribeWaba: jest.fn().mockResolvedValue(undefined),
+    ...overrides.whatsapp,
+  };
+  const channels = {
+    findChannelsByPlatformAccountAllWorkspaces: jest.fn().mockResolvedValue([]),
+    createChannel: jest.fn().mockResolvedValue({ id: 1, accountName: 'Acme' }),
+    ...overrides.channels,
+  };
+  const inbox = {
+    assertWorkspaceAccessPublic: jest.fn().mockResolvedValue(undefined),
+    ...overrides.inbox,
+  };
+  const service = new WhatsAppOnboardingService(whatsapp as any, channels as any, inbox as any);
+  return { service, whatsapp, channels, inbox };
+}
+
+describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
+  const input = { code: 'c', wabaId: 'w1', phoneNumberId: '111' };
+
+  it('runs the full happy path and creates the channel', async () => {
+    const { service, whatsapp, channels } = makeService();
+    const res = await service.completeEmbeddedSignup('ws-A', 'u1', input);
+    expect(whatsapp.exchangeCodeForBusinessToken).toHaveBeenCalledWith('c');
+    expect(whatsapp.registerPhoneNumber).toHaveBeenCalledWith('biz', '111', '000000');
+    expect(whatsapp.subscribeWaba).toHaveBeenCalledWith('biz', 'w1');
+    expect(channels.createChannel).toHaveBeenCalledWith(
+      'ws-A',
+      'u1',
+      expect.objectContaining({
+        platform: 'whatsapp',
+        platformAccountId: '111',
+        accessToken: 'biz',
+        metadata: expect.objectContaining({ wabaId: 'w1', connectMethod: 'embedded_signup' }),
+      }),
+    );
+    expect(res).toEqual({ id: 1, accountName: 'Acme' });
+  });
+
+  it('passes a caller-supplied pin through to register', async () => {
+    const { service, whatsapp } = makeService();
+    await service.completeEmbeddedSignup('ws-A', 'u1', { ...input, pin: '654321' });
+    expect(whatsapp.registerPhoneNumber).toHaveBeenCalledWith('biz', '111', '654321');
+  });
+
+  it('rejects when the phone number is already connected in another workspace', async () => {
+    const { service } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest
+          .fn()
+          .mockResolvedValue([{ id: 9, workspaceId: 'ws-OTHER' }]),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('allows re-connecting a number already in the SAME workspace (delegates to createChannel)', async () => {
+    const { service, channels } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest
+          .fn()
+          .mockResolvedValue([{ id: 9, workspaceId: 'ws-A' }]),
+        createChannel: jest.fn().mockResolvedValue({ id: 9, accountName: 'Acme' }),
+      },
+    });
+    const res = await service.completeEmbeddedSignup('ws-A', 'u1', input);
+    expect(res).toEqual({ id: 9, accountName: 'Acme' });
+    expect(channels.createChannel).toHaveBeenCalled();
+  });
+
+  it('surfaces an expired/invalid code as a BadRequest', async () => {
+    const { service } = makeService({
+      whatsapp: {
+        exchangeCodeForBusinessToken: jest.fn().mockRejectedValue(new Error('Invalid code')),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('fails the connect when WABA subscribe fails (blocking, not best-effort)', async () => {
+    const { service } = makeService({
+      whatsapp: {
+        subscribeWaba: jest.fn().mockRejectedValue(new Error('subscribe boom')),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toThrow('subscribe boom');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd socialmedia-workspace && npm run test -- whatsapp-onboarding`
+Expected: FAIL — service does not exist.
+
+- [ ] **Step 4: Implement the orchestration service**
+
+Create `src/channels/services/whatsapp-onboarding.service.ts`:
+
+```ts
+import {
+  Injectable,
+  Logger,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { WhatsAppService } from './whatsapp.service';
+import { ChannelService } from './channel.service';
+import { InboxService } from '../../inbox/inbox.service';
+import type { ChannelResponseDto } from '../dto/channel.dto';
+
+export interface EmbeddedSignupInput {
+  code: string;
+  wabaId: string;
+  phoneNumberId: string;
+  pin?: string;
+}
+
+@Injectable()
+export class WhatsAppOnboardingService {
+  private readonly logger = new Logger(WhatsAppOnboardingService.name);
+
+  constructor(
+    private readonly whatsapp: WhatsAppService,
+    private readonly channels: ChannelService,
+    private readonly inbox: InboxService,
+  ) {}
+
+  /**
+   * Complete WhatsApp Embedded Signup (Tech Provider flow): exchange the code
+   * for a business token, register the phone number, subscribe our app to the
+   * WABA, guard cross-workspace duplicates, then persist the channel.
+   */
+  async completeEmbeddedSignup(
+    workspaceId: string,
+    userId: string,
+    input: EmbeddedSignupInput,
+  ): Promise<ChannelResponseDto> {
+    await this.inbox.assertWorkspaceAccessPublic(workspaceId, userId);
+
+    // 1. Exchange the short-lived code for a customer-scoped business token.
+    let accessToken: string;
+    let expiresIn: number | null;
+    try {
+      const exchanged = await this.whatsapp.exchangeCodeForBusinessToken(input.code);
+      accessToken = exchanged.accessToken;
+      expiresIn = exchanged.expiresIn;
+    } catch (err) {
+      throw new BadRequestException(
+        `Could not complete WhatsApp signup — ${
+          (err as Error).message
+        }. The signup code expires within ~30 seconds; please try connecting again.`,
+      );
+    }
+
+    // 2. Resolve display name / verified name (also validates the number).
+    let displayPhoneNumber: string | null = null;
+    let verifiedName: string | null = null;
+    try {
+      const phones = await this.whatsapp.getWabaPhoneNumbers(accessToken, input.wabaId);
+      const match = phones.find((p) => p.id === input.phoneNumberId) ?? phones[0];
+      displayPhoneNumber = match?.displayPhoneNumber ?? null;
+      verifiedName = match?.verifiedName ?? null;
+    } catch (err) {
+      this.logger.warn(
+        `getWabaPhoneNumbers failed for waba=${input.wabaId}: ${(err as Error).message}`,
+      );
+    }
+
+    // 3. Register the phone number for Cloud API (idempotent).
+    await this.whatsapp.registerPhoneNumber(
+      accessToken,
+      input.phoneNumberId,
+      input.pin ?? '000000',
+    );
+
+    // 4. Subscribe our app to the WABA — BLOCKING. A channel that never
+    //    receives webhooks is worse than a visible failure.
+    await this.whatsapp.subscribeWaba(accessToken, input.wabaId);
+
+    // 5. Cross-workspace guard: reject if this phone number is already owned by
+    //    a DIFFERENT workspace (webhook routing is keyed on phone_number_id).
+    const existing =
+      await this.channels.findChannelsByPlatformAccountAllWorkspaces(
+        'whatsapp',
+        input.phoneNumberId,
+      );
+    const otherWorkspace = existing.find((c) => c.workspaceId !== workspaceId);
+    if (otherWorkspace) {
+      throw new ConflictException(
+        'This WhatsApp number is already connected to another workspace. Disconnect it there first.',
+      );
+    }
+
+    // 6. Persist. createChannel encrypts the token and, for a same-workspace
+    //    broken row, reconnects in place (a healthy same-workspace duplicate
+    //    still throws ConflictException — expected).
+    const accountName = verifiedName || input.phoneNumberId;
+    return this.channels.createChannel(workspaceId, userId, {
+      platform: 'whatsapp',
+      accountType: 'business_account',
+      platformAccountId: input.phoneNumberId,
+      accountName,
+      accessToken,
+      tokenExpiresAt: expiresIn
+        ? new Date(Date.now() + expiresIn * 1000).toISOString()
+        : undefined,
+      metadata: {
+        wabaId: input.wabaId,
+        displayPhoneNumber: displayPhoneNumber ?? input.phoneNumberId,
+        connectMethod: 'embedded_signup',
+      },
+    });
+  }
+}
+```
+
+> Verify `CreateChannelDto` accepts `tokenExpiresAt` as an ISO string (Task 2 read of `channel.service.ts` shows `dto.tokenExpiresAt` is passed to `new Date(...)`). If `CreateChannelDto` types it differently, match that type. If `ChannelResponseDto` import path differs, correct it.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd socialmedia-workspace && npm run test -- whatsapp-onboarding`
+Expected: PASS.
+
+- [ ] **Step 6: Add the controller endpoint**
+
+In `src/channels/channels.controller.ts`: import the DTO + service, inject the service in the constructor, and add the endpoint next to `connectWhatsApp` (after line 5442, inside the class):
+
+```ts
+  @Post('workspaces/:workspaceId/whatsapp/embedded-signup')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async connectWhatsAppEmbeddedSignup(
+    @Param('workspaceId') workspaceId: string,
+    @Body() dto: EmbeddedSignupWhatsAppDto,
+    @CurrentUser() user: { userId: string; email: string },
+  ) {
+    return this.whatsappOnboardingService.completeEmbeddedSignup(
+      workspaceId,
+      user.userId,
+      {
+        code: dto.code,
+        wabaId: dto.wabaId,
+        phoneNumberId: dto.phoneNumberId,
+        pin: dto.pin,
+      },
+    );
+  }
+```
+
+Add the import near the other DTO imports:
+```ts
+import { EmbeddedSignupWhatsAppDto } from './dto/embedded-signup-whatsapp.dto';
+import { WhatsAppOnboardingService } from './services/whatsapp-onboarding.service';
+```
+Add to the constructor parameter list:
+```ts
+    private readonly whatsappOnboardingService: WhatsAppOnboardingService,
+```
+
+- [ ] **Step 7: Register the service in the module**
+
+In `src/channels/channels.module.ts`, add `WhatsAppOnboardingService` to the `providers` array (import it at the top). Ensure `InboxService` is available to it — if `ChannelsModule` does not already import the module that exports `InboxService`, add that import (check how `channels.controller.ts` already uses `inboxService` — the wiring already exists, so the provider is reachable).
+
+- [ ] **Step 8: Build + commit**
+
+Run: `cd socialmedia-workspace && npm run build && npm run test -- whatsapp`
+Expected: no build errors, all whatsapp tests pass.
+
+```bash
+git add src/channels/dto/embedded-signup-whatsapp.dto.ts src/channels/services/whatsapp-onboarding.service.ts src/channels/services/whatsapp-onboarding.service.spec.ts src/channels/channels.controller.ts src/channels/channels.module.ts
+git commit -m "feat(whatsapp): Embedded Signup onboarding service + endpoint"
+```
+
+---
+
+## Task 4: Frontend — API + Facebook SDK loader + orchestration hook
+
+**Files:**
+- Modify: `src/features/channels/api/whatsapp.api.ts`
+- Create: `src/features/channels/utils/load-facebook-sdk.ts`
+- Create: `src/features/channels/hooks/use-whatsapp-embedded-signup.ts`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Consumes: `apiClient`, `ChannelDto`, `import.meta.env.VITE_META_APP_ID`, `import.meta.env.VITE_WHATSAPP_ES_CONFIG_ID`.
+- Produces:
+  - `whatsappApi.embeddedSignup(workspaceId, { code, wabaId, phoneNumberId })`
+  - `loadFacebookSdk(appId: string): Promise<FacebookSdk>`
+  - `useWhatsAppEmbeddedSignup()` → `{ start(): void; status: 'idle'|'loading'|'connecting'|'error'; error: string | null }`
+
+- [ ] **Step 1: Add the API function**
+
+In `src/features/channels/api/whatsapp.api.ts`, add:
+
+```ts
+export interface EmbeddedSignupWhatsAppPayload {
+  code: string
+  wabaId: string
+  phoneNumberId: string
+}
+```
+and inside `whatsappApi`:
+```ts
+  embeddedSignup: (workspaceId: string, payload: EmbeddedSignupWhatsAppPayload) =>
+    apiClient.post<ChannelDto>(
+      `/channels/workspaces/${workspaceId}/whatsapp/embedded-signup`,
+      payload,
+    ),
+```
+
+- [ ] **Step 2: Create the SDK loader**
+
+Create `src/features/channels/utils/load-facebook-sdk.ts`:
+
+```ts
+// Minimal typing for the pieces of the Facebook JS SDK we use.
+export interface FacebookAuthResponse {
+  code?: string
+}
+export interface FacebookLoginResponse {
+  authResponse: FacebookAuthResponse | null
+  status: string
+}
+export interface FacebookSdk {
+  init(params: { appId: string; autoLogAppEvents?: boolean; xfbml?: boolean; version: string }): void
+  login(
+    cb: (response: FacebookLoginResponse) => void,
+    options: {
+      config_id: string
+      response_type: 'code'
+      override_default_response_type: boolean
+      extras: { setup: Record<string, unknown> }
+    },
+  ): void
+}
+
+declare global {
+  interface Window {
+    FB?: FacebookSdk
+    fbAsyncInit?: () => void
+  }
+}
+
+const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js'
+const GRAPH_VERSION = 'v21.0'
+let sdkPromise: Promise<FacebookSdk> | null = null
+
+/** Lazily inject + init the Facebook JS SDK exactly once. */
+export function loadFacebookSdk(appId: string): Promise<FacebookSdk> {
+  if (sdkPromise) return sdkPromise
+  sdkPromise = new Promise<FacebookSdk>((resolve, reject) => {
+    if (window.FB) {
+      window.FB.init({ appId, autoLogAppEvents: true, xfbml: false, version: GRAPH_VERSION })
+      resolve(window.FB)
+      return
+    }
+    window.fbAsyncInit = () => {
+      window.FB!.init({ appId, autoLogAppEvents: true, xfbml: false, version: GRAPH_VERSION })
+      resolve(window.FB!)
+    }
+    const script = document.createElement('script')
+    script.src = SDK_SRC
+    script.async = true
+    script.defer = true
+    script.crossOrigin = 'anonymous'
+    script.onerror = () => {
+      sdkPromise = null
+      reject(new Error('Could not load the Facebook SDK. Check your connection and retry.'))
+    }
+    document.body.appendChild(script)
+  })
+  return sdkPromise
+}
+```
+
+- [ ] **Step 3: Create the orchestration hook**
+
+Create `src/features/channels/hooks/use-whatsapp-embedded-signup.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { ApiError } from '@/lib/api'
+import { useWorkspaceId } from '@/hooks/use-workspace-id'
+import { queryKeys } from '@/lib/query-client'
+import { loadFacebookSdk } from '../utils/load-facebook-sdk'
+import { whatsappApi } from '../api/whatsapp.api'
+
+type Status = 'idle' | 'loading' | 'connecting' | 'error'
+
+interface EmbeddedSignupSessionData {
+  phone_number_id?: string
+  waba_id?: string
+  business_id?: string
+  current_step?: string
+  error_message?: string
+}
+
+interface UseWhatsAppEmbeddedSignupResult {
+  start: () => void
+  status: Status
+  error: string | null
+}
+
+const APP_ID = import.meta.env.VITE_META_APP_ID as string | undefined
+const CONFIG_ID = import.meta.env.VITE_WHATSAPP_ES_CONFIG_ID as string | undefined
+
+export function useWhatsAppEmbeddedSignup(
+  onConnected?: () => void,
+): UseWhatsAppEmbeddedSignupResult {
+  const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<Status>('idle')
+  const [error, setError] = useState<string | null>(null)
+  // Captured from the WA_EMBEDDED_SIGNUP message event; paired with the code
+  // from the FB.login callback.
+  const sessionRef = useRef<EmbeddedSignupSessionData | null>(null)
+
+  const submit = useMutation({
+    mutationFn: (payload: { code: string; wabaId: string; phoneNumberId: string }) => {
+      if (!workspaceId) throw new Error('No active workspace')
+      return whatsappApi.embeddedSignup(workspaceId, payload)
+    },
+    onSuccess: async (channel) => {
+      setStatus('idle')
+      toast.success('WhatsApp connected', {
+        description: channel.accountName ? `Linked ${channel.accountName}` : undefined,
+      })
+      if (workspaceId) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.channels.list(workspaceId) })
+      }
+      onConnected?.()
+    },
+    onError: (err) => {
+      setStatus('error')
+      setError(
+        err instanceof ApiError
+          ? err.message
+          : 'Could not finish connecting WhatsApp. Please try again.',
+      )
+    },
+  })
+
+  // Listen for the Embedded Signup session events (origin: facebook.com).
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (!event.origin.endsWith('facebook.com')) return
+      let parsed: { type?: string; event?: string; data?: EmbeddedSignupSessionData }
+      try {
+        parsed = typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+      } catch {
+        return
+      }
+      if (parsed?.type !== 'WA_EMBEDDED_SIGNUP') return
+      if (parsed.event === 'FINISH' || parsed.event === 'FINISH_ONLY_WABA') {
+        sessionRef.current = parsed.data ?? null
+      } else if (parsed.event === 'CANCEL') {
+        setStatus('idle')
+        setError(
+          parsed.data?.current_step
+            ? `Signup was cancelled at "${parsed.data.current_step}". You can try again.`
+            : null,
+        )
+      } else if (parsed.event === 'ERROR') {
+        setStatus('error')
+        setError(parsed.data?.error_message ?? 'WhatsApp signup returned an error.')
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
+
+  const start = useCallback(() => {
+    setError(null)
+    if (!APP_ID || !CONFIG_ID) {
+      setStatus('error')
+      setError('WhatsApp signup is not configured (missing app id / config id).')
+      return
+    }
+    setStatus('loading')
+    sessionRef.current = null
+    loadFacebookSdk(APP_ID)
+      .then((FB) => {
+        setStatus('connecting')
+        FB.login(
+          (response) => {
+            const code = response.authResponse?.code
+            const session = sessionRef.current
+            if (!code || !session?.waba_id || !session?.phone_number_id) {
+              // User closed the dialog or abandoned before finishing.
+              setStatus((s) => (s === 'error' ? s : 'idle'))
+              return
+            }
+            submit.mutate({
+              code,
+              wabaId: session.waba_id,
+              phoneNumberId: session.phone_number_id,
+            })
+          },
+          {
+            config_id: CONFIG_ID,
+            response_type: 'code',
+            override_default_response_type: true,
+            extras: { setup: {} },
+          },
+        )
+      })
+      .catch((err: Error) => {
+        setStatus('error')
+        setError(err.message)
+      })
+  }, [submit])
+
+  return {
+    start,
+    status: submit.isPending ? 'connecting' : status,
+    error,
+  }
+}
+```
+
+- [ ] **Step 4: Document env**
+
+In `.env.example` (frontend), add:
+```
+# Meta app id (public) for WhatsApp Embedded Signup
+VITE_META_APP_ID=
+# Facebook Login for Business configuration id for WhatsApp Embedded Signup
+VITE_WHATSAPP_ES_CONFIG_ID=
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd socialmedia-frontend && npm run build`
+Expected: tsc + vite build succeed (no type errors from the new files).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/channels/api/whatsapp.api.ts src/features/channels/utils/load-facebook-sdk.ts src/features/channels/hooks/use-whatsapp-embedded-signup.ts .env.example
+git commit -m "feat(whatsapp): frontend Embedded Signup SDK loader + hook + api"
+```
+
+---
+
+## Task 5: Frontend — Embedded Signup button + dialog restructure
+
+**Files:**
+- Create: `src/features/channels/components/whatsapp-embedded-signup-button.tsx`
+- Modify: `src/features/channels/components/whatsapp-connect-dialog.tsx`
+
+**Interfaces:**
+- Consumes: `useWhatsAppEmbeddedSignup` (Task 4), shadcn `Button`, `Collapsible` (`src/components/ui/collapsible.tsx` — already installed).
+- Produces: `<WhatsAppEmbeddedSignupButton onConnected={...} />`.
+
+- [ ] **Step 1: Create the button component**
+
+Create `src/features/channels/components/whatsapp-embedded-signup-button.tsx`:
+
+```tsx
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useWhatsAppEmbeddedSignup } from '../hooks/use-whatsapp-embedded-signup'
+
+interface WhatsAppEmbeddedSignupButtonProps {
+  onConnected: () => void
+}
+
+export function WhatsAppEmbeddedSignupButton({
+  onConnected,
+}: WhatsAppEmbeddedSignupButtonProps) {
+  const { start, status, error } = useWhatsAppEmbeddedSignup(onConnected)
+  const isBusy = status === 'loading' || status === 'connecting'
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button type="button" onClick={start} disabled={isBusy} className="w-full">
+        {isBusy ? (
+          <>
+            <Loader2 className="size-4 animate-spin" />
+            {status === 'loading' ? 'Opening Facebook…' : 'Connecting…'}
+          </>
+        ) : (
+          'Connect with Facebook'
+        )}
+      </Button>
+      <p className="text-center text-xs text-muted-foreground">
+        You'll be asked to select your WhatsApp Business account and grant access.
+      </p>
+      {error && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Restructure the dialog**
+
+In `src/features/channels/components/whatsapp-connect-dialog.tsx`:
+
+1. Add imports:
+```tsx
+import { ChevronsUpDown } from 'lucide-react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { WhatsAppEmbeddedSignupButton } from './whatsapp-embedded-signup-button'
+```
+2. Add a state for the advanced disclosure inside the component:
+```tsx
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+```
+3. Reset it in the existing `useEffect(() => { if (open) {...} }, [open])` block: add `setAdvancedOpen(false)`.
+4. In the returned JSX, put the ES button as the primary action ABOVE the form, and wrap the existing manual `<form>...</form>` in a Collapsible. Replace the `<form onSubmit={handleSubmit} ...>` block's surrounding so the structure becomes:
+
+```tsx
+        <div className="flex flex-col gap-4">
+          <WhatsAppEmbeddedSignupButton onConnected={() => onOpenChange(false)} />
+
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs text-muted-foreground">or</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full justify-between text-muted-foreground"
+              >
+                Advanced: use your own token
+                <ChevronsUpDown className="size-4" />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-3">
+              {/* existing manual <form onSubmit={handleSubmit} ...> ... </form> stays here verbatim */}
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+```
+
+Keep the existing manual `<form>` (fields, validation, `connect.mutate`, footer) exactly as-is, just moved inside `CollapsibleContent`. Update the `DialogDescription` copy to: "Connect your WhatsApp Business account with Facebook — or expand Advanced to paste a token manually."
+
+> shadcn note: `Collapsible` uses `@base-ui` under the hood in this repo (see `[[project_basecn_vs_radix_idioms]]`). `CollapsibleTrigger asChild` should work; if the installed wrapper does not support `asChild`, render the trigger without `asChild` and style it directly. Verify against `src/components/ui/collapsible.tsx`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd socialmedia-frontend && npm run build`
+Expected: tsc + vite build succeed.
+
+- [ ] **Step 4: Manual smoke (no test runner on frontend)**
+
+With `VITE_META_APP_ID` + `VITE_WHATSAPP_ES_CONFIG_ID` set in `.env`, run `npm run dev`, open the WhatsApp connect dialog: the primary "Connect with Facebook" button shows; "Advanced: use your own token" expands the manual form. (The actual FB dialog needs the Meta config_id + a test admin account — covered in the Meta console setup, not this build check.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/channels/components/whatsapp-embedded-signup-button.tsx src/features/channels/components/whatsapp-connect-dialog.tsx
+git commit -m "feat(whatsapp): primary Embedded Signup CTA + manual form under Advanced"
+```
+
+---
+
+## Self-review notes (for the executor)
+
+- **Spec coverage:** Task 1 = Graph methods + version const + env; Task 2 = cross-workspace guard + deterministic routing (spec §"security fix"); Task 3 = endpoint + DTO + orchestration + error handling (expired code, subscribe-blocking, cross-workspace 409, idempotent register); Tasks 4–5 = FB SDK + hook + button + dialog restructure + env. Manual connect kept (Task 5 keeps the form). Out-of-scope items (Maestro `.some()` bug, template messages, token refresh) intentionally excluded.
+- **Verify before "done":** backend `npm run build` + `npm run test -- whatsapp` + `npm run test -- channel.service`; frontend `npm run build`.
+- **Do NOT** touch `facebook.service.ts` version, the webhook signature path, or remove the manual connect.
+- **Meta console prerequisites** (user, not code): register app as Tech Provider, create a Facebook-Login-for-Business config → `config_id`, prefer a never-expiring token config, set `META_APP_ID` / `VITE_META_APP_ID` / `VITE_WHATSAPP_ES_CONFIG_ID`. Testable in dev mode by an app admin/developer.
+```

--- a/docs/superpowers/specs/2026-07-09-whatsapp-embedded-signup-design.md
+++ b/docs/superpowers/specs/2026-07-09-whatsapp-embedded-signup-design.md
@@ -1,0 +1,223 @@
+# WhatsApp Embedded Signup — Design Spec
+
+**Date:** 2026-07-09
+**Branch:** `feat/whatsapp-embedded-signup` (both repos)
+**Status:** Approved for planning
+
+## Goal
+
+Replace the manual-token WhatsApp connect with **Meta Embedded Signup v4**
+(Facebook Login for Business) so that connecting a WhatsApp Business Account
+happens through *our* app's Facebook consent dialog. This makes the
+`whatsapp_business_messaging` + `whatsapp_business_management` permissions
+**demo-able for Meta App Review** (the manual token-paste flow has no consent
+screen to screencast → guaranteed rejection). Keep the manual flow available as
+a hidden "Advanced" fallback until App Review grants Advanced Access.
+
+## Architecture (one paragraph)
+
+The browser loads the Facebook JS SDK on demand and calls `FB.login` with our
+Facebook-Login-for-Business `config_id`. When the business finishes the dialog,
+a `message` event of type `WA_EMBEDDED_SIGNUP` delivers `waba_id`,
+`phone_number_id`, and `business_id`; the `FB.login` callback delivers a
+short-lived (30s) `code`. The frontend immediately POSTs `{ code, wabaId,
+phoneNumberId }` to a new backend endpoint, which performs three server-to-server
+Graph calls (exchange code → register phone number → subscribe app to the WABA)
+and then persists the channel through the existing `createChannel` path (which
+already fires the analytics/backfill lifecycle hook).
+
+## Tech Stack
+
+- Backend: NestJS (`socialmedia-workspace`) — `whatsapp.service.ts`,
+  `channels.controller.ts`, existing `createChannel` / channel schema.
+- Frontend: Vite + React 19 + shadcn (`socialmedia-frontend`) — new connect
+  component + restructured connect dialog. Facebook JS SDK loaded lazily.
+
+## Global Constraints
+
+- **Graph API version:** introduce a single `GRAPH_API_VERSION` constant
+  (currently drifts v18 in `facebook.service.ts` / dead `OAUTH_CONFIGS.whatsapp`
+  vs v21 in `whatsapp.service.ts`). Use **v21.0** as the pinned value.
+- **Token at rest:** access token MUST be encrypted via the existing
+  `encrypt()` util (`common/utils/encryption.util.ts`) exactly as `createChannel`
+  already does. Never log the token or the exchange `code`.
+- **shadcn-only** on the frontend (Collapsible, Button, Dialog, Form, etc. via
+  the shadcn registry); theme tokens only.
+- **No secrets client-side** beyond the public `META_APP_ID` and the
+  `config_id` (both are safe to expose — they appear in the OAuth dialog URL).
+- **Webhook signature** stays fail-closed (`META_APP_SECRET`); do not weaken it.
+
+## Meta requirements (researched 2026-07-09, official docs)
+
+- Embedded Signup **v2 deprecates 2026-10-15** → build **v4**.
+- `FB.login(cb, { config_id, response_type: 'code', override_default_response_type: true, extras: { setup: {} } })`.
+  `config_id` replaces `scope`; `response_type` must be `code`.
+- Success `message` event `WA_EMBEDDED_SIGNUP` → `waba_id`, `phone_number_id`,
+  `business_id` (+ optional asset ids). Abandonment → `current_step`. Error →
+  `error_message`, `error_code`, `session_id`.
+- Callback `code` is valid **~30 seconds** → exchange immediately server-side.
+- **Prerequisite:** app must be a **Tech Provider** with a Facebook-Login-for-
+  Business configuration (`config_id`). Business Verification is **already done**.
+- **Dev-mode testable:** anyone added as **admin/developer/tester** on the app
+  can complete the flow with their own Meta credentials — this is how we test +
+  record the App Review screencast before Advanced Access is granted.
+- Tech Provider model uses **business tokens** exclusively; onboarded customers
+  must add their **own payment method** to their WABA before sending at scale.
+
+### Server-to-server calls (Tech Provider)
+
+1. **Exchange code → business token**
+   `GET /v21.0/oauth/access_token?client_id={META_APP_ID}&client_secret={META_APP_SECRET}&code={code}`
+   → returns the customer-scoped business access token.
+2. **Register the phone number for Cloud API**
+   `POST /v21.0/{phoneNumberId}/register`
+   body `{ messaging_product: 'whatsapp', pin: '<6-digit>' }` (bearer business token).
+   Treat "already registered" as success (idempotent).
+3. **Subscribe our app to the customer's WABA webhooks**
+   `POST /v21.0/{wabaId}/subscribed_apps` (bearer business token). Already exists
+   as `whatsappService.subscribeWaba`; make it **blocking** in this flow.
+
+Fallback discovery (if the `message` event omits ids): `GET /v21.0/{wabaId}/phone_numbers`
+to resolve the phone number id from the WABA.
+
+---
+
+## Components
+
+### Backend
+
+**`whatsapp.service.ts` — new methods** (also move the Meta verify currently
+inlined at `channels.controller.ts:5380` into the service):
+- `exchangeCodeForBusinessToken(code): Promise<{ accessToken: string; expiresIn: number | null }>`
+- `registerPhoneNumber(accessToken, phoneNumberId, pin): Promise<void>` —
+  swallow the "already registered" error path.
+- `getWabaPhoneNumbers(accessToken, wabaId): Promise<Array<{ id; displayPhoneNumber; verifiedName }>>` —
+  fallback discovery + to read `verified_name` / `display_phone_number`.
+- Reuse existing `subscribeWaba(accessToken, wabaId)` (make blocking here).
+- Add a shared `GRAPH_API_VERSION` constant used by all methods.
+
+**`channels.controller.ts` — new endpoint**
+`POST /channels/workspaces/:workspaceId/whatsapp/embedded-signup`
+body DTO `EmbeddedSignupWhatsAppDto { code: string; wabaId: numeric-string; phoneNumberId: numeric-string; pin?: 6-digit-string }`.
+Steps: assert workspace access → `exchangeCodeForBusinessToken` → (ids missing?
+`getWabaPhoneNumbers`) → read `verified_name`/`display_phone_number` →
+`registerPhoneNumber` → `subscribeWaba` (blocking) → **cross-workspace guard**
+→ `createChannel(... platform:'whatsapp', platformAccountId: phoneNumberId,
+metadata:{ wabaId, businessId?, displayPhoneNumber, connectMethod:'embedded_signup' },
+accessToken (encrypted by createChannel), tokenExpiresAt from expiresIn if present)`.
+The existing manual `connectWhatsApp` endpoint stays.
+
+**Cross-workspace security guard (required for self-serve):**
+Before `createChannel`, reject with `409` + clear message if the same
+`phone_number_id` is already connected in **any other workspace**. Also make
+`inbox.service.ts:findChannelByPlatformAccount` deterministic (it currently does
+an unscoped `findFirst` on `(platform, platformAccountId)`) — order the lookup
+and log a warning if more than one row matches, so webhook routing never lands a
+message in the wrong tenant.
+
+**Env:** `META_APP_ID` (new — currently only `META_APP_SECRET` exists),
+`META_APP_SECRET` (exists), pinned `GRAPH_API_VERSION`. Document in `.env.example`.
+
+### Frontend
+
+**`whatsapp-embedded-signup-button.tsx` (new)** — lazily injects the Facebook
+JS SDK (`connect.facebook.net/en_US/sdk.js`) on first use, `FB.init({ appId:
+VITE_META_APP_ID, version: 'v21.0' })`, calls `FB.login(...)` with
+`VITE_WHATSAPP_ES_CONFIG_ID`. A `message` listener (verify `event.origin`
+endsWith `facebook.com`) captures `WA_EMBEDDED_SIGNUP` ids; on the `FB.login`
+callback `authResponse.code`, POSTs to the new endpoint via a
+`use-whatsapp-embedded-signup.ts` hook. Handles loading / abandoned
+(`current_step`) / error (`error_message`) states.
+
+**`whatsapp-connect-dialog.tsx` (restructure)** — primary CTA becomes
+"Connect with Facebook" (the ES button). The existing manual form
+(phoneNumberId/wabaId/accessToken) moves behind a shadcn `Collapsible`:
+"Advanced: use your own token". No behavior change to the manual path.
+
+**`whatsapp.api.ts` / hook** — add `embeddedSignup(workspaceId, payload)` →
+`POST /channels/workspaces/${workspaceId}/whatsapp/embedded-signup`.
+
+**Env:** `VITE_META_APP_ID`, `VITE_WHATSAPP_ES_CONFIG_ID`.
+
+## Data flow
+
+1. User clicks "Connect with Facebook" → SDK loads → `FB.login` dialog.
+2. Business selects/creates WABA + phone number, grants our app access.
+3. `WA_EMBEDDED_SIGNUP` message → `{ waba_id, phone_number_id, business_id }`;
+   callback → `code`.
+4. Frontend POST `{ code, wabaId, phoneNumberId }` → backend.
+5. Backend: exchange code → register phone (pin) → subscribe app to WABA →
+   cross-workspace guard → `createChannel` (encrypts token, fires
+   `onChannelConnected` backfill).
+6. Response → frontend invalidates `queryKeys.channels.list(workspaceId)`; the
+   new WhatsApp channel appears. Inbound messages already route via the existing
+   webhook → `phone_number_id` → channel.
+
+## Error handling
+
+- `code` expired (>30s): 400 → "Took too long, please try again."
+- User abandoned (`current_step`): friendly inline message, no error toast.
+- `register` "already registered": treat as success (idempotent).
+- 2FA PIN mismatch on `register`: 400 → "This number has two-step verification
+  enabled; disable it in WhatsApp Manager and retry."
+- Re-running ES for an already-connected number **in the same workspace**:
+  update-in-place (today `createChannel` throws a hard `ConflictException` — for
+  whatsapp treat a healthy same-workspace duplicate as a reconnect/update).
+- Same number in a **different** workspace: 409 with a clear tenancy message.
+- `subscribeWaba` failure: **fail the connect** (blocking) with a retry-able
+  error — a channel that never receives messages is worse than a visible error.
+
+## Testing
+
+- Unit: new `whatsapp.service` methods (mock `fetch`) — exchange/register/
+  discovery, including the "already registered" branch.
+- Unit: the ES controller endpoint (happy path + expired code + cross-workspace
+  409 + subscribe failure).
+- Unit: `findChannelByPlatformAccount` determinism + multi-row warning.
+- Frontend: ES button states (loading/success/abandoned/error) with the SDK
+  mocked; dialog renders primary CTA + collapsible manual form.
+- Update existing specs: `whatsapp.service.spec.ts`,
+  `whatsapp-webhook.util.spec.ts`, `whatsapp-dm.adapter.spec.ts`.
+- Build both repos (`npm run build`).
+
+## Out of scope (separate efforts)
+
+- **Maestro batched-webhook `.some()` bug** (`webhooks.controller.ts:199`) — a
+  real defect (a batch mixing the maestro number and a customer number diverts
+  everything to the bridge), but independent of this flow. Its own small fix.
+- Template-message sending (outside the 24h window) — already stubbed
+  ("template required (coming soon)"); not part of connect.
+- Removing the manual flow entirely — deferred until App Review grants Advanced
+  Access.
+- **Business-token refresh** — only needed if the chosen `config_id` issues
+  60-day tokens (not a never-expiring one). If so, a follow-up adds a refresh
+  path for whatsapp (today `supportsRefreshToken:false`, so tokens would silently
+  expire at 60 days). Prefer a never-expiring config to avoid this entirely.
+
+## Prerequisites / Meta console setup (user actions, documented alongside)
+
+1. Register the app as a **Tech Provider** (WhatsApp → Tech Provider).
+2. Create a **Facebook Login for Business** configuration → get `config_id`,
+   requesting `whatsapp_business_messaging` + `whatsapp_business_management`.
+   **Prefer a never-expiring token configuration** if the app offers one — it
+   matches the current channel model (`supportsRefreshToken:false`,
+   `tokenExpiresAt:null`) and needs no refresh. If only the 60-day template is
+   available, tokens expire in 60 days → the token-refresh follow-up below applies.
+3. Add the WhatsApp product + configure the webhook (already wired) and the
+   `account_update` webhook field.
+4. Set env: backend `META_APP_ID`; frontend `VITE_META_APP_ID`,
+   `VITE_WHATSAPP_ES_CONFIG_ID`.
+5. Test in dev mode as an app admin/developer, then record the App Review
+   screencast (login → consent showing the two whatsapp scopes → connected
+   channel + a sent/received message).
+
+## Decisions locked
+
+- Approach: **Facebook JS SDK `FB.login`** (not server redirect) — Meta
+  documents ES as the JS-SDK flow; reviewers expect it; the SDK `message` event
+  is the only clean source of `waba_id`/`phone_number_id`.
+- Manual connect: **kept, demoted to "Advanced"** collapsible.
+- Business token: store as-is with `tokenExpiresAt` from `expires_in` when the
+  config issues a 60-day token; the channel's `supportsRefreshToken` stays
+  false, so a future refresh mechanism is a follow-up if 60-day tokens are used
+  (a never-expiring config avoids it).

--- a/docs/superpowers/specs/2026-07-09-whatsapp-embedded-signup-design.md
+++ b/docs/superpowers/specs/2026-07-09-whatsapp-embedded-signup-design.md
@@ -161,8 +161,10 @@ callback `authResponse.code`, POSTs to the new endpoint via a
 - 2FA PIN mismatch on `register`: 400 → "This number has two-step verification
   enabled; disable it in WhatsApp Manager and retry."
 - Re-running ES for an already-connected number **in the same workspace**:
-  update-in-place (today `createChannel` throws a hard `ConflictException` — for
-  whatsapp treat a healthy same-workspace duplicate as a reconnect/update).
+  a **healthy** duplicate (connected, active, token not expired) returns 409
+  early — before any Meta call — consistent with every other platform's
+  connect path. A **broken/expired** same-workspace channel falls through and
+  is reconnected in place by `createChannel`'s existing reconnect branch.
 - Same number in a **different** workspace: 409 with a clear tenancy message.
 - `subscribeWaba` failure: **fail the connect** (blocking) with a retry-able
   error — a channel that never receives messages is worse than a visible error.

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -82,6 +82,8 @@ import { TelegramService } from './services/telegram.service';
 import { ConnectTelegramBotDto } from './dto/telegram-connect.dto';
 import { ConnectWhatsAppDto } from './dto/connect-whatsapp.dto';
 import { WhatsAppService } from './services/whatsapp.service';
+import { EmbeddedSignupWhatsAppDto } from './dto/embedded-signup-whatsapp.dto';
+import { WhatsAppOnboardingService } from './services/whatsapp-onboarding.service';
 
 @Controller('channels')
 export class ChannelsController {
@@ -115,6 +117,7 @@ export class ChannelsController {
     private readonly telegramConnectService: TelegramConnectService,
     private readonly telegramService: TelegramService,
     private readonly whatsappService: WhatsAppService,
+    private readonly whatsappOnboardingService: WhatsAppOnboardingService,
   ) {}
 
   // ==========================================================================
@@ -5439,5 +5442,29 @@ export class ChannelsController {
     }
 
     return channel;
+  }
+
+  // ==========================================================================
+  // WhatsApp — Embedded Signup (Tech Provider flow)
+  // ==========================================================================
+
+  @Post('workspaces/:workspaceId/whatsapp/embedded-signup')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async connectWhatsAppEmbeddedSignup(
+    @Param('workspaceId') workspaceId: string,
+    @Body() dto: EmbeddedSignupWhatsAppDto,
+    @CurrentUser() user: { userId: string; email: string },
+  ) {
+    return this.whatsappOnboardingService.completeEmbeddedSignup(
+      workspaceId,
+      user.userId,
+      {
+        code: dto.code,
+        wabaId: dto.wabaId,
+        phoneNumberId: dto.phoneNumberId,
+        pin: dto.pin,
+      },
+    );
   }
 }

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -84,6 +84,10 @@ import { ConnectWhatsAppDto } from './dto/connect-whatsapp.dto';
 import { WhatsAppService } from './services/whatsapp.service';
 import { EmbeddedSignupWhatsAppDto } from './dto/embedded-signup-whatsapp.dto';
 import { WhatsAppOnboardingService } from './services/whatsapp-onboarding.service';
+import {
+  readEmbeddedSignupConfig,
+  type EmbeddedSignupConfig,
+} from './services/embedded-signup-config';
 
 @Controller('channels')
 export class ChannelsController {
@@ -5364,6 +5368,19 @@ export class ChannelsController {
   // ==========================================================================
   // WhatsApp — Manual connect (Phase-1 onboarding)
   // ==========================================================================
+
+  /**
+   * Public (non-secret) client config for launching WhatsApp Embedded Signup —
+   * `app_id` + `config_id` are visible in Meta's consent-dialog URL anyway, so
+   * exposing them here (behind auth) avoids duplicating them into a frontend
+   * `VITE_*` build-time var. App-level route (no `:workspaceId`): the config
+   * is per-deployment, not per-workspace.
+   */
+  @Get('whatsapp/embedded-signup-config')
+  @UseGuards(JwtAuthGuard)
+  getWhatsAppEmbeddedSignupConfig(): EmbeddedSignupConfig {
+    return readEmbeddedSignupConfig(process.env);
+  }
 
   @Post('workspaces/:workspaceId/whatsapp/connect')
   @UseGuards(JwtAuthGuard)

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -27,6 +27,7 @@ import { DiscordService } from './services/discord.service';
 import { DiscordGatewayService } from './services/discord-gateway.service';
 import { TelegramConnectService } from './services/telegram-connect.service';
 import { WhatsAppService } from './services/whatsapp.service';
+import { WhatsAppOnboardingService } from './services/whatsapp-onboarding.service';
 import { MetaAdsClient } from '../ads/services/meta-ads.client';
 import { AdAccountsService } from '../ads/services/ad-accounts.service';
 import { BoostPostService } from '../ads/services/boost-post.service';
@@ -76,6 +77,7 @@ import { RefreshTokenExpiryScheduler } from './schedulers/refresh-token-expiry.s
     TelegramService,
     TelegramConnectService,
     WhatsAppService,
+    WhatsAppOnboardingService,
     DiscordService,
     DiscordGatewayService,
     TokenRefreshProcessor,

--- a/src/channels/dto/embedded-signup-whatsapp.dto.ts
+++ b/src/channels/dto/embedded-signup-whatsapp.dto.ts
@@ -1,0 +1,25 @@
+import { IsString, IsNotEmpty, IsOptional, Matches } from 'class-validator';
+
+export class EmbeddedSignupWhatsAppDto {
+  // Short-lived exchangeable code from the Embedded Signup callback (~30s TTL).
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+$/, { message: 'wabaId must be a numeric id' })
+  wabaId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+$/, { message: 'phoneNumberId must be a numeric id' })
+  phoneNumberId!: string;
+
+  // 6-digit two-step-verification PIN used to register the number. Defaults to
+  // '000000' when the number has no two-step PIN set.
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{6}$/, { message: 'pin must be 6 digits' })
+  pin?: string;
+}

--- a/src/channels/services/channel.service.spec.ts
+++ b/src/channels/services/channel.service.spec.ts
@@ -1,0 +1,31 @@
+import { ChannelService } from './channel.service';
+
+// Minimal fake db that records the query builder chain and returns canned rows.
+const rows = [
+  { id: 7, workspaceId: 'ws-A' },
+  { id: 3, workspaceId: 'ws-B' },
+];
+jest.mock('../../drizzle/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => Promise.resolve(rows),
+        }),
+      }),
+    }),
+  },
+}));
+
+describe('ChannelService.findChannelsByPlatformAccountAllWorkspaces', () => {
+  it('returns every workspace holding this platform account', async () => {
+    // ChannelService's constructor takes (oauthService, syncLifecycle) — neither
+    // is touched by this method, so stub both.
+    const service = new ChannelService({} as any, {} as any);
+    const res = await service.findChannelsByPlatformAccountAllWorkspaces(
+      'whatsapp',
+      '111',
+    );
+    expect(res).toEqual(rows);
+  });
+});

--- a/src/channels/services/channel.service.spec.ts
+++ b/src/channels/services/channel.service.spec.ts
@@ -2,8 +2,20 @@ import { ChannelService } from './channel.service';
 
 // Minimal fake db that records the query builder chain and returns canned rows.
 const rows = [
-  { id: 7, workspaceId: 'ws-A' },
-  { id: 3, workspaceId: 'ws-B' },
+  {
+    id: 7,
+    workspaceId: 'ws-A',
+    connectionStatus: 'connected',
+    isActive: true,
+    tokenExpiresAt: null,
+  },
+  {
+    id: 3,
+    workspaceId: 'ws-B',
+    connectionStatus: 'connected',
+    isActive: true,
+    tokenExpiresAt: null,
+  },
 ];
 jest.mock('../../drizzle/db', () => ({
   db: {

--- a/src/channels/services/channel.service.ts
+++ b/src/channels/services/channel.service.ts
@@ -352,6 +352,30 @@ export class ChannelService {
   }
 
   /**
+   * Every channel row (across ALL workspaces) that holds this platform account.
+   * Used by WhatsApp Embedded Signup to reject connecting a phone number that
+   * another workspace already owns (webhook routing is keyed on the account id).
+   */
+  async findChannelsByPlatformAccountAllWorkspaces(
+    platform: SupportedPlatform,
+    platformAccountId: string,
+  ): Promise<Array<{ id: number; workspaceId: string }>> {
+    return db
+      .select({
+        id: socialMediaChannels.id,
+        workspaceId: socialMediaChannels.workspaceId,
+      })
+      .from(socialMediaChannels)
+      .where(
+        and(
+          eq(socialMediaChannels.platform, platform),
+          eq(socialMediaChannels.platformAccountId, platformAccountId),
+        ),
+      )
+      .orderBy(asc(socialMediaChannels.id));
+  }
+
+  /**
    * Get all channels for a workspace
    */
   async getWorkspaceChannels(

--- a/src/channels/services/channel.service.ts
+++ b/src/channels/services/channel.service.ts
@@ -42,6 +42,29 @@ import {
   ChannelStatsResponseDto,
 } from '../dto/channel.dto';
 
+/**
+ * Shared "is this channel usable right now" predicate. A channel counts as
+ * healthy when it's marked connected, active, and its token (if any) hasn't
+ * expired. Used both by `createChannel`'s duplicate-connect guard and by
+ * platform-specific pre-flight guards (e.g. WhatsApp Embedded Signup) that
+ * need to short-circuit a healthy same-workspace duplicate before making any
+ * external API calls.
+ */
+export function isChannelHealthy(channel: {
+  connectionStatus: string | null;
+  isActive: boolean | null;
+  tokenExpiresAt: Date | string | null;
+}): boolean {
+  const tokenStillValid =
+    !channel.tokenExpiresAt ||
+    new Date(channel.tokenExpiresAt).getTime() > Date.now();
+  return (
+    channel.connectionStatus === 'connected' &&
+    !!channel.isActive &&
+    tokenStillValid
+  );
+}
+
 @Injectable()
 export class ChannelService {
   private readonly logger = new Logger(ChannelService.name);
@@ -84,16 +107,7 @@ export class ChannelService {
       const existingChannel = existing[0];
 
       // Genuine duplicate: channel is healthy — protect against double-connect
-      const tokenStillValid =
-        !existingChannel.tokenExpiresAt ||
-        new Date(existingChannel.tokenExpiresAt).getTime() > Date.now();
-
-      const isHealthyConnection =
-        existingChannel.connectionStatus === 'connected' &&
-        existingChannel.isActive &&
-        tokenStillValid;
-
-      if (isHealthyConnection) {
+      if (isChannelHealthy(existingChannel)) {
         throw new ConflictException(
           `This ${dto.platform} account is already connected to this workspace`,
         );
@@ -359,11 +373,22 @@ export class ChannelService {
   async findChannelsByPlatformAccountAllWorkspaces(
     platform: SupportedPlatform,
     platformAccountId: string,
-  ): Promise<Array<{ id: number; workspaceId: string }>> {
+  ): Promise<
+    Array<{
+      id: number;
+      workspaceId: string;
+      connectionStatus: string | null;
+      isActive: boolean | null;
+      tokenExpiresAt: Date | null;
+    }>
+  > {
     return db
       .select({
         id: socialMediaChannels.id,
         workspaceId: socialMediaChannels.workspaceId,
+        connectionStatus: socialMediaChannels.connectionStatus,
+        isActive: socialMediaChannels.isActive,
+        tokenExpiresAt: socialMediaChannels.tokenExpiresAt,
       })
       .from(socialMediaChannels)
       .where(

--- a/src/channels/services/embedded-signup-config.spec.ts
+++ b/src/channels/services/embedded-signup-config.spec.ts
@@ -1,0 +1,45 @@
+import { readEmbeddedSignupConfig } from './embedded-signup-config';
+
+describe('readEmbeddedSignupConfig', () => {
+  it('returns configured:true with both values when both are set', () => {
+    expect(
+      readEmbeddedSignupConfig({
+        META_APP_ID: 'app-123',
+        WHATSAPP_ES_CONFIG_ID: 'config-456',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ appId: 'app-123', configId: 'config-456', configured: true });
+  });
+
+  it('returns configured:false with configId null when only appId is set', () => {
+    expect(
+      readEmbeddedSignupConfig({
+        META_APP_ID: 'app-123',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ appId: 'app-123', configId: null, configured: false });
+  });
+
+  it('returns configured:false with appId null when only configId is set', () => {
+    expect(
+      readEmbeddedSignupConfig({
+        WHATSAPP_ES_CONFIG_ID: 'config-456',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ appId: null, configId: 'config-456', configured: false });
+  });
+
+  it('returns both null and configured:false when neither is set', () => {
+    expect(readEmbeddedSignupConfig({} as NodeJS.ProcessEnv)).toEqual({
+      appId: null,
+      configId: null,
+      configured: false,
+    });
+  });
+
+  it('treats an empty string as unset', () => {
+    expect(
+      readEmbeddedSignupConfig({
+        META_APP_ID: '',
+        WHATSAPP_ES_CONFIG_ID: '',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ appId: null, configId: null, configured: false });
+  });
+});

--- a/src/channels/services/embedded-signup-config.ts
+++ b/src/channels/services/embedded-signup-config.ts
@@ -1,0 +1,20 @@
+export interface EmbeddedSignupConfig {
+  appId: string | null;
+  configId: string | null;
+  configured: boolean;
+}
+
+/**
+ * Public (non-secret) client config the browser needs to launch WhatsApp Embedded
+ * Signup. `app_id` and `config_id` are visible in Meta's consent-dialog URL, so
+ * exposing them to an authenticated user is safe — the app SECRET never leaves the
+ * server. Returns nulls + `configured:false` when unset so the UI can render a
+ * "not set up" state instead of erroring.
+ */
+export function readEmbeddedSignupConfig(
+  env: NodeJS.ProcessEnv,
+): EmbeddedSignupConfig {
+  const appId = env.META_APP_ID || null;
+  const configId = env.WHATSAPP_ES_CONFIG_ID || null;
+  return { appId, configId, configured: Boolean(appId && configId) };
+}

--- a/src/channels/services/whatsapp-onboarding.service.spec.ts
+++ b/src/channels/services/whatsapp-onboarding.service.spec.ts
@@ -57,7 +57,7 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
   });
 
   it('rejects when the phone number is already connected in another workspace', async () => {
-    const { service } = makeService({
+    const { service, whatsapp } = makeService({
       channels: {
         findChannelsByPlatformAccountAllWorkspaces: jest
           .fn()
@@ -67,6 +67,8 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
     await expect(
       service.completeEmbeddedSignup('ws-A', 'u1', input),
     ).rejects.toBeInstanceOf(ConflictException);
+    // The guard must short-circuit before any mutating Meta call.
+    expect(whatsapp.exchangeCodeForBusinessToken).not.toHaveBeenCalled();
   });
 
   it('allows re-connecting a number already in the SAME workspace (delegates to createChannel)', async () => {
@@ -95,7 +97,7 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
   });
 
   it('fails the connect when WABA subscribe fails (blocking, not best-effort)', async () => {
-    const { service } = makeService({
+    const { service, channels } = makeService({
       whatsapp: {
         subscribeWaba: jest.fn().mockRejectedValue(new Error('subscribe boom')),
       },
@@ -103,5 +105,7 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
     await expect(
       service.completeEmbeddedSignup('ws-A', 'u1', input),
     ).rejects.toThrow('subscribe boom');
+    // No persistence should occur when subscribe fails before createChannel.
+    expect(channels.createChannel).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/services/whatsapp-onboarding.service.spec.ts
+++ b/src/channels/services/whatsapp-onboarding.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConflictException, BadRequestException } from '@nestjs/common';
 import { WhatsAppOnboardingService } from './whatsapp-onboarding.service';
+import { isChannelHealthy } from './channel.service';
 
 function makeService(overrides: {
   whatsapp?: Partial<any>;
@@ -71,17 +72,45 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
     expect(whatsapp.exchangeCodeForBusinessToken).not.toHaveBeenCalled();
   });
 
-  it('allows re-connecting a number already in the SAME workspace (delegates to createChannel)', async () => {
-    const { service, channels } = makeService({
+  it('rejects a HEALTHY same-workspace duplicate before any Meta call', async () => {
+    const { service, whatsapp } = makeService({
       channels: {
-        findChannelsByPlatformAccountAllWorkspaces: jest
-          .fn()
-          .mockResolvedValue([{ id: 9, workspaceId: 'ws-A' }]),
+        findChannelsByPlatformAccountAllWorkspaces: jest.fn().mockResolvedValue([
+          { id: 9, workspaceId: 'ws-A', connectionStatus: 'connected', isActive: true, tokenExpiresAt: null },
+        ]),
+      },
+    });
+    await expect(service.completeEmbeddedSignup('ws-A', 'u1', input)).rejects.toBeInstanceOf(ConflictException);
+    expect(whatsapp.exchangeCodeForBusinessToken).not.toHaveBeenCalled();
+    expect(whatsapp.registerPhoneNumber).not.toHaveBeenCalled();
+    expect(whatsapp.subscribeWaba).not.toHaveBeenCalled();
+  });
+
+  it('lets a BROKEN same-workspace channel through so createChannel can reconnect it', async () => {
+    const { service, whatsapp, channels } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest.fn().mockResolvedValue([
+          { id: 9, workspaceId: 'ws-A', connectionStatus: 'disconnected', isActive: false, tokenExpiresAt: null },
+        ]),
         createChannel: jest.fn().mockResolvedValue({ id: 9, accountName: 'Acme' }),
       },
     });
     const res = await service.completeEmbeddedSignup('ws-A', 'u1', input);
+    expect(whatsapp.exchangeCodeForBusinessToken).toHaveBeenCalled();
+    expect(channels.createChannel).toHaveBeenCalled();
     expect(res).toEqual({ id: 9, accountName: 'Acme' });
+  });
+
+  it('lets an EXPIRED-token same-workspace channel through (unhealthy)', async () => {
+    const { service, channels } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest.fn().mockResolvedValue([
+          { id: 9, workspaceId: 'ws-A', connectionStatus: 'connected', isActive: true, tokenExpiresAt: new Date(Date.now() - 1000) },
+        ]),
+        createChannel: jest.fn().mockResolvedValue({ id: 9, accountName: 'Acme' }),
+      },
+    });
+    await service.completeEmbeddedSignup('ws-A', 'u1', input);
     expect(channels.createChannel).toHaveBeenCalled();
   });
 
@@ -107,5 +136,57 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
     ).rejects.toThrow('subscribe boom');
     // No persistence should occur when subscribe fails before createChannel.
     expect(channels.createChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe('isChannelHealthy', () => {
+  it('is true when connected, active, and never expires', () => {
+    expect(
+      isChannelHealthy({
+        connectionStatus: 'connected',
+        isActive: true,
+        tokenExpiresAt: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when disconnected', () => {
+    expect(
+      isChannelHealthy({
+        connectionStatus: 'disconnected',
+        isActive: true,
+        tokenExpiresAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when inactive', () => {
+    expect(
+      isChannelHealthy({
+        connectionStatus: 'connected',
+        isActive: false,
+        tokenExpiresAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when the token has already expired', () => {
+    expect(
+      isChannelHealthy({
+        connectionStatus: 'connected',
+        isActive: true,
+        tokenExpiresAt: new Date(Date.now() - 1000),
+      }),
+    ).toBe(false);
+  });
+
+  it('is true when the token expires in the future', () => {
+    expect(
+      isChannelHealthy({
+        connectionStatus: 'connected',
+        isActive: true,
+        tokenExpiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toBe(true);
   });
 });

--- a/src/channels/services/whatsapp-onboarding.service.spec.ts
+++ b/src/channels/services/whatsapp-onboarding.service.spec.ts
@@ -1,0 +1,107 @@
+import { ConflictException, BadRequestException } from '@nestjs/common';
+import { WhatsAppOnboardingService } from './whatsapp-onboarding.service';
+
+function makeService(overrides: {
+  whatsapp?: Partial<any>;
+  channels?: Partial<any>;
+  inbox?: Partial<any>;
+} = {}) {
+  const whatsapp = {
+    exchangeCodeForBusinessToken: jest.fn().mockResolvedValue({ accessToken: 'biz', expiresIn: 5184000 }),
+    getWabaPhoneNumbers: jest.fn().mockResolvedValue([
+      { id: '111', displayPhoneNumber: '+1 555', verifiedName: 'Acme' },
+    ]),
+    registerPhoneNumber: jest.fn().mockResolvedValue(undefined),
+    subscribeWaba: jest.fn().mockResolvedValue(undefined),
+    ...overrides.whatsapp,
+  };
+  const channels = {
+    findChannelsByPlatformAccountAllWorkspaces: jest.fn().mockResolvedValue([]),
+    createChannel: jest.fn().mockResolvedValue({ id: 1, accountName: 'Acme' }),
+    ...overrides.channels,
+  };
+  const inbox = {
+    assertWorkspaceAccessPublic: jest.fn().mockResolvedValue(undefined),
+    ...overrides.inbox,
+  };
+  const service = new WhatsAppOnboardingService(whatsapp as any, channels as any, inbox as any);
+  return { service, whatsapp, channels, inbox };
+}
+
+describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
+  const input = { code: 'c', wabaId: 'w1', phoneNumberId: '111' };
+
+  it('runs the full happy path and creates the channel', async () => {
+    const { service, whatsapp, channels } = makeService();
+    const res = await service.completeEmbeddedSignup('ws-A', 'u1', input);
+    expect(whatsapp.exchangeCodeForBusinessToken).toHaveBeenCalledWith('c');
+    expect(whatsapp.registerPhoneNumber).toHaveBeenCalledWith('biz', '111', '000000');
+    expect(whatsapp.subscribeWaba).toHaveBeenCalledWith('biz', 'w1');
+    expect(channels.createChannel).toHaveBeenCalledWith(
+      'ws-A',
+      'u1',
+      expect.objectContaining({
+        platform: 'whatsapp',
+        platformAccountId: '111',
+        accessToken: 'biz',
+        metadata: expect.objectContaining({ wabaId: 'w1', connectMethod: 'embedded_signup' }),
+      }),
+    );
+    expect(res).toEqual({ id: 1, accountName: 'Acme' });
+  });
+
+  it('passes a caller-supplied pin through to register', async () => {
+    const { service, whatsapp } = makeService();
+    await service.completeEmbeddedSignup('ws-A', 'u1', { ...input, pin: '654321' });
+    expect(whatsapp.registerPhoneNumber).toHaveBeenCalledWith('biz', '111', '654321');
+  });
+
+  it('rejects when the phone number is already connected in another workspace', async () => {
+    const { service } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest
+          .fn()
+          .mockResolvedValue([{ id: 9, workspaceId: 'ws-OTHER' }]),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('allows re-connecting a number already in the SAME workspace (delegates to createChannel)', async () => {
+    const { service, channels } = makeService({
+      channels: {
+        findChannelsByPlatformAccountAllWorkspaces: jest
+          .fn()
+          .mockResolvedValue([{ id: 9, workspaceId: 'ws-A' }]),
+        createChannel: jest.fn().mockResolvedValue({ id: 9, accountName: 'Acme' }),
+      },
+    });
+    const res = await service.completeEmbeddedSignup('ws-A', 'u1', input);
+    expect(res).toEqual({ id: 9, accountName: 'Acme' });
+    expect(channels.createChannel).toHaveBeenCalled();
+  });
+
+  it('surfaces an expired/invalid code as a BadRequest', async () => {
+    const { service } = makeService({
+      whatsapp: {
+        exchangeCodeForBusinessToken: jest.fn().mockRejectedValue(new Error('Invalid code')),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('fails the connect when WABA subscribe fails (blocking, not best-effort)', async () => {
+    const { service } = makeService({
+      whatsapp: {
+        subscribeWaba: jest.fn().mockRejectedValue(new Error('subscribe boom')),
+      },
+    });
+    await expect(
+      service.completeEmbeddedSignup('ws-A', 'u1', input),
+    ).rejects.toThrow('subscribe boom');
+  });
+});

--- a/src/channels/services/whatsapp-onboarding.service.ts
+++ b/src/channels/services/whatsapp-onboarding.service.ts
@@ -1,0 +1,115 @@
+import {
+  Injectable,
+  Logger,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { WhatsAppService } from './whatsapp.service';
+import { ChannelService } from './channel.service';
+import { InboxService } from '../../inbox/inbox.service';
+import type { ChannelResponseDto } from '../dto/channel.dto';
+
+export interface EmbeddedSignupInput {
+  code: string;
+  wabaId: string;
+  phoneNumberId: string;
+  pin?: string;
+}
+
+@Injectable()
+export class WhatsAppOnboardingService {
+  private readonly logger = new Logger(WhatsAppOnboardingService.name);
+
+  constructor(
+    private readonly whatsapp: WhatsAppService,
+    private readonly channels: ChannelService,
+    private readonly inbox: InboxService,
+  ) {}
+
+  /**
+   * Complete WhatsApp Embedded Signup (Tech Provider flow): exchange the code
+   * for a business token, register the phone number, subscribe our app to the
+   * WABA, guard cross-workspace duplicates, then persist the channel.
+   */
+  async completeEmbeddedSignup(
+    workspaceId: string,
+    userId: string,
+    input: EmbeddedSignupInput,
+  ): Promise<ChannelResponseDto> {
+    await this.inbox.assertWorkspaceAccessPublic(workspaceId, userId);
+
+    // 1. Exchange the short-lived code for a customer-scoped business token.
+    let accessToken: string;
+    let expiresIn: number | null;
+    try {
+      const exchanged = await this.whatsapp.exchangeCodeForBusinessToken(input.code);
+      accessToken = exchanged.accessToken;
+      expiresIn = exchanged.expiresIn;
+    } catch (err) {
+      throw new BadRequestException(
+        `Could not complete WhatsApp signup — ${
+          (err as Error).message
+        }. The signup code expires within ~30 seconds; please try connecting again.`,
+      );
+    }
+
+    // 2. Resolve display name / verified name (also validates the number).
+    let displayPhoneNumber: string | null = null;
+    let verifiedName: string | null = null;
+    try {
+      const phones = await this.whatsapp.getWabaPhoneNumbers(accessToken, input.wabaId);
+      const match = phones.find((p) => p.id === input.phoneNumberId) ?? phones[0];
+      displayPhoneNumber = match?.displayPhoneNumber ?? null;
+      verifiedName = match?.verifiedName ?? null;
+    } catch (err) {
+      this.logger.warn(
+        `getWabaPhoneNumbers failed for waba=${input.wabaId}: ${(err as Error).message}`,
+      );
+    }
+
+    // 3. Register the phone number for Cloud API (idempotent).
+    await this.whatsapp.registerPhoneNumber(
+      accessToken,
+      input.phoneNumberId,
+      input.pin ?? '000000',
+    );
+
+    // 4. Subscribe our app to the WABA — BLOCKING. A channel that never
+    //    receives webhooks is worse than a visible failure.
+    await this.whatsapp.subscribeWaba(accessToken, input.wabaId);
+
+    // 5. Cross-workspace guard: reject if this phone number is already owned by
+    //    a DIFFERENT workspace (webhook routing is keyed on phone_number_id).
+    const existing =
+      await this.channels.findChannelsByPlatformAccountAllWorkspaces(
+        'whatsapp',
+        input.phoneNumberId,
+      );
+    const otherWorkspace = existing.find((c) => c.workspaceId !== workspaceId);
+    if (otherWorkspace) {
+      throw new ConflictException(
+        'This WhatsApp number is already connected to another workspace. Disconnect it there first.',
+      );
+    }
+
+    // 6. Persist. createChannel encrypts the token and, for a same-workspace
+    //    broken row, reconnects in place (a healthy same-workspace duplicate
+    //    still throws ConflictException — expected).
+    const accountName = verifiedName || input.phoneNumberId;
+    return this.channels.createChannel(workspaceId, userId, {
+      platform: 'whatsapp',
+      accountType: 'business_account',
+      platformAccountId: input.phoneNumberId,
+      accountName,
+      accessToken,
+      tokenExpiresAt: expiresIn
+        ? new Date(Date.now() + expiresIn * 1000).toISOString()
+        : undefined,
+      metadata: {
+        wabaId: input.wabaId,
+        displayPhoneNumber: displayPhoneNumber ?? input.phoneNumberId,
+        connectMethod: 'embedded_signup',
+      },
+    });
+  }
+}

--- a/src/channels/services/whatsapp-onboarding.service.ts
+++ b/src/channels/services/whatsapp-onboarding.service.ts
@@ -27,9 +27,9 @@ export class WhatsAppOnboardingService {
   ) {}
 
   /**
-   * Complete WhatsApp Embedded Signup (Tech Provider flow): exchange the code
-   * for a business token, register the phone number, subscribe our app to the
-   * WABA, guard cross-workspace duplicates, then persist the channel.
+   * Complete WhatsApp Embedded Signup (Tech Provider flow): guard cross-workspace
+   * duplicates, exchange the code for a business token, register the phone
+   * number, subscribe our app to the WABA, then persist the channel.
    */
   async completeEmbeddedSignup(
     workspaceId: string,
@@ -38,7 +38,23 @@ export class WhatsAppOnboardingService {
   ): Promise<ChannelResponseDto> {
     await this.inbox.assertWorkspaceAccessPublic(workspaceId, userId);
 
-    // 1. Exchange the short-lived code for a customer-scoped business token.
+    // 1. Cross-workspace guard: reject if this phone number is already owned by
+    //    a DIFFERENT workspace (webhook routing is keyed on phone_number_id).
+    //    Runs BEFORE any mutating Meta call so a cross-workspace collision never
+    //    triggers registerPhoneNumber/subscribeWaba against the caller's token.
+    const existing =
+      await this.channels.findChannelsByPlatformAccountAllWorkspaces(
+        'whatsapp',
+        input.phoneNumberId,
+      );
+    const otherWorkspace = existing.find((c) => c.workspaceId !== workspaceId);
+    if (otherWorkspace) {
+      throw new ConflictException(
+        'This WhatsApp number is already connected to another workspace. Disconnect it there first.',
+      );
+    }
+
+    // 2. Exchange the short-lived code for a customer-scoped business token.
     let accessToken: string;
     let expiresIn: number | null;
     try {
@@ -53,7 +69,7 @@ export class WhatsAppOnboardingService {
       );
     }
 
-    // 2. Resolve display name / verified name (also validates the number).
+    // 3. Resolve display name / verified name (also validates the number).
     let displayPhoneNumber: string | null = null;
     let verifiedName: string | null = null;
     try {
@@ -67,30 +83,16 @@ export class WhatsAppOnboardingService {
       );
     }
 
-    // 3. Register the phone number for Cloud API (idempotent).
+    // 4. Register the phone number for Cloud API (idempotent).
     await this.whatsapp.registerPhoneNumber(
       accessToken,
       input.phoneNumberId,
       input.pin ?? '000000',
     );
 
-    // 4. Subscribe our app to the WABA — BLOCKING. A channel that never
+    // 5. Subscribe our app to the WABA — BLOCKING. A channel that never
     //    receives webhooks is worse than a visible failure.
     await this.whatsapp.subscribeWaba(accessToken, input.wabaId);
-
-    // 5. Cross-workspace guard: reject if this phone number is already owned by
-    //    a DIFFERENT workspace (webhook routing is keyed on phone_number_id).
-    const existing =
-      await this.channels.findChannelsByPlatformAccountAllWorkspaces(
-        'whatsapp',
-        input.phoneNumberId,
-      );
-    const otherWorkspace = existing.find((c) => c.workspaceId !== workspaceId);
-    if (otherWorkspace) {
-      throw new ConflictException(
-        'This WhatsApp number is already connected to another workspace. Disconnect it there first.',
-      );
-    }
 
     // 6. Persist. createChannel encrypts the token and, for a same-workspace
     //    broken row, reconnects in place (a healthy same-workspace duplicate

--- a/src/channels/services/whatsapp-onboarding.service.ts
+++ b/src/channels/services/whatsapp-onboarding.service.ts
@@ -5,7 +5,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { WhatsAppService } from './whatsapp.service';
-import { ChannelService } from './channel.service';
+import { ChannelService, isChannelHealthy } from './channel.service';
 import { InboxService } from '../../inbox/inbox.service';
 import type { ChannelResponseDto } from '../dto/channel.dto';
 
@@ -28,8 +28,9 @@ export class WhatsAppOnboardingService {
 
   /**
    * Complete WhatsApp Embedded Signup (Tech Provider flow): guard cross-workspace
-   * duplicates, exchange the code for a business token, register the phone
-   * number, subscribe our app to the WABA, then persist the channel.
+   * and healthy same-workspace duplicates, exchange the code for a business
+   * token, register the phone number, subscribe our app to the WABA, then
+   * persist the channel.
    */
   async completeEmbeddedSignup(
     workspaceId: string,
@@ -51,6 +52,19 @@ export class WhatsAppOnboardingService {
     if (otherWorkspace) {
       throw new ConflictException(
         'This WhatsApp number is already connected to another workspace. Disconnect it there first.',
+      );
+    }
+
+    // A healthy channel in THIS workspace means there is nothing to do — reject before
+    // burning the (idempotent but rate-limited) Meta calls. A broken/expired channel
+    // falls through so the Meta calls can mint a fresh token and createChannel's
+    // reconnect branch updates it in place.
+    const healthySameWorkspace = existing.find(
+      (c) => c.workspaceId === workspaceId && isChannelHealthy(c),
+    );
+    if (healthySameWorkspace) {
+      throw new ConflictException(
+        'This WhatsApp number is already connected to this workspace.',
       );
     }
 
@@ -94,9 +108,9 @@ export class WhatsAppOnboardingService {
     //    receives webhooks is worse than a visible failure.
     await this.whatsapp.subscribeWaba(accessToken, input.wabaId);
 
-    // 6. Persist. createChannel encrypts the token and, for a same-workspace
-    //    broken row, reconnects in place (a healthy same-workspace duplicate
-    //    still throws ConflictException — expected).
+    // 6. Persist. A healthy same-workspace duplicate was already rejected above
+    //    (step 1.5), so any same-workspace row reaching here is broken/expired —
+    //    createChannel's reconnect branch refreshes it in place.
     const accountName = verifiedName || input.phoneNumberId;
     return this.channels.createChannel(workspaceId, userId, {
       platform: 'whatsapp',

--- a/src/channels/services/whatsapp.service.spec.ts
+++ b/src/channels/services/whatsapp.service.spec.ts
@@ -1,4 +1,4 @@
-import { WhatsAppService } from './whatsapp.service';
+import { WhatsAppService, GRAPH_API_VERSION } from './whatsapp.service';
 
 describe('WhatsAppService.sendText', () => {
   const svc = new WhatsAppService();
@@ -144,5 +144,101 @@ describe('WhatsAppService.subscribeWaba', () => {
       ok: false, status: 400, json: async () => ({ error: { message: 'no perms' } }),
     } as any);
     await expect(svc.subscribeWaba('tok', '12345')).rejects.toThrow('no perms');
+  });
+});
+
+describe('WhatsAppService — Embedded Signup Graph methods', () => {
+  let service: WhatsAppService;
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    service = new WhatsAppService();
+    process.env = { ...OLD_ENV, META_APP_ID: 'app123', META_APP_SECRET: 'secret456' };
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetAllMocks();
+  });
+
+  it('pins Graph API version to v21.0', () => {
+    expect(GRAPH_API_VERSION).toBe('v21.0');
+  });
+
+  it('exchangeCodeForBusinessToken hits oauth/access_token with app creds + code', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'biz-token', expires_in: 5184000 }),
+    });
+    const res = await service.exchangeCodeForBusinessToken('the-code');
+    expect(res).toEqual({ accessToken: 'biz-token', expiresIn: 5184000 });
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(url).toContain(`/${GRAPH_API_VERSION}/oauth/access_token`);
+    expect(url).toContain('client_id=app123');
+    expect(url).toContain('client_secret=secret456');
+    expect(url).toContain('code=the-code');
+  });
+
+  it('exchangeCodeForBusinessToken returns null expiresIn when Meta omits it (never-expiring config)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'biz-token' }),
+    });
+    const res = await service.exchangeCodeForBusinessToken('c');
+    expect(res).toEqual({ accessToken: 'biz-token', expiresIn: null });
+  });
+
+  it('exchangeCodeForBusinessToken throws the Meta error message on failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Invalid code' } }),
+    });
+    await expect(service.exchangeCodeForBusinessToken('bad')).rejects.toThrow('Invalid code');
+  });
+
+  it('registerPhoneNumber posts messaging_product + pin', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await service.registerPhoneNumber('tok', '111', '123456');
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`https://graph.facebook.com/${GRAPH_API_VERSION}/111/register`);
+    expect(JSON.parse((init as any).body)).toEqual({ messaging_product: 'whatsapp', pin: '123456' });
+  });
+
+  it('registerPhoneNumber treats "already registered" as success', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Phone number already registered', code: 100 } }),
+    });
+    await expect(service.registerPhoneNumber('tok', '111', '123456')).resolves.toBeUndefined();
+  });
+
+  it('registerPhoneNumber throws on a genuine failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Two-step verification pin mismatch' } }),
+    });
+    await expect(service.registerPhoneNumber('tok', '111', '000000')).rejects.toThrow(
+      'Two-step verification pin mismatch',
+    );
+  });
+
+  it('getWabaPhoneNumbers maps the Graph response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: '111', display_phone_number: '+1 555', verified_name: 'Acme' },
+          { id: '222', display_phone_number: null, verified_name: null },
+        ],
+      }),
+    });
+    const res = await service.getWabaPhoneNumbers('tok', 'waba1');
+    expect(res).toEqual([
+      { id: '111', displayPhoneNumber: '+1 555', verifiedName: 'Acme' },
+      { id: '222', displayPhoneNumber: null, verifiedName: null },
+    ]);
   });
 });

--- a/src/channels/services/whatsapp.service.ts
+++ b/src/channels/services/whatsapp.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-export const WHATSAPP_GRAPH_BASE = 'https://graph.facebook.com/v21.0';
+export const GRAPH_API_VERSION = 'v21.0';
+export const WHATSAPP_GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
 @Injectable()
 export class WhatsAppService {
@@ -109,6 +110,86 @@ export class WhatsAppService {
         data?.error?.message || `WABA subscribe failed (${res.status})`;
       throw new Error(msg);
     }
+  }
+
+  /**
+   * Exchange the short-lived Embedded Signup code (valid ~30s) for a
+   * customer-scoped business access token. Tech Provider server-to-server call.
+   */
+  async exchangeCodeForBusinessToken(
+    code: string,
+  ): Promise<{ accessToken: string; expiresIn: number | null }> {
+    const appId = process.env.META_APP_ID;
+    const appSecret = process.env.META_APP_SECRET;
+    if (!appId || !appSecret) {
+      throw new Error('META_APP_ID / META_APP_SECRET are not configured');
+    }
+    const url =
+      `${WHATSAPP_GRAPH_BASE}/oauth/access_token` +
+      `?client_id=${encodeURIComponent(appId)}` +
+      `&client_secret=${encodeURIComponent(appSecret)}` +
+      `&code=${encodeURIComponent(code)}`;
+    const res = await fetch(url);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data?.access_token) {
+      const msg = data?.error?.message || `Code exchange failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return {
+      accessToken: data.access_token as string,
+      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : null,
+    };
+  }
+
+  /**
+   * Register the customer's business phone number for Cloud API use. `pin` is
+   * the 6-digit two-step-verification PIN. If the number is already registered
+   * (idempotent re-run) we treat it as success.
+   */
+  async registerPhoneNumber(
+    accessToken: string,
+    phoneNumberId: string,
+    pin: string,
+  ): Promise<void> {
+    const res = await fetch(`${WHATSAPP_GRAPH_BASE}/${phoneNumberId}/register`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ messaging_product: 'whatsapp', pin }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) return;
+    const msg = (data?.error?.message as string) || '';
+    if (/already\s+registered/i.test(msg)) return; // idempotent
+    throw new Error(msg || `Phone number register failed (${res.status})`);
+  }
+
+  /**
+   * List the phone numbers on a WABA — fallback when the Embedded Signup
+   * message event omits the phone_number_id, and to read verified_name.
+   */
+  async getWabaPhoneNumbers(
+    accessToken: string,
+    wabaId: string,
+  ): Promise<
+    Array<{ id: string; displayPhoneNumber: string | null; verifiedName: string | null }>
+  > {
+    const res = await fetch(
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/phone_numbers?fields=id,display_phone_number,verified_name`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg = data?.error?.message || `WABA phone lookup failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return ((data?.data as any[]) ?? []).map((p) => ({
+      id: String(p.id),
+      displayPhoneNumber: p.display_phone_number ?? null,
+      verifiedName: p.verified_name ?? null,
+    }));
   }
 
   /**

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -1843,12 +1843,19 @@ export class InboxService {
     platform: SupportedPlatform,
     platformAccountId: string,
   ) {
-    return db.query.socialMediaChannels.findFirst({
+    const matches = await db.query.socialMediaChannels.findMany({
       where: and(
         eq(socialMediaChannels.platform, platform),
         eq(socialMediaChannels.platformAccountId, platformAccountId),
       ),
+      orderBy: (c, { asc }) => asc(c.id),
     });
+    if (matches.length > 1) {
+      this.logger.warn(
+        `findChannelByPlatformAccount: ${matches.length} rows for ${platform}/${platformAccountId} — routing to the lowest channel id (${matches[0].id}). This should not happen; a cross-workspace duplicate slipped past the connect guard.`,
+      );
+    }
+    return matches[0];
   }
 
   async findTelegramChannelByRouteId(


### PR DESCRIPTION
Adds WhatsApp Embedded Signup so users connect a WABA through Meta's
dialog instead of pasting a token by hand. 8 commits, 16 files.

**Flow:** frontend gets `{appId, configId}` from `GET /channels/whatsapp/embedded-signup-config`
→ `FB.login` with the Login-for-Business config → the returned code is exchanged
server-side for a business token → phone number registered → WABA subscribed to
our webhook → channel created with the token encrypted at rest.

- Graph methods: exchange code, register phone number, list phone numbers
- Cross-workspace guard runs *before* any Meta side effect
- A healthy same-workspace duplicate returns 409 before burning Meta calls;
  a broken/expired one falls through so `createChannel` reconnects in place
- App id / config id served from the backend, so changing them needs no
  frontend rebuild

**Requires before deploy:** `META_APP_ID` and `WHATSAPP_ES_CONFIG_ID` on Railway.
Without them the endpoint returns `configured: false` and the UI shows a
disabled "not set up" button — by design, not a bug.

**Known follow-up:** the business token expires in 60 days and no refresh
flow exists yet.
