### PR TITLE
feat(calendar-sync): sync scheduled inbox messages to Google/Outlook

### DIFF
--- a/docs/superpowers/plans/calendar-messages-migration.sql
+++ b/docs/superpowers/plans/calendar-messages-migration.sql
@@ -1,0 +1,92 @@
+-- =============================================================================
+-- Calendar Sync — scheduled inbox messages (Task F)
+--
+-- Generalises `calendar_post_links` into `calendar_item_links`: one row still
+-- links ONE Schedura item to ONE external calendar event, but the item is now
+-- EITHER a scheduled post (`post_id`) OR a scheduled inbox message
+-- (`message_id`) — an exclusive arc enforced by a CHECK.
+--
+-- ⚠ THIS TABLE HOLDS LIVE ROWS pointing at events that already exist in real
+--   users' Google/Outlook calendars (tagged `schedura_post_id`). It is therefore
+--   MIGRATED IN PLACE — RENAME + ALTER, never DROP/CREATE. Post events keep
+--   their existing tag and their existing link rows; messages get a NEW parallel
+--   tag (`schedura_message_id`).
+--
+-- Hand-written (not `db:generate`) to avoid bundling unrelated schema drift.
+-- Mirrors src/drizzle/schema/calendar-sync.schema.ts. Safe to re-run.
+--
+-- id types: workspace_id / post_id / message_id are uuid (uuid pks); channel_id
+-- is integer because social_media_channels.id is a bigserial (numeric) pk.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- ONE-LINERS (Railway web console mangles multi-line paste — paste these ONE AT
+-- A TIME, in order; each is idempotent):
+--
+-- ALTER TABLE IF EXISTS "calendar_post_links" RENAME TO "calendar_item_links";
+-- ALTER TABLE "calendar_item_links" ALTER COLUMN "post_id" DROP NOT NULL;
+-- ALTER TABLE "calendar_item_links" ADD COLUMN IF NOT EXISTS "message_id" uuid;
+-- DO $$ BEGIN ALTER TABLE "calendar_item_links" ADD CONSTRAINT "calendar_item_links_message_id_scheduled_inbox_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "scheduled_inbox_messages"("id") ON DELETE cascade; EXCEPTION WHEN duplicate_object THEN null; END $$;
+-- DO $$ BEGIN ALTER TABLE "calendar_item_links" ADD CONSTRAINT "cil_exactly_one_owner" CHECK (num_nonnulls("post_id", "message_id") = 1); EXCEPTION WHEN duplicate_object THEN null; END $$;
+-- ALTER TABLE "calendar_item_links" DROP CONSTRAINT IF EXISTS "cpl_channel_post_uq";
+-- CREATE UNIQUE INDEX IF NOT EXISTS "cil_channel_post_uq" ON "calendar_item_links" ("channel_id", "post_id") WHERE "post_id" IS NOT NULL;
+-- CREATE UNIQUE INDEX IF NOT EXISTS "cil_channel_message_uq" ON "calendar_item_links" ("channel_id", "message_id") WHERE "message_id" IS NOT NULL;
+-- ALTER INDEX IF EXISTS "cpl_channel_event_ix" RENAME TO "cil_channel_event_ix";
+-- CREATE INDEX IF NOT EXISTS "cil_channel_event_ix" ON "calendar_item_links" ("channel_id", "external_event_id");
+-- -----------------------------------------------------------------------------
+
+
+-- 1. Rename the table (in place — the rows and their FKs come along) ------------
+-- `IF EXISTS` makes a re-run (table already renamed) a no-op instead of an error.
+ALTER TABLE IF EXISTS "calendar_post_links" RENAME TO "calendar_item_links";
+
+-- 2. post_id becomes optional (a message-owned row has none) --------------------
+-- Idempotent by nature: dropping an already-absent NOT NULL is a no-op.
+ALTER TABLE "calendar_item_links" ALTER COLUMN "post_id" DROP NOT NULL;
+
+-- 3. The new message arc -------------------------------------------------------
+ALTER TABLE "calendar_item_links" ADD COLUMN IF NOT EXISTS "message_id" uuid;
+
+DO $$ BEGIN
+  ALTER TABLE "calendar_item_links"
+    ADD CONSTRAINT "calendar_item_links_message_id_scheduled_inbox_messages_id_fk"
+    FOREIGN KEY ("message_id") REFERENCES "scheduled_inbox_messages"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 4. Exclusive arc: exactly one of (post_id, message_id) is set -----------------
+-- Existing live rows all have post_id set + message_id NULL → they satisfy this,
+-- so the constraint validates without touching them.
+DO $$ BEGIN
+  ALTER TABLE "calendar_item_links"
+    ADD CONSTRAINT "cil_exactly_one_owner"
+    CHECK (num_nonnulls("post_id", "message_id") = 1);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 5. Swap the old (channel_id, post_id) unique for two PARTIAL uniques ----------
+ALTER TABLE "calendar_item_links" DROP CONSTRAINT IF EXISTS "cpl_channel_post_uq";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cil_channel_post_uq"
+  ON "calendar_item_links" ("channel_id", "post_id")
+  WHERE "post_id" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cil_channel_message_uq"
+  ON "calendar_item_links" ("channel_id", "message_id")
+  WHERE "message_id" IS NOT NULL;
+
+-- 6. Keep the (channel_id, external_event_id) lookup index ----------------------
+-- A table RENAME does NOT rename its indexes, so rename it for consistency. The
+-- CREATE below is the fresh-DB fallback (and a no-op after the rename).
+ALTER INDEX IF EXISTS "cpl_channel_event_ix" RENAME TO "cil_channel_event_ix";
+
+CREATE INDEX IF NOT EXISTS "cil_channel_event_ix"
+  ON "calendar_item_links" ("channel_id", "external_event_id");
+
+-- =============================================================================
+-- Verification (optional):
+--
+--   SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint
+--     WHERE conrelid = 'calendar_item_links'::regclass;
+--   SELECT indexname, indexdef FROM pg_indexes
+--     WHERE tablename = 'calendar_item_links';
+--   SELECT count(*) FROM calendar_item_links WHERE post_id IS NOT NULL; -- live post links survive
+-- =============================================================================

--- a/src/calendar-sync/calendar-conflict.ts
+++ b/src/calendar-sync/calendar-conflict.ts
@@ -4,13 +4,20 @@ import { contentHash } from './calendar-sync.mapper';
 // Calendar conflict engine (PURE)
 // -----------------------------------------------------------------------------
 // Decides what to do with an inbound change to an event WE wrote (an event
-// carrying our `schedura_post_id` tag and backed by a `calendar_post_links` row).
+// carrying our `schedura_post_id` / `schedura_message_id` tag and backed by a
+// `calendar_item_links` row).
+//
+// The item is a scheduled POST or a scheduled INBOX MESSAGE; the truth table is
+// identical for both, so the engine only ever sees the two fields they share
+// (`updatedAt` + `scheduledAt`). The CALLER applies the decision and knows which
+// kind it holds (post -> draft, message -> cancelled).
 //
 // Last-write-wins by updated timestamp, guarded by etag + content-hash echo
 // suppression so our OWN writes coming back down the delta stream can never
 // bounce back up again (ping-pong):
 //
-//   1. the event was deleted externally        -> apply_external (post -> draft)
+//   1. the event was deleted externally        -> apply_external (post -> draft /
+//                                                 message -> cancelled)
 //   2. the event's etag is the one we stored   -> skip_echo   (this IS our write)
 //   3. the event's content is what we pushed   -> skip_echo   (etag drifted, same content)
 //   4. the external edit is newer than the post-> apply_external (reschedule post)
@@ -25,7 +32,7 @@ export type ConflictDecision =
   | 'repush_app'
   | 'noop';
 
-/** The `calendar_post_links` fields the decision depends on. */
+/** The `calendar_item_links` fields the decision depends on. */
 export interface ConflictLink {
   /** Provider etag/changeKey of the version WE last wrote. */
   etag?: string | null;
@@ -48,7 +55,11 @@ export interface ConflictEvent {
   externalUpdatedAt?: Date | null;
 }
 
-/** The post fields the decision depends on. */
+/**
+ * The app-side item fields the decision depends on. Named `ConflictPost` for
+ * historical reasons — a scheduled inbox message satisfies it structurally and
+ * is resolved through exactly the same truth table.
+ */
 export interface ConflictPost {
   updatedAt?: Date | null;
   scheduledAt?: Date | null;

--- a/src/calendar-sync/calendar-sync.constants.ts
+++ b/src/calendar-sync/calendar-sync.constants.ts
@@ -8,12 +8,23 @@ export const CALENDAR_RECONCILE_QUEUE = 'calendar-reconcile';
 export const CALENDAR_RENEWAL_QUEUE = 'calendar-renewal';
 
 // -----------------------------------------------------------------------------
-// Event ownership tags. Every post-event we write carries these private props so
+// Event ownership tags. Every event we write carries these private props so
 // two-way write-back only ever touches events we created.
-//   Google:  extendedProperties.private[SCHEDURA_POST_ID_PROP]
-//   Graph:   a singleValueExtendedProperties entry keyed by GRAPH_POST_ID_PROP_ID
+//
+//   post event:     schedura_post_id    + schedura_workspace_id
+//   message event:  schedura_message_id + schedura_workspace_id
+//
+//   Google:  extendedProperties.private[<prop>]
+//   Graph:   a singleValueExtendedProperties entry keyed by the matching
+//            GRAPH_*_PROP_ID named MAPI property.
+//
+// BACKWARD COMPATIBILITY: `schedura_post_id` is LOAD-BEARING — live events in
+// real users' calendars already carry it (and live `calendar_item_links` rows
+// point at them). It must never be renamed or re-keyed. The message tag is a
+// NEW, PARALLEL prop; posts keep using exactly what they use today.
 // -----------------------------------------------------------------------------
 export const SCHEDURA_POST_ID_PROP = 'schedura_post_id';
+export const SCHEDURA_MESSAGE_ID_PROP = 'schedura_message_id';
 export const SCHEDURA_WORKSPACE_ID_PROP = 'schedura_workspace_id';
 
 // Microsoft Graph named MAPI property (fixed GUID + name). Used as the
@@ -21,9 +32,14 @@ export const SCHEDURA_WORKSPACE_ID_PROP = 'schedura_workspace_id';
 export const GRAPH_POST_ID_PROP_ID =
   'String {a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c} Name schedura_post_id';
 
+// Same GUID, new name — the message-id counterpart of GRAPH_POST_ID_PROP_ID.
+// Reusing the property-set GUID keeps all Schedura tags in one MAPI namespace.
+export const GRAPH_MESSAGE_ID_PROP_ID =
+  'String {a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c} Name schedura_message_id';
+
 // Companion named MAPI property carrying the owning workspace id. Written
-// alongside GRAPH_POST_ID_PROP_ID so Graph events mirror Google's two private
-// props (schedura_post_id + schedura_workspace_id).
+// alongside GRAPH_POST_ID_PROP_ID / GRAPH_MESSAGE_ID_PROP_ID so Graph events
+// mirror Google's two private props.
 export const GRAPH_WORKSPACE_ID_PROP_ID =
   'String {a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c} Name schedura_workspace_id';
 

--- a/src/calendar-sync/calendar-sync.mapper.spec.ts
+++ b/src/calendar-sync/calendar-sync.mapper.spec.ts
@@ -1,9 +1,12 @@
 import {
   postToEventInput,
+  messageToEventInput,
   contentHash,
+  MessageForMapping,
   PostForMapping,
 } from './calendar-sync.mapper';
 import {
+  SCHEDURA_MESSAGE_ID_PROP,
   SCHEDURA_POST_ID_PROP,
   SCHEDURA_WORKSPACE_ID_PROP,
 } from './calendar-sync.constants';
@@ -12,6 +15,14 @@ const basePost: PostForMapping = {
   id: 'post-uuid-1',
   workspaceId: 'ws-uuid-1',
   content: 'Launch day! 🎉 Check out our new feature.',
+  scheduledAt: new Date('2026-08-01T10:00:00.000Z'),
+};
+
+const baseMessage: MessageForMapping = {
+  id: 'msg-uuid-1',
+  workspaceId: 'ws-uuid-1',
+  text: 'Thanks for the kind words!',
+  targetLabel: '@alex',
   scheduledAt: new Date('2026-08-01T10:00:00.000Z'),
 };
 
@@ -49,6 +60,70 @@ describe('calendar-sync.mapper', () => {
     it('throws when the post has no scheduledAt', () => {
       expect(() =>
         postToEventInput({ ...basePost, scheduledAt: null }),
+      ).toThrow(/scheduledAt/);
+    });
+  });
+
+  describe('messageToEventInput', () => {
+    it('tags the event with the MESSAGE id prop, never the post id prop', () => {
+      const input = messageToEventInput(baseMessage);
+      expect(input.privateProps[SCHEDURA_MESSAGE_ID_PROP]).toBe('msg-uuid-1');
+      expect(input.privateProps[SCHEDURA_WORKSPACE_ID_PROP]).toBe('ws-uuid-1');
+      // Backward compatibility: post events keep `schedura_post_id` to
+      // themselves — a message event must NEVER carry it.
+      expect(input.privateProps[SCHEDURA_POST_ID_PROP]).toBeUndefined();
+    });
+
+    it('maps scheduledAt to start and defaults end to start + 30min', () => {
+      const input = messageToEventInput(baseMessage);
+      expect(input.startTime.toISOString()).toBe('2026-08-01T10:00:00.000Z');
+      expect(input.endTime.toISOString()).toBe('2026-08-01T10:30:00.000Z');
+    });
+
+    it('reads like a calendar entry: "Reply to <label>: <excerpt>"', () => {
+      const input = messageToEventInput(baseMessage);
+      expect(input.summary).toBe('Reply to @alex: Thanks for the kind words!');
+    });
+
+    it('falls back to the label alone when there is no text', () => {
+      const input = messageToEventInput({ ...baseMessage, text: null });
+      expect(input.summary).toBe('Reply to @alex');
+    });
+
+    it('falls back to the excerpt alone when there is no label', () => {
+      const input = messageToEventInput({ ...baseMessage, targetLabel: null });
+      expect(input.summary).toBe('Reply: Thanks for the kind words!');
+    });
+
+    it('never produces an empty title when both label and text are missing', () => {
+      const input = messageToEventInput({
+        ...baseMessage,
+        text: null,
+        targetLabel: null,
+      });
+      expect(input.summary).toBe('Scheduled reply');
+    });
+
+    it('strips the composer HTML out of the excerpt', () => {
+      const input = messageToEventInput({
+        ...baseMessage,
+        text: '<p>Thanks &amp; welcome!</p>',
+      });
+      expect(input.summary).toBe('Reply to @alex: Thanks & welcome!');
+    });
+
+    it('truncates long text to <= 80 chars with an ellipsis', () => {
+      const input = messageToEventInput({
+        ...baseMessage,
+        text: 'x'.repeat(200),
+      });
+      expect(input.summary.length).toBeLessThanOrEqual(80);
+      expect(input.summary.endsWith('…')).toBe(true);
+    });
+
+    it('throws when the message has no scheduledAt', () => {
+      expect(() =>
+        messageToEventInput({ ...baseMessage, scheduledAt: null }),
       ).toThrow(/scheduledAt/);
     });
   });

--- a/src/calendar-sync/calendar-sync.mapper.ts
+++ b/src/calendar-sync/calendar-sync.mapper.ts
@@ -1,17 +1,21 @@
 import { createHash } from 'crypto';
 import {
+  SCHEDURA_MESSAGE_ID_PROP,
   SCHEDURA_POST_ID_PROP,
   SCHEDURA_WORKSPACE_ID_PROP,
 } from './calendar-sync.constants';
 
-// Default calendar-event duration when a post has no explicit end time.
+// Default calendar-event duration when an item has no explicit end time.
 const DEFAULT_EVENT_DURATION_MS = 30 * 60 * 1000; // 30 minutes
 
-// Max length of the event title derived from post content.
+// Max length of the event title derived from item content.
 const MAX_SUMMARY_LENGTH = 80;
 
 // Shown when a scheduled post has no caption/content.
 const EMPTY_SUMMARY_FALLBACK = '(untitled post)';
+
+// Shown when a scheduled message carries neither a target label nor text.
+const EMPTY_MESSAGE_SUMMARY_FALLBACK = 'Scheduled reply';
 
 // Minimal post shape the mapper needs. Kept structural (not the full Drizzle
 // row) so it is trivial to unit-test and decoupled from schema churn.
@@ -19,6 +23,18 @@ export interface PostForMapping {
   id: string;
   workspaceId: string;
   content: string | null;
+  scheduledAt: Date | null;
+}
+
+// Minimal scheduled-inbox-message shape the mapper needs. Same rationale as
+// PostForMapping — structural, not the Drizzle row.
+export interface MessageForMapping {
+  id: string;
+  workspaceId: string;
+  /** Reply/DM body. May contain light HTML (the composer is rich-text). */
+  text: string | null;
+  /** Human-readable target, e.g. `@alex` or `Post · @bob`. */
+  targetLabel: string | null;
   scheduledAt: Date | null;
 }
 
@@ -31,19 +47,63 @@ export interface EventInput {
   privateProps: Record<string, string>;
 }
 
-/**
- * Derive a concise, single-line event title from post content.
- */
-function toSummary(content: string | null): string {
-  const collapsed = (content ?? '').replace(/\s+/g, ' ').trim();
-  if (collapsed.length === 0) {
-    return EMPTY_SUMMARY_FALLBACK;
-  }
+/** Collapse whitespace to a single line. */
+function collapse(value: string | null | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/** Strip the composer's light HTML so the calendar title is plain text. */
+function stripHtml(value: string | null | undefined): string {
+  return collapse(
+    (value ?? '')
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>'),
+  );
+}
+
+/** Clamp a single-line title to MAX_SUMMARY_LENGTH with an ellipsis. */
+function truncate(collapsed: string): string {
   if (collapsed.length <= MAX_SUMMARY_LENGTH) {
     return collapsed;
   }
   // Reserve one char for the ellipsis.
   return collapsed.slice(0, MAX_SUMMARY_LENGTH - 1).trimEnd() + '…';
+}
+
+/**
+ * Derive a concise, single-line event title from post content.
+ */
+function toSummary(content: string | null): string {
+  const collapsed = collapse(content);
+  if (collapsed.length === 0) {
+    return EMPTY_SUMMARY_FALLBACK;
+  }
+  return truncate(collapsed);
+}
+
+/**
+ * Derive a concise, single-line event title for a scheduled inbox message.
+ * Reads like a calendar entry rather than a raw body dump:
+ *
+ *   label + text  ->  `Reply to @alex: thanks for the kind words!`
+ *   label only    ->  `Reply to @alex`
+ *   text only     ->  `Reply: thanks for the kind words!`
+ *   neither       ->  `Scheduled reply`
+ */
+function toMessageSummary(
+  targetLabel: string | null,
+  text: string | null,
+): string {
+  const label = collapse(targetLabel);
+  const excerpt = stripHtml(text);
+
+  if (label && excerpt) return truncate(`Reply to ${label}: ${excerpt}`);
+  if (label) return truncate(`Reply to ${label}`);
+  if (excerpt) return truncate(`Reply: ${excerpt}`);
+  return EMPTY_MESSAGE_SUMMARY_FALLBACK;
 }
 
 /**
@@ -69,6 +129,36 @@ export function postToEventInput(post: PostForMapping): EventInput {
     privateProps: {
       [SCHEDURA_POST_ID_PROP]: post.id,
       [SCHEDURA_WORKSPACE_ID_PROP]: post.workspaceId,
+    },
+  };
+}
+
+/**
+ * Map a scheduled inbox message (comment reply / DM) to the provider-agnostic
+ * event body, tagged with `schedura_message_id` + `schedura_workspace_id`.
+ *
+ * Deliberately a SEPARATE tag from `schedura_post_id`: post events already live
+ * in real calendars keyed by that prop, and re-keying them would orphan them.
+ *
+ * Throws if the message has no `scheduledAt` — callers must gate on
+ * schedulability (status === 'pending').
+ */
+export function messageToEventInput(message: MessageForMapping): EventInput {
+  if (!message.scheduledAt) {
+    throw new Error(
+      `Cannot map scheduled message ${message.id} to a calendar event: missing scheduledAt`,
+    );
+  }
+  const startTime = new Date(message.scheduledAt);
+  const endTime = new Date(startTime.getTime() + DEFAULT_EVENT_DURATION_MS);
+
+  return {
+    summary: toMessageSummary(message.targetLabel, message.text),
+    startTime,
+    endTime,
+    privateProps: {
+      [SCHEDURA_MESSAGE_ID_PROP]: message.id,
+      [SCHEDURA_WORKSPACE_ID_PROP]: message.workspaceId,
     },
   };
 }

--- a/src/calendar-sync/calendar-sync.module.ts
+++ b/src/calendar-sync/calendar-sync.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ChannelsModule } from '../channels/channels.module';
 import { PostsModule } from '../posts/posts.module';
+import { InboxModule } from '../inbox/inbox.module';
 import {
   CALENDAR_RECONCILE_QUEUE,
   CALENDAR_RENEWAL_QUEUE,
@@ -39,10 +40,17 @@ import { CalendarRenewalProcessor } from './processors/calendar-renewal.processo
 // polls every 15 min as the safety net. ChannelsController subscribes on connect
 // and tears down on disconnect, so ChannelsModule ↔ CalendarSyncModule is now
 // circular too → forwardRef on both sides.
+// Task F extends the same two-way machinery to SCHEDULED INBOX MESSAGES (comment
+// replies + DMs): the push service mirrors pending messages onto the calendars,
+// and the pull service applies external moves/deletes back via
+// ScheduledMessagesService's EXISTING update/cancel paths (which re-arm/remove
+// the BullMQ delayed send job). InboxModule ↔ CalendarSyncModule is therefore
+// circular for exactly the same reason PostsModule is → forwardRef on both sides.
 @Module({
   imports: [
     forwardRef(() => ChannelsModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => InboxModule),
     BullModule.registerQueue(
       { name: CALENDAR_RECONCILE_QUEUE },
       { name: CALENDAR_RENEWAL_QUEUE },

--- a/src/calendar-sync/providers/delta.types.ts
+++ b/src/calendar-sync/providers/delta.types.ts
@@ -29,12 +29,14 @@ export interface NormalizedExternalEvent {
   externalUpdatedAt: Date | null;
   /**
    * True when the event carries OUR ownership tag (i.e. Schedura wrote it for a
-   * scheduled post). Such events are NOT imported as external events — they are
-   * the two-way write-back surface (Task D).
+   * scheduled post OR a scheduled inbox message). Such events are NOT imported as
+   * external events — they are the two-way write-back surface (Task D).
    */
   isOurs: boolean;
-  /** The tagged post id, when `isOurs`. */
+  /** The tagged post id, when the event is a POST event we wrote. */
   postId?: string;
+  /** The tagged scheduled-message id, when the event is a MESSAGE event we wrote. */
+  messageId?: string;
   /** Provider concurrency token (Google `etag`, Graph `@odata.etag`). */
   etag?: string;
   /** Raw provider payload (persisted to `external_calendar_events.raw`). */

--- a/src/calendar-sync/providers/google-delta.util.ts
+++ b/src/calendar-sync/providers/google-delta.util.ts
@@ -1,5 +1,8 @@
 import { Logger } from '@nestjs/common';
-import { SCHEDURA_POST_ID_PROP } from '../calendar-sync.constants';
+import {
+  SCHEDURA_MESSAGE_ID_PROP,
+  SCHEDURA_POST_ID_PROP,
+} from '../calendar-sync.constants';
 import {
   CalendarDeltaOptions,
   CalendarDeltaResult,
@@ -203,6 +206,8 @@ function normalizeGoogleEvent(
   calendarId: string,
 ): NormalizedExternalEvent {
   const postId = item.extendedProperties?.private?.[SCHEDURA_POST_ID_PROP];
+  const messageId =
+    item.extendedProperties?.private?.[SCHEDURA_MESSAGE_ID_PROP];
   const isAllDay = Boolean(item.start?.date);
 
   return {
@@ -214,8 +219,9 @@ function normalizeGoogleEvent(
     isAllDay,
     htmlLink: item.htmlLink,
     externalUpdatedAt: item.updated ? toDateOrNull(item.updated) : null,
-    isOurs: Boolean(postId),
+    isOurs: Boolean(postId || messageId),
     postId: postId || undefined,
+    messageId: messageId || undefined,
     etag: item.etag,
     raw: item,
   };

--- a/src/calendar-sync/providers/outlook-delta.util.ts
+++ b/src/calendar-sync/providers/outlook-delta.util.ts
@@ -1,5 +1,8 @@
 import { Logger } from '@nestjs/common';
-import { GRAPH_POST_ID_PROP_ID } from '../calendar-sync.constants';
+import {
+  GRAPH_MESSAGE_ID_PROP_ID,
+  GRAPH_POST_ID_PROP_ID,
+} from '../calendar-sync.constants';
 import {
   CalendarDeltaOptions,
   CalendarDeltaResult,
@@ -55,10 +58,10 @@ interface GraphDeltaResponse {
  * endpoints (a `$expand=singleValueExtendedProperties(...)` makes the request
  * 400), so the delta payload never carries our named MAPI tag and `isOurs` is
  * effectively always false here. Ownership for Outlook is therefore decided by
- * the AUTHORITATIVE `calendar_post_links` lookup in `CalendarPullSyncService`
+ * the AUTHORITATIVE `calendar_item_links` lookup in `CalendarPullSyncService`
  * (`loadLinkedEventIds` / `loadLink`), which treats any event with a link row as
- * ours. `readPostIdTag()` below is kept as a belt-and-braces reader for the rare
- * payloads (non-delta refetches) that do carry the property.
+ * ours. `readTag()` below is kept as a belt-and-braces reader for the rare
+ * payloads (non-delta refetches) that do carry the properties.
  */
 export async function fetchOutlookCalendarDelta(
   options: CalendarDeltaOptions,
@@ -160,7 +163,7 @@ export async function fetchOutlookCalendarDelta(
  * NO `$expand`: Microsoft Graph does not support `$expand` on the delta
  * endpoints — `/me/calendarView/delta?$expand=singleValueExtendedProperties(...)`
  * is rejected with a 400, which killed the entire Outlook pull. Ownership is
- * resolved from `calendar_post_links` in the pull service instead (see the
+ * resolved from `calendar_item_links` in the pull service instead (see the
  * module doc above).
  */
 function buildInitialUrl(now: Date): string {
@@ -194,7 +197,8 @@ function normalizeGraphEvent(
   item: GraphDeltaEvent,
   calendarId: string,
 ): NormalizedExternalEvent {
-  const postId = readPostIdTag(item);
+  const postId = readTag(item, GRAPH_POST_ID_PROP_ID);
+  const messageId = readTag(item, GRAPH_MESSAGE_ID_PROP_ID);
 
   return {
     externalEventId: item.id,
@@ -207,34 +211,35 @@ function normalizeGraphEvent(
     externalUpdatedAt: item.lastModifiedDateTime
       ? toDateOrNull(item.lastModifiedDateTime)
       : null,
-    isOurs: Boolean(postId),
+    isOurs: Boolean(postId || messageId),
     postId: postId || undefined,
+    messageId: messageId || undefined,
     etag: item['@odata.etag'],
     raw: item,
   };
 }
 
 /**
- * Read our ownership tag out of the extended properties WHEN Graph happens to
- * include them. The delta stream never does (no `$expand` support), so this
- * returns undefined there and `calendar_post_links` decides ownership — but a
- * non-delta payload can carry them, and reading it is free. Graph can echo the
- * property id with different casing/whitespace than we sent, so the match is
+ * Read one of our ownership tags out of the extended properties WHEN Graph
+ * happens to include them. The delta stream never does (no `$expand` support),
+ * so this returns undefined there and `calendar_item_links` decides ownership —
+ * but a non-delta payload can carry them, and reading it is free. Graph can echo
+ * the property id with different casing/whitespace than we sent, so the match is
  * case-insensitive on the `Name <prop>` suffix as well as exact.
  */
-function readPostIdTag(item: GraphDeltaEvent): string | undefined {
+function readTag(item: GraphDeltaEvent, propId: string): string | undefined {
   const props = item.singleValueExtendedProperties;
   if (!props?.length) return undefined;
 
-  const wantedSuffix = GRAPH_POST_ID_PROP_ID.slice(
-    GRAPH_POST_ID_PROP_ID.toLowerCase().indexOf('name '),
-  ).toLowerCase();
+  const wantedSuffix = propId
+    .slice(propId.toLowerCase().indexOf('name '))
+    .toLowerCase();
 
   const hit = props.find((prop) => {
     if (!prop?.id) return false;
     const id = prop.id.toLowerCase();
     return (
-      prop.id === GRAPH_POST_ID_PROP_ID ||
+      prop.id === propId ||
       (wantedSuffix.length > 0 && id.endsWith(wantedSuffix))
     );
   });

--- a/src/calendar-sync/services/calendar-pull-sync.delete.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.delete.spec.ts
@@ -1,20 +1,24 @@
 // `CalendarPullSyncService` uses the module-level `db` singleton (not DI), so a
 // Nest TestingModule can't intercept it — jest.mock the module and drive the
-// exact query paths the external-DELETE write-back touches.
+// exact query paths the external-DELETE write-back touches. Selects are keyed BY
+// TABLE so the post lookup and the scheduled-message lookup return different rows.
 jest.mock('../../drizzle/db', () => {
-  const selectResult: { rows: unknown[] } = { rows: [] };
-  const deletedTables: unknown[] = [];
+  const state = {
+    selectByTable: new Map<unknown, unknown[]>(),
+    deletedTables: [] as unknown[],
+  };
   return {
-    __selectResult: selectResult,
-    __deletedTables: deletedTables,
+    __state: state,
     db: {
       select: jest.fn(() => ({
-        from: jest.fn(() => ({
-          where: jest.fn(() => Promise.resolve(selectResult.rows)),
+        from: jest.fn((table: unknown) => ({
+          where: jest.fn(() =>
+            Promise.resolve(state.selectByTable.get(table) ?? []),
+          ),
         })),
       })),
       delete: jest.fn((table: unknown) => {
-        deletedTables.push(table);
+        state.deletedTables.push(table);
         return { where: jest.fn(() => Promise.resolve()) };
       }),
       update: jest.fn(() => ({
@@ -28,31 +32,36 @@ import { ChannelService } from '../../channels/services/channel.service';
 import { GoogleCalendarService } from '../../channels/services/google-calendar.service';
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { PostService } from '../../posts/services/post.service';
+import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
 import { posts } from '../../drizzle/schema/posts.schema';
+import { scheduledInboxMessages } from '../../drizzle/schema/scheduled-inbox-messages.schema';
 import {
-  calendarPostLinks,
-  CalendarPostLink,
+  calendarItemLinks,
+  CalendarItemLink,
 } from '../../drizzle/schema/calendar-sync.schema';
 import { CalendarPushSyncService } from './calendar-push-sync.service';
 import { CalendarPullSyncService } from './calendar-pull-sync.service';
 
 // Handles onto the mocked db module's internals.
 const dbMock = jest.requireMock('../../drizzle/db') as unknown as {
-  __selectResult: { rows: unknown[] };
-  __deletedTables: unknown[];
+  __state: {
+    selectByTable: Map<unknown, unknown[]>;
+    deletedTables: unknown[];
+  };
 };
 
 // The private write-back entry point under test.
 interface PullSyncInternals {
-  applyExternalDelete(link: CalendarPostLink): Promise<void>;
+  applyExternalDelete(link: CalendarItemLink): Promise<void>;
 }
 
-const LINK = {
+const POST_LINK = {
   id: 'link-1',
   workspaceId: 'ws-1',
   channelId: 42,
   provider: 'google',
   postId: 'post-1',
+  messageId: null,
   externalEventId: 'evt-1',
   externalCalendarId: 'primary',
   etag: 'etag-ours',
@@ -62,7 +71,15 @@ const LINK = {
   lastError: null,
   createdAt: new Date(),
   updatedAt: new Date(),
-} as CalendarPostLink;
+} as CalendarItemLink;
+
+const MESSAGE_LINK = {
+  ...POST_LINK,
+  id: 'link-2',
+  postId: null,
+  messageId: 'msg-1',
+  externalEventId: 'evt-2',
+} as CalendarItemLink;
 
 const SCHEDULED_POST = {
   id: 'post-1',
@@ -74,26 +91,48 @@ const SCHEDULED_POST = {
   updatedAt: new Date('2026-07-13T10:00:00.000Z'),
 };
 
-describe('CalendarPullSyncService — external delete → unschedule (never hard-delete)', () => {
+const PENDING_MESSAGE = {
+  id: 'msg-1',
+  workspaceId: 'ws-1',
+  channelId: 42,
+  text: 'thanks!',
+  targetLabel: '@alex',
+  status: 'pending',
+  scheduledAt: new Date('2026-08-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-07-13T10:00:00.000Z'),
+};
+
+describe('CalendarPullSyncService — external delete write-back (never hard-delete)', () => {
   let internals: PullSyncInternals;
   let updatePost: jest.Mock;
+  let cancelFromCalendar: jest.Mock;
   let syncPost: jest.Mock;
+  let syncMessage: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    dbMock.__deletedTables.length = 0;
-    dbMock.__selectResult.rows = [SCHEDULED_POST];
+    dbMock.__state.deletedTables.length = 0;
+    dbMock.__state.selectByTable.clear();
+    dbMock.__state.selectByTable.set(posts, [SCHEDULED_POST]);
+    dbMock.__state.selectByTable.set(scheduledInboxMessages, [PENDING_MESSAGE]);
 
     updatePost = jest.fn().mockResolvedValue(SCHEDULED_POST);
+    cancelFromCalendar = jest.fn().mockResolvedValue({ success: true });
     syncPost = jest.fn().mockResolvedValue(undefined);
+    syncMessage = jest.fn().mockResolvedValue(undefined);
 
     const channelService = {
       getAccessToken: jest.fn().mockResolvedValue('tok'),
     } as unknown as ChannelService;
     const pushSync = {
       syncPost,
+      syncMessage,
     } as unknown as CalendarPushSyncService;
     const postService = { updatePost } as unknown as PostService;
+    const scheduledMessages = {
+      cancelFromCalendar,
+      updateFromCalendar: jest.fn(),
+    } as unknown as ScheduledMessagesService;
 
     internals = new CalendarPullSyncService(
       channelService,
@@ -101,40 +140,93 @@ describe('CalendarPullSyncService — external delete → unschedule (never hard
       {} as OutlookCalendarService,
       pushSync,
       postService,
+      scheduledMessages,
     ) as unknown as PullSyncInternals;
   });
 
-  it('sends the post back to draft via PostService.updatePost({ scheduledAt: null })', async () => {
-    await internals.applyExternalDelete(LINK);
+  // ===========================================================================
+  // Post arc (LIVE behaviour — must be unchanged)
+  // ===========================================================================
 
-    expect(updatePost).toHaveBeenCalledTimes(1);
-    expect(updatePost).toHaveBeenCalledWith('post-1', 'ws-1', 'user-1', {
-      scheduledAt: null,
+  describe('post link', () => {
+    it('sends the post back to draft via PostService.updatePost({ scheduledAt: null })', async () => {
+      await internals.applyExternalDelete(POST_LINK);
+
+      expect(updatePost).toHaveBeenCalledTimes(1);
+      expect(updatePost).toHaveBeenCalledWith('post-1', 'ws-1', 'user-1', {
+        scheduledAt: null,
+      });
+      expect(cancelFromCalendar).not.toHaveBeenCalled();
+    });
+
+    it('NEVER hard-deletes the post — only the calendar link row is deleted', async () => {
+      await internals.applyExternalDelete(POST_LINK);
+
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+      expect(dbMock.__state.deletedTables).not.toContain(posts);
+    });
+
+    it('does not touch an already-published post, and still drops the stale link', async () => {
+      dbMock.__state.selectByTable.set(posts, [
+        { ...SCHEDULED_POST, status: 'published' },
+      ]);
+
+      await internals.applyExternalDelete(POST_LINK);
+
+      expect(updatePost).not.toHaveBeenCalled();
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+    });
+
+    it('drops the link (and nothing else) when the post no longer exists', async () => {
+      dbMock.__state.selectByTable.set(posts, []);
+
+      await internals.applyExternalDelete(POST_LINK);
+
+      expect(updatePost).not.toHaveBeenCalled();
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
     });
   });
 
-  it('NEVER hard-deletes the post — only the calendar link row is deleted', async () => {
-    await internals.applyExternalDelete(LINK);
+  // ===========================================================================
+  // Message arc
+  // ===========================================================================
 
-    expect(dbMock.__deletedTables).toEqual([calendarPostLinks]);
-    expect(dbMock.__deletedTables).not.toContain(posts);
-  });
+  describe('scheduled-message link', () => {
+    it('CANCELS the message via ScheduledMessagesService (reusing its BullMQ job removal)', async () => {
+      await internals.applyExternalDelete(MESSAGE_LINK);
 
-  it('does not touch an already-published post, and still drops the stale link', async () => {
-    dbMock.__selectResult.rows = [{ ...SCHEDULED_POST, status: 'published' }];
+      expect(cancelFromCalendar).toHaveBeenCalledTimes(1);
+      expect(cancelFromCalendar).toHaveBeenCalledWith('ws-1', 'msg-1');
+      expect(updatePost).not.toHaveBeenCalled();
+    });
 
-    await internals.applyExternalDelete(LINK);
+    it('NEVER hard-deletes the message row — only the calendar link row is deleted', async () => {
+      await internals.applyExternalDelete(MESSAGE_LINK);
 
-    expect(updatePost).not.toHaveBeenCalled();
-    expect(dbMock.__deletedTables).toEqual([calendarPostLinks]);
-  });
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+      expect(dbMock.__state.deletedTables).not.toContain(
+        scheduledInboxMessages,
+      );
+    });
 
-  it('drops the link (and nothing else) when the post no longer exists', async () => {
-    dbMock.__selectResult.rows = [];
+    it('does not cancel an already-sent message, and still drops the stale link', async () => {
+      dbMock.__state.selectByTable.set(scheduledInboxMessages, [
+        { ...PENDING_MESSAGE, status: 'sent' },
+      ]);
 
-    await internals.applyExternalDelete(LINK);
+      await internals.applyExternalDelete(MESSAGE_LINK);
 
-    expect(updatePost).not.toHaveBeenCalled();
-    expect(dbMock.__deletedTables).toEqual([calendarPostLinks]);
+      expect(cancelFromCalendar).not.toHaveBeenCalled();
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+    });
+
+    it('drops the link (and nothing else) when the message no longer exists', async () => {
+      dbMock.__state.selectByTable.set(scheduledInboxMessages, []);
+
+      await internals.applyExternalDelete(MESSAGE_LINK);
+
+      expect(cancelFromCalendar).not.toHaveBeenCalled();
+      expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+    });
   });
 });

--- a/src/calendar-sync/services/calendar-pull-sync.message.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.message.spec.ts
@@ -1,0 +1,295 @@
+// `CalendarPullSyncService` uses the module-level `db` singleton (not DI), so a
+// Nest TestingModule can't intercept it — jest.mock the module and drive the
+// exact query paths the two-way write-back touches. Selects are keyed BY TABLE so
+// the link lookup, the post lookup and the message lookup return different rows.
+jest.mock('../../drizzle/db', () => {
+  const state = {
+    selectByTable: new Map<unknown, unknown[]>(),
+    deletedTables: [] as unknown[],
+    updates: [] as Array<{ table: unknown; set: Record<string, unknown> }>,
+  };
+  return {
+    __state: state,
+    db: {
+      select: jest.fn(() => ({
+        from: jest.fn((table: unknown) => ({
+          where: jest.fn(() =>
+            Promise.resolve(state.selectByTable.get(table) ?? []),
+          ),
+        })),
+      })),
+      delete: jest.fn((table: unknown) => {
+        state.deletedTables.push(table);
+        return { where: jest.fn(() => Promise.resolve()) };
+      }),
+      update: jest.fn((table: unknown) => ({
+        set: jest.fn((values: Record<string, unknown>) => {
+          state.updates.push({ table, set: values });
+          return { where: jest.fn(() => Promise.resolve()) };
+        }),
+      })),
+    },
+  };
+});
+
+import { ChannelService } from '../../channels/services/channel.service';
+import { GoogleCalendarService } from '../../channels/services/google-calendar.service';
+import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
+import { PostService } from '../../posts/services/post.service';
+import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
+import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
+import { posts } from '../../drizzle/schema/posts.schema';
+import { scheduledInboxMessages } from '../../drizzle/schema/scheduled-inbox-messages.schema';
+import { calendarItemLinks } from '../../drizzle/schema/calendar-sync.schema';
+import { NormalizedExternalEvent } from '../providers/delta.types';
+import { contentHash, messageToEventInput } from '../calendar-sync.mapper';
+import { CalendarPushSyncService } from './calendar-push-sync.service';
+import { CalendarPullSyncService } from './calendar-pull-sync.service';
+
+const dbMock = jest.requireMock('../../drizzle/db') as unknown as {
+  __state: {
+    selectByTable: Map<unknown, unknown[]>;
+    deletedTables: unknown[];
+    updates: Array<{ table: unknown; set: Record<string, unknown> }>;
+  };
+};
+
+// The private write-back entry point under test.
+interface PullSyncInternals {
+  applyOwnedChange(
+    channel: unknown,
+    event: NormalizedExternalEvent,
+  ): Promise<void>;
+}
+
+const CHANNEL = {
+  id: 42,
+  workspaceId: 'ws-1',
+  platform: 'google_calendar',
+  isActive: true,
+  connectionStatus: 'connected',
+};
+
+// Far enough out that MIN_RESCHEDULE_LEAD_MS (2 min) is comfortably satisfied.
+const ORIGINAL_AT = new Date(Date.now() + 24 * 60 * 60 * 1000);
+const MOVED_TO = new Date(Date.now() + 48 * 60 * 60 * 1000);
+const APP_UPDATED_AT = new Date(Date.now() - 60 * 60 * 1000);
+const EXTERNAL_UPDATED_AT = new Date(Date.now() - 60 * 1000); // newer than the app → apply_external
+
+const POST_LINK = {
+  id: 'link-1',
+  workspaceId: 'ws-1',
+  channelId: 42,
+  provider: 'google',
+  postId: 'post-1',
+  messageId: null,
+  externalEventId: 'evt-post',
+  externalCalendarId: 'primary',
+  etag: 'etag-ours',
+  lastPushedHash: 'hash-ours',
+  lastExternalUpdatedAt: null,
+  syncStatus: 'synced',
+  lastError: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const MESSAGE_LINK = {
+  ...POST_LINK,
+  id: 'link-2',
+  postId: null,
+  messageId: 'msg-1',
+  externalEventId: 'evt-msg',
+};
+
+const SCHEDULED_POST = {
+  id: 'post-1',
+  workspaceId: 'ws-1',
+  createdById: 'user-1',
+  content: 'hello world',
+  status: 'scheduled',
+  scheduledAt: ORIGINAL_AT,
+  updatedAt: APP_UPDATED_AT,
+};
+
+const PENDING_MESSAGE = {
+  id: 'msg-1',
+  workspaceId: 'ws-1',
+  channelId: 42,
+  text: 'thanks for the kind words!',
+  targetLabel: '@alex',
+  status: 'pending',
+  scheduledAt: ORIGINAL_AT,
+  updatedAt: APP_UPDATED_AT,
+};
+
+/** An inbound MOVE of an event we own: newer than the app, new start, new etag. */
+function movedEvent(
+  externalEventId: string,
+  startsAt: Date = MOVED_TO,
+): NormalizedExternalEvent {
+  return {
+    externalEventId,
+    calendarId: 'primary',
+    title: 'whatever the user renamed it to',
+    startsAt,
+    endsAt: new Date(startsAt.getTime() + 30 * 60 * 1000),
+    isAllDay: false,
+    externalUpdatedAt: EXTERNAL_UPDATED_AT,
+    isOurs: true,
+    etag: 'etag-theirs',
+    raw: {},
+  };
+}
+
+/** The `set` payloads of every UPDATE against `calendar_item_links`. */
+function linkUpdates(): Array<Record<string, unknown>> {
+  return dbMock.__state.updates
+    .filter((u) => u.table === calendarItemLinks)
+    .map((u) => u.set);
+}
+
+describe('CalendarPullSyncService — owned-event dispatch (post vs scheduled message)', () => {
+  let internals: PullSyncInternals;
+  let updatePost: jest.Mock;
+  let updateFromCalendar: jest.Mock;
+  let cancelFromCalendar: jest.Mock;
+  let syncPost: jest.Mock;
+  let syncMessage: jest.Mock;
+
+  function seed(link: Record<string, unknown>) {
+    dbMock.__state.selectByTable.set(socialMediaChannels, [CHANNEL]);
+    dbMock.__state.selectByTable.set(calendarItemLinks, [link]);
+    dbMock.__state.selectByTable.set(posts, [SCHEDULED_POST]);
+    dbMock.__state.selectByTable.set(scheduledInboxMessages, [PENDING_MESSAGE]);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbMock.__state.selectByTable.clear();
+    dbMock.__state.deletedTables.length = 0;
+    dbMock.__state.updates.length = 0;
+
+    updatePost = jest.fn().mockResolvedValue(SCHEDULED_POST);
+    updateFromCalendar = jest.fn().mockResolvedValue({});
+    cancelFromCalendar = jest.fn().mockResolvedValue({ success: true });
+    syncPost = jest.fn().mockResolvedValue(undefined);
+    syncMessage = jest.fn().mockResolvedValue(undefined);
+
+    internals = new CalendarPullSyncService(
+      {
+        getAccessToken: jest.fn().mockResolvedValue('tok'),
+      } as unknown as ChannelService,
+      {} as GoogleCalendarService,
+      {} as OutlookCalendarService,
+      { syncPost, syncMessage } as unknown as CalendarPushSyncService,
+      { updatePost } as unknown as PostService,
+      {
+        updateFromCalendar,
+        cancelFromCalendar,
+      } as unknown as ScheduledMessagesService,
+    ) as unknown as PullSyncInternals;
+  });
+
+  // ===========================================================================
+  // Post arc (LIVE behaviour — must be unchanged)
+  // ===========================================================================
+
+  it('routes a moved POST event to PostService.updatePost (never to the message path)', async () => {
+    seed(POST_LINK);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-post'));
+
+    expect(updatePost).toHaveBeenCalledTimes(1);
+    expect(updatePost).toHaveBeenCalledWith('post-1', 'ws-1', 'user-1', {
+      scheduledAt: MOVED_TO,
+    });
+    expect(updateFromCalendar).not.toHaveBeenCalled();
+    expect(cancelFromCalendar).not.toHaveBeenCalled();
+  });
+
+  // ===========================================================================
+  // Message arc
+  // ===========================================================================
+
+  it('routes a moved MESSAGE event to ScheduledMessagesService.updateFromCalendar (re-arms the BullMQ job)', async () => {
+    seed(MESSAGE_LINK);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-msg'));
+
+    expect(updateFromCalendar).toHaveBeenCalledTimes(1);
+    expect(updateFromCalendar).toHaveBeenCalledWith('ws-1', 'msg-1', {
+      scheduledAt: MOVED_TO.toISOString(),
+    });
+    expect(updatePost).not.toHaveBeenCalled();
+  });
+
+  it('pre-stamps the link with the MESSAGE body hash so the follow-up push is a no-op (echo suppression)', async () => {
+    seed(MESSAGE_LINK);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-msg'));
+
+    const expectedHash = contentHash(
+      messageToEventInput({
+        id: PENDING_MESSAGE.id,
+        workspaceId: PENDING_MESSAGE.workspaceId,
+        text: PENDING_MESSAGE.text,
+        targetLabel: PENDING_MESSAGE.targetLabel,
+        scheduledAt: MOVED_TO,
+      }),
+    );
+
+    const [stamp] = linkUpdates();
+    expect(stamp).toMatchObject({
+      etag: 'etag-theirs',
+      lastPushedHash: expectedHash,
+      syncStatus: 'synced',
+    });
+    // The stamp must land BEFORE the app-side update runs, or the push inside it
+    // would see a stale hash and bounce the change back to the provider.
+    expect(updateFromCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reschedule a non-pending message — it reconciles the stale event away instead', async () => {
+    seed(MESSAGE_LINK);
+    dbMock.__state.selectByTable.set(scheduledInboxMessages, [
+      { ...PENDING_MESSAGE, status: 'sent' },
+    ]);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-msg'));
+
+    expect(updateFromCalendar).not.toHaveBeenCalled();
+    expect(syncMessage).toHaveBeenCalledWith('msg-1');
+  });
+
+  it('rejects a MESSAGE move that lands inside the 2-minute lead window', async () => {
+    seed(MESSAGE_LINK);
+    const tooSoon = new Date(Date.now() + 30 * 1000);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-msg', tooSoon));
+
+    expect(updateFromCalendar).not.toHaveBeenCalled();
+    expect(linkUpdates().some((set) => set.syncStatus === 'error')).toBe(true);
+  });
+
+  it('skips the echo of our OWN write (matching etag) for a message link', async () => {
+    seed(MESSAGE_LINK);
+    const echo = { ...movedEvent('evt-msg'), etag: 'etag-ours' };
+
+    await internals.applyOwnedChange(CHANNEL, echo);
+
+    expect(updateFromCalendar).not.toHaveBeenCalled();
+    expect(syncMessage).not.toHaveBeenCalled();
+    expect(linkUpdates()).toHaveLength(0);
+  });
+
+  it('drops the link when the linked message no longer exists', async () => {
+    seed(MESSAGE_LINK);
+    dbMock.__state.selectByTable.set(scheduledInboxMessages, []);
+
+    await internals.applyOwnedChange(CHANNEL, movedEvent('evt-msg'));
+
+    expect(updateFromCalendar).not.toHaveBeenCalled();
+    expect(dbMock.__state.deletedTables).toEqual([calendarItemLinks]);
+  });
+});

--- a/src/calendar-sync/services/calendar-pull-sync.reconcile.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.reconcile.spec.ts
@@ -48,6 +48,7 @@ import { ChannelService } from '../../channels/services/channel.service';
 import { GoogleCalendarService } from '../../channels/services/google-calendar.service';
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { PostService } from '../../posts/services/post.service';
+import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import {
   calendarSyncState,
@@ -140,8 +141,15 @@ describe('CalendarPullSyncService.reconcile', () => {
       channelService,
       googleCalendarService,
       {} as OutlookCalendarService,
-      { syncPost: jest.fn() } as unknown as CalendarPushSyncService,
+      {
+        syncPost: jest.fn(),
+        syncMessage: jest.fn(),
+      } as unknown as CalendarPushSyncService,
       { updatePost: jest.fn() } as unknown as PostService,
+      {
+        updateFromCalendar: jest.fn(),
+        cancelFromCalendar: jest.fn(),
+      } as unknown as ScheduledMessagesService,
     );
   });
 

--- a/src/calendar-sync/services/calendar-pull-sync.service.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.service.ts
@@ -4,8 +4,12 @@ import { db } from '../../drizzle/db';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import { posts } from '../../drizzle/schema/posts.schema';
 import {
-  calendarPostLinks,
-  CalendarPostLink,
+  scheduledInboxMessages,
+  type ScheduledInboxMessage,
+} from '../../drizzle/schema/scheduled-inbox-messages.schema';
+import {
+  calendarItemLinks,
+  CalendarItemLink,
   calendarSyncState,
   CalendarSyncStateRow,
   externalCalendarEvents,
@@ -19,6 +23,7 @@ import {
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { CalendarPreconditionFailedError } from '../../channels/services/calendar-precondition.error';
 import { PostService } from '../../posts/services/post.service';
+import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
 import { fetchGoogleCalendarDelta } from '../providers/google-delta.util';
 import { fetchOutlookCalendarDelta } from '../providers/outlook-delta.util';
 import {
@@ -28,7 +33,12 @@ import {
   fullSyncWindow,
 } from '../providers/delta.types';
 import { ConflictEvent, resolveConflict } from '../calendar-conflict';
-import { contentHash, postToEventInput } from '../calendar-sync.mapper';
+import {
+  EventInput,
+  contentHash,
+  messageToEventInput,
+  postToEventInput,
+} from '../calendar-sync.mapper';
 import { CalendarPushSyncService } from './calendar-push-sync.service';
 
 // Calendar channel platforms that participate in the pull (external import).
@@ -40,8 +50,17 @@ type CalendarChannel = typeof socialMediaChannels.$inferSelect;
 type Post = typeof posts.$inferSelect;
 
 /**
- * Same guard the calendar UI applies when a user drags a post: a reschedule must
- * land in the future with enough lead time for the publish job to be queued.
+ * The app-side item a link points at. Exactly one arc of `calendar_item_links`
+ * is populated, so a loaded link resolves to exactly one of these.
+ */
+type LinkedItem =
+  | { kind: 'post'; post: Post }
+  | { kind: 'message'; message: ScheduledInboxMessage };
+
+/**
+ * Same guard the calendar UI applies when a user drags a post or a scheduled
+ * reply: a reschedule must land in the future with enough lead time for the
+ * publish/send job to be queued. (Matches `ScheduledMessagesService.MIN_LEAD_MS`.)
  */
 const MIN_RESCHEDULE_LEAD_MS = 2 * 60 * 1000; // 2 minutes
 
@@ -83,11 +102,13 @@ interface CalendarWriteService {
  * (Google `syncToken` / Graph `deltaLink`) on `calendar_sync_state`, and falls
  * back to a bounded full list whenever the provider rejects the stored cursor.
  *
- * Events carrying our ownership tag (`schedura_post_id`) are the two-way
- * write-back surface (Task D): each one is matched to its `calendar_post_links`
- * row, run through the pure `resolveConflict()` engine, and applied — an
- * external MOVE reschedules the post, an external DELETE sends it back to draft
- * (never a hard delete), and an app-newer edit is re-pushed to the provider.
+ * Events carrying one of our ownership tags (`schedura_post_id` /
+ * `schedura_message_id`) are the two-way write-back surface (Task D): each one is
+ * matched to its `calendar_item_links` row, run through the pure
+ * `resolveConflict()` engine, and applied — an external MOVE reschedules the
+ * linked item, an external DELETE unschedules a post (→ draft) or CANCELS a
+ * scheduled message, and an app-newer edit is re-pushed to the provider. Neither
+ * a post nor a message is ever hard-deleted.
  *
  * `reconcile()` never throws: it is driven by BullMQ/webhooks where one broken
  * connection must not stall the others. Every per-event apply is likewise
@@ -106,6 +127,9 @@ export class CalendarPullSyncService {
     // calendars, calendars write back to posts) → forwardRef.
     @Inject(forwardRef(() => PostService))
     private readonly postService: PostService,
+    // InboxModule ↔ CalendarSyncModule is circular for the same reason.
+    @Inject(forwardRef(() => ScheduledMessagesService))
+    private readonly scheduledMessages: ScheduledMessagesService,
   ) {}
 
   /**
@@ -238,10 +262,10 @@ export class CalendarPullSyncService {
     delta: CalendarDeltaResult,
   ): Promise<string[]> {
     // AUTHORITATIVE ownership check: an event is OURS when a
-    // `calendar_post_links` row points at it, regardless of what the provider
+    // `calendar_item_links` row points at it, regardless of what the provider
     // payload says. This is not merely defence-in-depth — for Outlook it is the
     // ONLY signal, because Graph refuses `$expand` on its delta endpoints and so
-    // never returns our MAPI ownership tag (`isOurs` is always false there).
+    // never returns our MAPI ownership tags (`isOurs` is always false there).
     // Without this an event we wrote would be re-imported as an "external" event
     // and shown twice.
     const linkedIds = await this.loadLinkedEventIds(
@@ -281,12 +305,15 @@ export class CalendarPullSyncService {
   }
 
   // ==========================================================================
-  // Two-way write-back (events carrying our `schedura_post_id` tag)
+  // Two-way write-back (events carrying one of our ownership tags)
   // ==========================================================================
 
   /**
    * Apply one inbound change to an event WE wrote. Isolated: any failure is
    * logged and swallowed so the rest of the delta still applies.
+   *
+   * The link decides which app-side item the event belongs to (post OR scheduled
+   * message — an exclusive arc), and every branch below dispatches on that.
    */
   private async applyOwnedChange(
     channel: CalendarChannel,
@@ -303,9 +330,9 @@ export class CalendarPullSyncService {
         return;
       }
 
-      const post = await this.loadPost(link.postId);
-      if (!post) {
-        // Post is gone (hard-deleted elsewhere) → the link is dead weight.
+      const item = await this.loadItem(link);
+      if (!item) {
+        // The item is gone (hard-deleted elsewhere) → the link is dead weight.
         await this.deleteLink(link.id);
         return;
       }
@@ -313,21 +340,21 @@ export class CalendarPullSyncService {
       const decision = resolveConflict({
         link,
         event: toConflictEvent(event),
-        post,
+        post: toConflictItem(item),
       });
 
       switch (decision) {
         case 'skip_echo':
         case 'noop':
           this.logger.debug(
-            `Conflict for post ${post.id} on channel ${channel.id}: ${decision}`,
+            `Conflict for ${describeItem(item)} on channel ${channel.id}: ${decision}`,
           );
           return;
         case 'apply_external':
-          await this.applyExternalMove(channel, link, post, event);
+          await this.applyExternalMove(channel, link, item, event);
           return;
         case 'repush_app':
-          await this.repushApp(channel, link, post, event.externalUpdatedAt);
+          await this.repushApp(channel, link, item, event.externalUpdatedAt);
           return;
       }
     } catch (error) {
@@ -339,8 +366,8 @@ export class CalendarPullSyncService {
   }
 
   /**
-   * Tombstones: any deleted event that is one of OURS unschedules its post back
-   * to draft. The post itself is NEVER deleted.
+   * Tombstones: a deleted event that is one of OURS unschedules its post back to
+   * draft, or CANCELS its scheduled message. Neither row is ever deleted.
    */
   private async applyOwnedDeletions(
     channel: CalendarChannel,
@@ -349,11 +376,11 @@ export class CalendarPullSyncService {
     for (const chunk of chunkIds(deletedIds, 200)) {
       const links = await db
         .select()
-        .from(calendarPostLinks)
+        .from(calendarItemLinks)
         .where(
           and(
-            eq(calendarPostLinks.channelId, channel.id),
-            inArray(calendarPostLinks.externalEventId, chunk),
+            eq(calendarItemLinks.channelId, channel.id),
+            inArray(calendarItemLinks.externalEventId, chunk),
           ),
         );
 
@@ -364,7 +391,7 @@ export class CalendarPullSyncService {
           const message =
             error instanceof Error ? error.message : String(error);
           this.logger.warn(
-            `External-delete write-back failed for post ${link.postId} on channel ${channel.id}: ${message}`,
+            `External-delete write-back failed for ${describeLink(link)} on channel ${channel.id}: ${message}`,
           );
         }
       }
@@ -372,13 +399,17 @@ export class CalendarPullSyncService {
   }
 
   /**
-   * External DELETE → the post goes back to draft/unscheduled via PostService's
-   * existing `updatePost({ scheduledAt: null })` path (which also cancels the
-   * queued publish job). NEVER a hard delete.
+   * External DELETE →
+   *   - post:    back to draft/unscheduled via PostService's existing
+   *              `updatePost({ scheduledAt: null })` path (which also cancels the
+   *              queued publish job).
+   *   - message: CANCELLED via ScheduledMessagesService's existing cancel path
+   *              (status → 'cancelled' + the BullMQ delayed job removed).
+   * NEVER a hard delete of either row.
    */
-  private async applyExternalDelete(link: CalendarPostLink): Promise<void> {
-    const post = await this.loadPost(link.postId);
-    if (!post) {
+  private async applyExternalDelete(link: CalendarItemLink): Promise<void> {
+    const item = await this.loadItem(link);
+    if (!item) {
       await this.deleteLink(link.id);
       return;
     }
@@ -387,25 +418,41 @@ export class CalendarPullSyncService {
     const decision = resolveConflict({
       link,
       event: { deleted: true },
-      post,
+      post: toConflictItem(item),
     });
     if (decision !== 'apply_external') {
       return;
     }
 
-    if (post.status === 'scheduled') {
-      // Reuses the existing unschedule path: status → 'draft', scheduledAt
-      // cleared, BullMQ publish job cancelled. Its fire-and-forget calendar push
-      // then removes the (now stale) events + links on every calendar.
-      await this.postService.updatePost(
-        post.id,
-        post.workspaceId,
-        post.createdById,
-        { scheduledAt: null },
-      );
-      this.logger.log(
-        `Post ${post.id} unscheduled → draft (its calendar event was deleted externally)`,
-      );
+    if (item.kind === 'post') {
+      const post = item.post;
+      if (post.status === 'scheduled') {
+        // Reuses the existing unschedule path: status → 'draft', scheduledAt
+        // cleared, BullMQ publish job cancelled. Its fire-and-forget calendar
+        // push then removes the (now stale) events + links on every calendar.
+        await this.postService.updatePost(
+          post.id,
+          post.workspaceId,
+          post.createdById,
+          { scheduledAt: null },
+        );
+        this.logger.log(
+          `Post ${post.id} unscheduled → draft (its calendar event was deleted externally)`,
+        );
+      }
+    } else {
+      const message = item.message;
+      if (message.status === 'pending') {
+        // Reuses ScheduledMessagesService's cancel path (BullMQ delayed job
+        // removed + status → 'cancelled' + realtime event). Never a hard delete.
+        await this.scheduledMessages.cancelFromCalendar(
+          message.workspaceId,
+          message.id,
+        );
+        this.logger.log(
+          `Scheduled message ${message.id} cancelled (its calendar event was deleted externally)`,
+        );
+      }
     }
 
     // Idempotent: the push path above may already have dropped it.
@@ -413,24 +460,27 @@ export class CalendarPullSyncService {
   }
 
   /**
-   * External MOVE → reschedule the post to the event's start via PostService's
-   * existing `updatePost({ scheduledAt })` path.
+   * External MOVE → reschedule the linked item to the event's start through its
+   * EXISTING app-side reschedule path (`PostService.updatePost({ scheduledAt })`
+   * for posts, `ScheduledMessagesService.updateFromCalendar({ scheduledAt })` for
+   * messages — the latter also re-arms the BullMQ delayed send job).
    *
    * Echo suppression: the link is stamped with the inbound etag AND the hash of
-   * what we WOULD have pushed for the new time BEFORE the post update runs, so
-   * the fire-and-forget push inside `updatePost` sees an unchanged hash and
-   * skips the provider write entirely (no ping-pong, no 412 from a stale etag).
+   * what we WOULD have pushed for the new time BEFORE the app update runs, so the
+   * fire-and-forget push inside that update sees an unchanged hash and skips the
+   * provider write entirely (no ping-pong, no 412 from a stale etag).
    */
   private async applyExternalMove(
     channel: CalendarChannel,
-    link: CalendarPostLink,
-    post: Post,
+    link: CalendarItemLink,
+    item: LinkedItem,
     event: ConflictEvent,
   ): Promise<void> {
-    // The post is no longer schedulable (published/failed/draft) → the event is
-    // stale. Let the push service reconcile it away instead of rescheduling.
-    if (post.status !== 'scheduled') {
-      await this.pushSync.syncPost(post.id);
+    // The item is no longer schedulable (published/failed/draft, or a message
+    // that is sending/sent/failed/cancelled) → the event is stale. Let the push
+    // service reconcile it away instead of rescheduling.
+    if (!isSchedulable(item)) {
+      await this.resyncItem(item);
       return;
     }
 
@@ -438,28 +488,21 @@ export class CalendarPullSyncService {
     if (!newStart) return;
 
     // Same rule as the calendar drag-reschedule: must be far enough in the
-    // future for the publish job. A violating move is NOT applied — we surface it
-    // and re-push the app's real time so the calendar stops lying.
+    // future for the publish/send job. A violating move is NOT applied — we
+    // surface it and re-push the app's real time so the calendar stops lying.
     if (newStart.getTime() - Date.now() < MIN_RESCHEDULE_LEAD_MS) {
       this.logger.warn(
-        `Rejecting external move of post ${post.id} to ${newStart.toISOString()}: must be at least 2 minutes in the future — re-pushing the app's schedule`,
+        `Rejecting external move of ${describeItem(item)} to ${newStart.toISOString()}: must be at least 2 minutes in the future — re-pushing the app's schedule`,
       );
       await this.markLinkError(
         link.id,
         `External move to ${newStart.toISOString()} rejected: must be at least 2 minutes in the future`,
       );
-      await this.repushApp(channel, link, post, event.externalUpdatedAt);
+      await this.repushApp(channel, link, item, event.externalUpdatedAt);
       return;
     }
 
-    const pushedHash = contentHash(
-      postToEventInput({
-        id: post.id,
-        workspaceId: post.workspaceId,
-        content: post.content,
-        scheduledAt: newStart,
-      }),
-    );
+    const pushedHash = contentHash(eventInputFor(item, newStart));
 
     // Stamp the link FIRST (see the doc comment above — this is what makes the
     // subsequent push a no-op instead of an echo).
@@ -472,17 +515,25 @@ export class CalendarPullSyncService {
     });
 
     try {
-      await this.postService.updatePost(
-        post.id,
-        post.workspaceId,
-        post.createdById,
-        { scheduledAt: newStart },
-      );
+      if (item.kind === 'post') {
+        await this.postService.updatePost(
+          item.post.id,
+          item.post.workspaceId,
+          item.post.createdById,
+          { scheduledAt: newStart },
+        );
+      } else {
+        await this.scheduledMessages.updateFromCalendar(
+          item.message.workspaceId,
+          item.message.id,
+          { scheduledAt: newStart.toISOString() },
+        );
+      }
       this.logger.log(
-        `Post ${post.id} rescheduled to ${newStart.toISOString()} from an external calendar move (channel ${channel.id})`,
+        `${describeItem(item)} rescheduled to ${newStart.toISOString()} from an external calendar move (channel ${channel.id})`,
       );
     } catch (error) {
-      // The post did not move → roll the link back so the next reconcile retries
+      // The item did not move → roll the link back so the next reconcile retries
       // rather than silently believing the two sides agree.
       const message = error instanceof Error ? error.message : String(error);
       await this.updateLink(link.id, {
@@ -493,13 +544,13 @@ export class CalendarPullSyncService {
         lastError: message.slice(0, 1000),
       });
       this.logger.warn(
-        `Failed to apply external move to post ${post.id}: ${message}`,
+        `Failed to apply external move to ${describeItem(item)}: ${message}`,
       );
     }
   }
 
   /**
-   * App wins → rewrite the provider event from the post, guarded by
+   * App wins → rewrite the provider event from the app-side item, guarded by
    * `If-Match: link.etag`.
    *
    * On **412 Precondition Failed** the event changed under us: re-fetch it,
@@ -508,25 +559,20 @@ export class CalendarPullSyncService {
    */
   private async repushApp(
     channel: CalendarChannel,
-    link: CalendarPostLink,
-    post: Post,
+    link: CalendarItemLink,
+    item: LinkedItem,
     externalUpdatedAt: Date | null | undefined,
     allowRefetch = true,
   ): Promise<void> {
     // Not schedulable anymore → the event should not exist at all; the push
     // service removes it (and the link) rather than us rewriting it.
-    if (post.status !== 'scheduled' || !post.scheduledAt) {
-      await this.pushSync.syncPost(post.id);
+    if (!isSchedulable(item)) {
+      await this.resyncItem(item);
       return;
     }
 
     const service = this.writeServiceFor(channel.platform as CalendarPlatform);
-    const eventInput = postToEventInput({
-      id: post.id,
-      workspaceId: post.workspaceId,
-      content: post.content,
-      scheduledAt: post.scheduledAt,
-    });
+    const eventInput = eventInputFor(item);
     const hash = contentHash(eventInput);
 
     const accessToken = await this.channelService.getAccessToken(
@@ -559,19 +605,19 @@ export class CalendarPullSyncService {
         lastError: null,
       });
       this.logger.log(
-        `Re-pushed post ${post.id}'s schedule over an older external edit (channel ${channel.id})`,
+        `Re-pushed ${describeItem(item)}'s schedule over an older external edit (channel ${channel.id})`,
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
       if (error instanceof CalendarPreconditionFailedError && allowRefetch) {
-        await this.resolveAfterPrecondition(channel, link, post, service);
+        await this.resolveAfterPrecondition(channel, link, item, service);
         return;
       }
 
       await this.markLinkError(link.id, message);
       this.logger.warn(
-        `Re-push failed for post ${post.id} on channel ${channel.id}: ${message}`,
+        `Re-push failed for ${describeItem(item)} on channel ${channel.id}: ${message}`,
       );
     }
   }
@@ -583,8 +629,8 @@ export class CalendarPullSyncService {
    */
   private async resolveAfterPrecondition(
     channel: CalendarChannel,
-    link: CalendarPostLink,
-    post: Post,
+    link: CalendarItemLink,
+    item: LinkedItem,
     service: CalendarWriteService,
   ): Promise<void> {
     const accessToken = await this.channelService.getAccessToken(
@@ -597,14 +643,18 @@ export class CalendarPullSyncService {
       link.externalCalendarId ?? 'primary',
     );
     const freshEvent = toConflictEventFromProvider(fresh);
-    const freshLink: CalendarPostLink = {
+    const freshLink: CalendarItemLink = {
       ...link,
       etag: freshEvent.etag ?? link.etag,
     };
 
-    const decision = resolveConflict({ link, event: freshEvent, post });
+    const decision = resolveConflict({
+      link,
+      event: freshEvent,
+      post: toConflictItem(item),
+    });
     this.logger.debug(
-      `412 on post ${post.id} (channel ${channel.id}) → re-resolved as ${decision}`,
+      `412 on ${describeItem(item)} (channel ${channel.id}) → re-resolved as ${decision}`,
     );
 
     switch (decision) {
@@ -620,14 +670,14 @@ export class CalendarPullSyncService {
         });
         return;
       case 'apply_external':
-        await this.applyExternalMove(channel, freshLink, post, freshEvent);
+        await this.applyExternalMove(channel, freshLink, item, freshEvent);
         return;
       case 'repush_app':
         // ONE more attempt, now with the live etag. A 412 here → error + move on.
         await this.repushApp(
           channel,
           freshLink,
-          post,
+          item,
           freshEvent.externalUpdatedAt,
           false,
         );
@@ -636,28 +686,65 @@ export class CalendarPullSyncService {
   }
 
   // ==========================================================================
-  // Link + post helpers
+  // Link + item helpers
   // ==========================================================================
 
   private async loadLink(
     channelId: number,
     externalEventId: string,
-  ): Promise<CalendarPostLink | undefined> {
+  ): Promise<CalendarItemLink | undefined> {
     const [link] = await db
       .select()
-      .from(calendarPostLinks)
+      .from(calendarItemLinks)
       .where(
         and(
-          eq(calendarPostLinks.channelId, channelId),
-          eq(calendarPostLinks.externalEventId, externalEventId),
+          eq(calendarItemLinks.channelId, channelId),
+          eq(calendarItemLinks.externalEventId, externalEventId),
         ),
       );
     return link;
   }
 
+  /**
+   * Resolve a link's exclusive arc to the app-side row it points at. Returns
+   * null when that row no longer exists (→ the link is dead weight).
+   */
+  private async loadItem(link: CalendarItemLink): Promise<LinkedItem | null> {
+    if (link.postId) {
+      const post = await this.loadPost(link.postId);
+      return post ? { kind: 'post', post } : null;
+    }
+    if (link.messageId) {
+      const message = await this.loadMessage(link.messageId);
+      return message ? { kind: 'message', message } : null;
+    }
+    // Unreachable while `cil_exactly_one_owner` holds; treat as dead weight.
+    this.logger.warn(`Link ${link.id} has neither post_id nor message_id`);
+    return null;
+  }
+
   private async loadPost(postId: string): Promise<Post | undefined> {
     const [post] = await db.select().from(posts).where(eq(posts.id, postId));
     return post;
+  }
+
+  private async loadMessage(
+    messageId: string,
+  ): Promise<ScheduledInboxMessage | undefined> {
+    const [message] = await db
+      .select()
+      .from(scheduledInboxMessages)
+      .where(eq(scheduledInboxMessages.id, messageId));
+    return message;
+  }
+
+  /** Re-run the push side for an item that should no longer have an event. */
+  private async resyncItem(item: LinkedItem): Promise<void> {
+    if (item.kind === 'post') {
+      await this.pushSync.syncPost(item.post.id);
+    } else {
+      await this.pushSync.syncMessage(item.message.id);
+    }
   }
 
   private async updateLink(
@@ -671,9 +758,9 @@ export class CalendarPullSyncService {
     }>,
   ): Promise<void> {
     await db
-      .update(calendarPostLinks)
+      .update(calendarItemLinks)
       .set({ ...set, updatedAt: new Date() })
-      .where(eq(calendarPostLinks.id, linkId));
+      .where(eq(calendarItemLinks.id, linkId));
   }
 
   private async markLinkError(linkId: string, message: string): Promise<void> {
@@ -684,7 +771,7 @@ export class CalendarPullSyncService {
   }
 
   private async deleteLink(linkId: string): Promise<void> {
-    await db.delete(calendarPostLinks).where(eq(calendarPostLinks.id, linkId));
+    await db.delete(calendarItemLinks).where(eq(calendarItemLinks.id, linkId));
   }
 
   private writeServiceFor(platform: CalendarPlatform): CalendarWriteService {
@@ -769,7 +856,7 @@ export class CalendarPullSyncService {
 
   /**
    * External event ids of this channel that are already linked to one of our
-   * posts (i.e. events WE wrote).
+   * items — a post OR a scheduled message (i.e. events WE wrote).
    */
   private async loadLinkedEventIds(
     channelId: number,
@@ -780,12 +867,12 @@ export class CalendarPullSyncService {
     const found = new Set<string>();
     for (const chunk of chunkIds(externalEventIds, 200)) {
       const rows = await db
-        .select({ externalEventId: calendarPostLinks.externalEventId })
-        .from(calendarPostLinks)
+        .select({ externalEventId: calendarItemLinks.externalEventId })
+        .from(calendarItemLinks)
         .where(
           and(
-            eq(calendarPostLinks.channelId, channelId),
-            inArray(calendarPostLinks.externalEventId, chunk),
+            eq(calendarItemLinks.channelId, channelId),
+            inArray(calendarItemLinks.externalEventId, chunk),
           ),
         );
       for (const row of rows) found.add(row.externalEventId);
@@ -929,6 +1016,67 @@ export class CalendarPullSyncService {
       .set(set)
       .where(eq(calendarSyncState.id, stateId));
   }
+}
+
+// ============================================================================
+// Item helpers (pure) — the post/message dispatch table in one place.
+// ============================================================================
+
+/** Only a still-scheduled item may carry a live calendar event. */
+function isSchedulable(item: LinkedItem): boolean {
+  return item.kind === 'post'
+    ? item.post.status === 'scheduled' && !!item.post.scheduledAt
+    : item.message.status === 'pending' && !!item.message.scheduledAt;
+}
+
+/**
+ * The event body we WOULD push for this item (optionally at an overridden start,
+ * used to pre-compute the echo-suppression hash before an external move lands).
+ */
+function eventInputFor(item: LinkedItem, startOverride?: Date): EventInput {
+  if (item.kind === 'post') {
+    return postToEventInput({
+      id: item.post.id,
+      workspaceId: item.post.workspaceId,
+      content: item.post.content,
+      scheduledAt: startOverride ?? item.post.scheduledAt,
+    });
+  }
+  return messageToEventInput({
+    id: item.message.id,
+    workspaceId: item.message.workspaceId,
+    text: item.message.text,
+    targetLabel: item.message.targetLabel,
+    scheduledAt: startOverride ?? item.message.scheduledAt,
+  });
+}
+
+/**
+ * The two fields the pure conflict engine needs from the app-side item
+ * (`ConflictPost` is the historical name; it covers messages just the same).
+ */
+function toConflictItem(item: LinkedItem): {
+  updatedAt: Date | null;
+  scheduledAt: Date | null;
+} {
+  return item.kind === 'post'
+    ? { updatedAt: item.post.updatedAt, scheduledAt: item.post.scheduledAt }
+    : {
+        updatedAt: item.message.updatedAt,
+        scheduledAt: item.message.scheduledAt,
+      };
+}
+
+function describeItem(item: LinkedItem): string {
+  return item.kind === 'post'
+    ? `post ${item.post.id}`
+    : `scheduled message ${item.message.id}`;
+}
+
+function describeLink(link: CalendarItemLink): string {
+  return link.postId
+    ? `post ${link.postId}`
+    : `scheduled message ${link.messageId}`;
 }
 
 /** Delta event → the pure conflict engine's input shape. */

--- a/src/calendar-sync/services/calendar-push-sync.service.ts
+++ b/src/calendar-sync/services/calendar-push-sync.service.ts
@@ -1,14 +1,15 @@
 import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
-import { and, eq, gt, inArray } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { db } from '../../drizzle/db';
 import { posts } from '../../drizzle/schema/posts.schema';
+import { scheduledInboxMessages } from '../../drizzle/schema/scheduled-inbox-messages.schema';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import { workspace } from '../../drizzle/schema/workspace.schema';
 import { workspaceInvitation } from '../../drizzle/schema/workspace-invitation.schema';
 import {
-  calendarPostLinks,
-  CalendarPostLink,
-  NewCalendarPostLink,
+  calendarItemLinks,
+  CalendarItemLink,
+  NewCalendarItemLink,
 } from '../../drizzle/schema/calendar-sync.schema';
 import { ChannelService } from '../../channels/services/channel.service';
 import {
@@ -18,7 +19,12 @@ import {
   Calendar,
 } from '../../channels/services/google-calendar.service';
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
-import { contentHash, postToEventInput } from '../calendar-sync.mapper';
+import {
+  EventInput,
+  contentHash,
+  messageToEventInput,
+  postToEventInput,
+} from '../calendar-sync.mapper';
 
 // Calendar channel platforms that participate in app→calendar push.
 const CALENDAR_PLATFORMS = ['google_calendar', 'outlook_calendar'] as const;
@@ -48,12 +54,22 @@ interface CalendarProviderService {
 type CalendarChannel = typeof socialMediaChannels.$inferSelect;
 
 /**
+ * Which app-side item a link/event belongs to. EXACTLY one arc is set, mirroring
+ * the `cil_exactly_one_owner` CHECK on `calendar_item_links`.
+ */
+type ItemRef =
+  | { kind: 'post'; postId: string }
+  | { kind: 'message'; messageId: string };
+
+/**
  * CalendarPushSyncService — app→calendar push.
  *
- * When a post is scheduled/updated/unscheduled/deleted, upserts or removes the
- * matching event on every connected calendar of the post's workspace, tagging
- * our events with ownership private props and maintaining `calendar_post_links`
- * (etag + lastPushedHash for later two-way echo suppression).
+ * When a scheduled ITEM (a post, or a scheduled inbox message) is
+ * created/updated/unscheduled/cancelled/deleted, upserts or removes the matching
+ * event on every connected calendar of the item's workspace, tagging our events
+ * with ownership private props (`schedura_post_id` / `schedura_message_id`) and
+ * maintaining `calendar_item_links` (etag + lastPushedHash for later two-way echo
+ * suppression).
  *
  * Reuses the existing provider services + ChannelService token accessor; never
  * re-authenticates.
@@ -76,6 +92,10 @@ export class CalendarPushSyncService {
       ? { service: this.googleCalendarService, provider: 'google' }
       : { service: this.outlookCalendarService, provider: 'outlook' };
   }
+
+  // ==========================================================================
+  // Posts
+  // ==========================================================================
 
   /**
    * Upsert (or remove) the calendar event(s) for a single post across every
@@ -104,27 +124,100 @@ export class CalendarPushSyncService {
       return;
     }
 
-    const channels = await this.getWorkspaceCalendarChannels(post.workspaceId);
-    if (channels.length === 0) {
-      return;
-    }
-
     const eventInput = postToEventInput({
       id: post.id,
       workspaceId: post.workspaceId,
       content: post.content,
       scheduledAt: post.scheduledAt,
     });
+
+    await this.syncItem(
+      { kind: 'post', postId: post.id },
+      post.workspaceId,
+      eventInput,
+      primaryCalendarCache,
+    );
+  }
+
+  // ==========================================================================
+  // Scheduled inbox messages (comment replies + DMs)
+  // ==========================================================================
+
+  /**
+   * Upsert (or remove) the calendar event(s) for a single scheduled inbox
+   * message. Only `pending` future messages have events — `sending`, `sent`,
+   * `failed` and `cancelled` all resolve to "remove the event".
+   */
+  async syncMessage(
+    messageId: string,
+    primaryCalendarCache?: Map<number, string>,
+  ): Promise<void> {
+    const [message] = await db
+      .select()
+      .from(scheduledInboxMessages)
+      .where(eq(scheduledInboxMessages.id, messageId));
+    if (!message) {
+      this.logger.debug(
+        `syncMessage: scheduled message ${messageId} not found, skipping`,
+      );
+      return;
+    }
+
+    const isSchedulable =
+      message.status === 'pending' &&
+      !!message.scheduledAt &&
+      new Date(message.scheduledAt).getTime() > Date.now();
+
+    if (!isSchedulable) {
+      await this.removeMessageEvent(messageId);
+      return;
+    }
+
+    const eventInput = messageToEventInput({
+      id: message.id,
+      workspaceId: message.workspaceId,
+      text: message.text,
+      targetLabel: message.targetLabel,
+      scheduledAt: message.scheduledAt,
+    });
+
+    await this.syncItem(
+      { kind: 'message', messageId: message.id },
+      message.workspaceId,
+      eventInput,
+      primaryCalendarCache,
+    );
+  }
+
+  // ==========================================================================
+  // Shared push core
+  // ==========================================================================
+
+  /**
+   * Fan one item's event body out to every connected calendar of its workspace.
+   * Per-channel failures are isolated so one bad connection can't abort the rest.
+   */
+  private async syncItem(
+    item: ItemRef,
+    workspaceId: string,
+    eventInput: EventInput,
+    primaryCalendarCache?: Map<number, string>,
+  ): Promise<void> {
+    const channels = await this.getWorkspaceCalendarChannels(workspaceId);
+    if (channels.length === 0) {
+      return;
+    }
+
     const hash = contentHash(eventInput);
 
     for (const channel of channels) {
       // Per-channel isolation: a failure (DB hiccup, provider error) on one
       // channel must never abort the push to the remaining channels.
       try {
-        await this.syncPostToChannel(
+        await this.syncItemToChannel(
           channel,
-          post.id,
-          post.workspaceId,
+          item,
+          workspaceId,
           eventInput,
           hash,
           primaryCalendarCache,
@@ -132,17 +225,17 @@ export class CalendarPushSyncService {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.warn(
-          `Calendar push isolated failure for post ${post.id} on channel ${channel.id}: ${message}`,
+          `Calendar push isolated failure for ${describe(item)} on channel ${channel.id}: ${message}`,
         );
       }
     }
   }
 
-  private async syncPostToChannel(
+  private async syncItemToChannel(
     channel: CalendarChannel,
-    postId: string,
+    item: ItemRef,
     workspaceId: string,
-    eventInput: ReturnType<typeof postToEventInput>,
+    eventInput: EventInput,
     hash: string,
     primaryCalendarCache?: Map<number, string>,
   ): Promise<void> {
@@ -151,18 +244,13 @@ export class CalendarPushSyncService {
 
     // Keep the per-channel pre-select AND the error-recording update inside the
     // isolating try/catch so a DB hiccup here can't abort the other channels.
-    let existingLink: CalendarPostLink | undefined;
+    let existingLink: CalendarItemLink | undefined;
 
     try {
       [existingLink] = await db
         .select()
-        .from(calendarPostLinks)
-        .where(
-          and(
-            eq(calendarPostLinks.channelId, channel.id),
-            eq(calendarPostLinks.postId, postId),
-          ),
-        );
+        .from(calendarItemLinks)
+        .where(and(eq(calendarItemLinks.channelId, channel.id), ownerEq(item)));
 
       // Skip a no-op re-push (content unchanged + already synced) to avoid
       // needless writes + provider round-trips (also reduces echo churn).
@@ -194,7 +282,7 @@ export class CalendarPushSyncService {
         );
 
         await db
-          .update(calendarPostLinks)
+          .update(calendarItemLinks)
           .set({
             etag: updated.etag ?? existingLink.etag,
             lastPushedHash: hash,
@@ -202,10 +290,10 @@ export class CalendarPushSyncService {
             lastError: null,
             updatedAt: new Date(),
           })
-          .where(eq(calendarPostLinks.id, existingLink.id));
+          .where(eq(calendarItemLinks.id, existingLink.id));
       } else {
         // Resolve the channel's primary calendar id at most once per run
-        // (memoized by channelId) instead of once per post — avoids an N+1
+        // (memoized by channelId) instead of once per item — avoids an N+1
         // provider round-trip during backfill.
         let calendarId = primaryCalendarCache?.get(channel.id);
         if (!calendarId) {
@@ -221,38 +309,43 @@ export class CalendarPushSyncService {
           calendarId,
         });
 
-        const row: NewCalendarPostLink = {
+        const row: NewCalendarItemLink = {
           workspaceId,
           channelId: channel.id,
           provider,
-          postId,
+          postId: item.kind === 'post' ? item.postId : null,
+          messageId: item.kind === 'message' ? item.messageId : null,
           externalEventId: created.id,
           externalCalendarId: calendarId,
           etag: created.etag ?? null,
           lastPushedHash: hash,
           syncStatus: 'synced',
         };
-        await db.insert(calendarPostLinks).values(row);
+        await db.insert(calendarItemLinks).values(row);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(
-        `Calendar push failed for post ${postId} on channel ${channel.id} (${platform}): ${message}`,
+        `Calendar push failed for ${describe(item)} on channel ${channel.id} (${platform}): ${message}`,
       );
       // Record the failure on the link when one exists so it can be retried/
       // surfaced; a failed create has no link to annotate.
       if (existingLink) {
         await db
-          .update(calendarPostLinks)
+          .update(calendarItemLinks)
           .set({
             syncStatus: 'error',
             lastError: message.slice(0, 1000),
             updatedAt: new Date(),
           })
-          .where(eq(calendarPostLinks.id, existingLink.id));
+          .where(eq(calendarItemLinks.id, existingLink.id));
       }
     }
   }
+
+  // ==========================================================================
+  // Removal
+  // ==========================================================================
 
   /**
    * Delete the external event(s) for a post on every linked calendar and drop
@@ -262,8 +355,8 @@ export class CalendarPushSyncService {
   async removePostEvent(postId: string): Promise<void> {
     const links = await db
       .select()
-      .from(calendarPostLinks)
-      .where(eq(calendarPostLinks.postId, postId));
+      .from(calendarItemLinks)
+      .where(eq(calendarItemLinks.postId, postId));
 
     for (const link of links) {
       await this.removeLink(link);
@@ -271,14 +364,29 @@ export class CalendarPushSyncService {
   }
 
   /**
-   * Remove a single link on the UN-schedule path (post still exists, just no
-   * longer schedulable). Only drop the `calendar_post_links` row when the
+   * Same, for a scheduled inbox message. Called whenever the message stops being
+   * `pending` (cancelled / sent / failed) or its schedule is otherwise void.
+   */
+  async removeMessageEvent(messageId: string): Promise<void> {
+    const links = await db
+      .select()
+      .from(calendarItemLinks)
+      .where(eq(calendarItemLinks.messageId, messageId));
+
+    for (const link of links) {
+      await this.removeLink(link);
+    }
+  }
+
+  /**
+   * Remove a single link on the UN-schedule path (the item still exists, just no
+   * longer schedulable). Only drop the `calendar_item_links` row when the
    * provider delete succeeds OR is a confirmed 404 (deleteEvent swallows those
    * internally, so a normal return === confirmed gone). On any transient error
    * (5xx/network/token) RETAIN the link and mark it `error` so a later reconcile
    * can retry — dropping it now would orphan a ghost event on the calendar.
    */
-  private async removeLink(link: CalendarPostLink): Promise<void> {
+  private async removeLink(link: CalendarItemLink): Promise<void> {
     const platform =
       link.provider === 'google' ? 'google_calendar' : 'outlook_calendar';
     const { service } = this.providerFor(platform);
@@ -298,45 +406,45 @@ export class CalendarPushSyncService {
       // Transient failure — keep the link for retry instead of orphaning it.
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(
-        `Calendar event delete failed for post ${link.postId} on channel ${link.channelId}; retaining link for retry: ${message}`,
+        `Calendar event delete failed for ${describeLink(link)} on channel ${link.channelId}; retaining link for retry: ${message}`,
       );
       await db
-        .update(calendarPostLinks)
+        .update(calendarItemLinks)
         .set({
           syncStatus: 'error',
           lastError: message.slice(0, 1000),
           updatedAt: new Date(),
         })
-        .where(eq(calendarPostLinks.id, link.id));
+        .where(eq(calendarItemLinks.id, link.id));
       return;
     }
 
     // Confirmed gone → safe to drop the link.
-    await db.delete(calendarPostLinks).where(eq(calendarPostLinks.id, link.id));
+    await db.delete(calendarItemLinks).where(eq(calendarItemLinks.id, link.id));
   }
 
   /**
    * Load a post's calendar link rows into memory. Used by the post-DELETION
    * path so the external event ids survive the post's cascade delete of
-   * `calendar_post_links` — the provider deletes only need the ids, not the
+   * `calendar_item_links` — the provider deletes only need the ids, not the
    * (soon-cascaded) rows. Fast DB read; the caller runs it BEFORE deleting the
    * post.
    */
-  async loadPostLinks(postId: string): Promise<CalendarPostLink[]> {
+  async loadPostLinks(postId: string): Promise<CalendarItemLink[]> {
     return db
       .select()
-      .from(calendarPostLinks)
-      .where(eq(calendarPostLinks.postId, postId));
+      .from(calendarItemLinks)
+      .where(eq(calendarItemLinks.postId, postId));
   }
 
   /**
    * Best-effort provider-side deletion of events for already-detached links (the
-   * post + its `calendar_post_links` are already gone via cascade). Fire this in
+   * item + its `calendar_item_links` are already gone via cascade). Fire this in
    * the BACKGROUND from the delete path so a slow/hanging provider API can never
-   * stall or abort the post delete. Never touches `calendar_post_links` (nothing
-   * to reconcile) and never throws.
+   * stall or abort the delete. Never touches `calendar_item_links` (nothing to
+   * reconcile) and never throws.
    */
-  async deleteEventsForLinks(links: CalendarPostLink[]): Promise<void> {
+  async deleteEventsForLinks(links: CalendarItemLink[]): Promise<void> {
     for (const link of links) {
       const platform =
         link.provider === 'google' ? 'google_calendar' : 'outlook_calendar';
@@ -354,7 +462,7 @@ export class CalendarPushSyncService {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.warn(
-          `Background calendar event delete failed for deleted post ${link.postId} on channel ${link.channelId}: ${message}`,
+          `Background calendar event delete failed for deleted ${describeLink(link)} on channel ${link.channelId}: ${message}`,
         );
       }
     }
@@ -392,9 +500,10 @@ export class CalendarPushSyncService {
   }
 
   /**
-   * Push every currently-scheduled future post of a workspace to its connected
-   * calendars. Called after a calendar is connected (frontend/connect callback)
-   * so pre-existing scheduled posts appear. Per-post failures are isolated.
+   * Push every currently-scheduled future item (posts AND pending scheduled inbox
+   * messages) of a workspace to its connected calendars. Called after a calendar
+   * is connected (frontend/connect callback) so pre-existing scheduled items
+   * appear. Per-item failures are isolated.
    */
   async backfillWorkspace(workspaceId: string): Promise<void> {
     const scheduled = await db
@@ -408,13 +517,24 @@ export class CalendarPushSyncService {
         ),
       );
 
+    const messages = await db
+      .select({ id: scheduledInboxMessages.id })
+      .from(scheduledInboxMessages)
+      .where(
+        and(
+          eq(scheduledInboxMessages.workspaceId, workspaceId),
+          eq(scheduledInboxMessages.status, 'pending'),
+          gt(scheduledInboxMessages.scheduledAt, new Date()),
+        ),
+      );
+
     this.logger.log(
-      `Backfilling ${scheduled.length} scheduled post(s) for workspace ${workspaceId}`,
+      `Backfilling ${scheduled.length} scheduled post(s) + ${messages.length} scheduled message(s) for workspace ${workspaceId}`,
     );
 
     // Resolve each channel's primary calendar id at most once for the whole
-    // backfill run (memoized by channelId) instead of once per post — avoids an
-    // N+1 provider round-trip across many scheduled posts.
+    // backfill run (memoized by channelId) instead of once per item — avoids an
+    // N+1 provider round-trip across many scheduled items.
     const primaryCalendarCache = new Map<number, string>();
 
     for (const { id } of scheduled) {
@@ -423,6 +543,15 @@ export class CalendarPushSyncService {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.warn(`Backfill syncPost failed for ${id}: ${message}`);
+      }
+    }
+
+    for (const { id } of messages) {
+      try {
+        await this.syncMessage(id, primaryCalendarCache);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`Backfill syncMessage failed for ${id}: ${message}`);
       }
     }
   }
@@ -445,4 +574,33 @@ export class CalendarPushSyncService {
         ),
       );
   }
+}
+
+/**
+ * The owner predicate for a link lookup. The `IS NULL` half matters: without it
+ * a post whose id happened to collide with a message id (or, more realistically,
+ * a future third arc) could match the wrong row.
+ */
+function ownerEq(item: ItemRef) {
+  return item.kind === 'post'
+    ? and(
+        eq(calendarItemLinks.postId, item.postId),
+        isNull(calendarItemLinks.messageId),
+      )
+    : and(
+        eq(calendarItemLinks.messageId, item.messageId),
+        isNull(calendarItemLinks.postId),
+      );
+}
+
+function describe(item: ItemRef): string {
+  return item.kind === 'post'
+    ? `post ${item.postId}`
+    : `scheduled message ${item.messageId}`;
+}
+
+function describeLink(link: CalendarItemLink): string {
+  return link.postId
+    ? `post ${link.postId}`
+    : `scheduled message ${link.messageId}`;
 }

--- a/src/calendar-sync/services/external-events.service.ts
+++ b/src/calendar-sync/services/external-events.service.ts
@@ -3,7 +3,7 @@ import { and, asc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
 import { db } from '../../drizzle/db';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import {
-  calendarPostLinks,
+  calendarItemLinks,
   externalCalendarEvents,
 } from '../../drizzle/schema/calendar-sync.schema';
 
@@ -43,7 +43,7 @@ export class ExternalEventsService {
    * Overlap (not containment) so a multi-day/all-day event that starts before
    * the window still shows up inside it.
    *
-   * Rows that a `calendar_post_links` row claims are excluded at READ time. A
+   * Rows that a `calendar_item_links` row claims are excluded at READ time. A
    * post's own calendar event is already rendered as a post card, and there is a
    * narrow connect-time race in which the delta stream can observe an event we
    * just wrote BEFORE its link row commits — importing it as "external". This
@@ -84,11 +84,11 @@ export class ExternalEventsService {
       // an event WE wrote for a post is never an "external" event, even if a
       // raced delta managed to cache it as one.
       .leftJoin(
-        calendarPostLinks,
+        calendarItemLinks,
         and(
-          eq(calendarPostLinks.channelId, externalCalendarEvents.channelId),
+          eq(calendarItemLinks.channelId, externalCalendarEvents.channelId),
           eq(
-            calendarPostLinks.externalEventId,
+            calendarItemLinks.externalEventId,
             externalCalendarEvents.externalEventId,
           ),
         ),
@@ -99,7 +99,7 @@ export class ExternalEventsService {
           inArray(socialMediaChannels.platform, [...CALENDAR_PLATFORMS]),
           eq(socialMediaChannels.isActive, true),
           // The anti-join half: keep only the rows with NO matching link row.
-          isNull(calendarPostLinks.id),
+          isNull(calendarItemLinks.id),
           // Time-range overlap. Rows with a NULL start are excluded (a `lte`
           // against NULL is never true), which is what we want — they cannot be
           // placed on the grid.

--- a/src/channels/services/outlook-calendar.service.ts
+++ b/src/channels/services/outlook-calendar.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { CalendarPreconditionFailedError } from './calendar-precondition.error';
 import {
+  GRAPH_MESSAGE_ID_PROP_ID,
   GRAPH_POST_ID_PROP_ID,
   GRAPH_WORKSPACE_ID_PROP_ID,
+  SCHEDURA_MESSAGE_ID_PROP,
   SCHEDURA_POST_ID_PROP,
   SCHEDURA_WORKSPACE_ID_PROP,
 } from '../../calendar-sync/calendar-sync.constants';
@@ -644,6 +646,10 @@ export class OutlookCalendarService {
     const postId = privateProps[SCHEDURA_POST_ID_PROP];
     if (postId) {
       entries.push({ id: GRAPH_POST_ID_PROP_ID, value: postId });
+    }
+    const messageId = privateProps[SCHEDURA_MESSAGE_ID_PROP];
+    if (messageId) {
+      entries.push({ id: GRAPH_MESSAGE_ID_PROP_ID, value: messageId });
     }
     const workspaceId = privateProps[SCHEDURA_WORKSPACE_ID_PROP];
     if (workspaceId) {

--- a/src/drizzle/schema/calendar-sync.schema.ts
+++ b/src/drizzle/schema/calendar-sync.schema.ts
@@ -8,28 +8,40 @@ import {
   jsonb,
   integer,
   unique,
+  uniqueIndex,
   index,
+  check,
 } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import { workspace } from './workspace.schema';
 import { socialMediaChannels } from './channels.schema';
 import { posts } from './posts.schema';
+import { scheduledInboxMessages } from './scheduled-inbox-messages.schema';
 
 // =============================================================================
 // Calendar Two-Way Sync
 // -----------------------------------------------------------------------------
 // NOTE on id types: `social_media_channels.id` is a bigserial (numeric) pk, so
 // every `channel_id` FK below is `integer` (mode: 'number'), NOT uuid. In
-// contrast `workspace.id` and `posts.id` are uuid pks, so those FKs stay uuid.
+// contrast `workspace.id`, `posts.id` and `scheduled_inbox_messages.id` are uuid
+// pks, so those FKs stay uuid.
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-// 1. calendar_post_links — links a Schedura post to the external event we wrote
-//    on a connected calendar (one row per (channel, post)). Powers app→calendar
-//    push + two-way write-back (echo suppression via etag/lastPushedHash).
+// 1. calendar_item_links — links ONE Schedura calendar item to the external event
+//    we wrote on a connected calendar. The item is EITHER a scheduled post
+//    (`post_id`) OR a scheduled inbox message (`message_id`) — an exclusive arc,
+//    enforced by `cil_exactly_one_owner` (num_nonnulls(post_id, message_id) = 1).
+//    Powers app→calendar push + two-way write-back (echo suppression via
+//    etag/lastPushedHash).
+//
+//    HISTORY: this table was `calendar_post_links` (post_id NOT NULL). It is
+//    RENAMED in place (never dropped) — see
+//    docs/superpowers/plans/calendar-messages-migration.sql — because it holds
+//    live rows for events already sitting in real users' calendars.
 // -----------------------------------------------------------------------------
-export const calendarPostLinks = pgTable(
-  'calendar_post_links',
+export const calendarItemLinks = pgTable(
+  'calendar_item_links',
   {
     id: uuid('id').primaryKey().defaultRandom(),
     workspaceId: uuid('workspace_id')
@@ -39,9 +51,11 @@ export const calendarPostLinks = pgTable(
       .notNull()
       .references(() => socialMediaChannels.id, { onDelete: 'cascade' }),
     provider: varchar('provider', { length: 20 }).notNull(), // 'google' | 'outlook'
-    postId: uuid('post_id')
-      .notNull()
-      .references(() => posts.id, { onDelete: 'cascade' }),
+    // Exactly one of postId / messageId is set (see the CHECK below).
+    postId: uuid('post_id').references(() => posts.id, { onDelete: 'cascade' }),
+    messageId: uuid('message_id').references(() => scheduledInboxMessages.id, {
+      onDelete: 'cascade',
+    }),
     externalEventId: varchar('external_event_id', { length: 512 }).notNull(),
     externalCalendarId: varchar('external_calendar_id', { length: 512 }),
     etag: varchar('etag', { length: 512 }), // provider etag / changeKey
@@ -55,10 +69,22 @@ export const calendarPostLinks = pgTable(
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (t) => ({
-    uqChannelPost: unique('cpl_channel_post_uq').on(t.channelId, t.postId),
-    ixChannelEvent: index('cpl_channel_event_ix').on(
+    // PARTIAL uniques: a plain unique on (channel_id, post_id) would let many
+    // message rows share the (channel_id, NULL) key in Postgres anyway, but the
+    // partial form documents the intent and keeps each arc's index tight.
+    uqChannelPost: uniqueIndex('cil_channel_post_uq')
+      .on(t.channelId, t.postId)
+      .where(sql`${t.postId} IS NOT NULL`),
+    uqChannelMessage: uniqueIndex('cil_channel_message_uq')
+      .on(t.channelId, t.messageId)
+      .where(sql`${t.messageId} IS NOT NULL`),
+    ixChannelEvent: index('cil_channel_event_ix').on(
       t.channelId,
       t.externalEventId,
+    ),
+    ckExactlyOneOwner: check(
+      'cil_exactly_one_owner',
+      sql`num_nonnulls(${t.postId}, ${t.messageId}) = 1`,
     ),
   }),
 );
@@ -139,20 +165,24 @@ export const calendarSyncState = pgTable(
 // =============================================================================
 // Relations
 // =============================================================================
-export const calendarPostLinksRelations = relations(
-  calendarPostLinks,
+export const calendarItemLinksRelations = relations(
+  calendarItemLinks,
   ({ one }) => ({
     workspace: one(workspace, {
-      fields: [calendarPostLinks.workspaceId],
+      fields: [calendarItemLinks.workspaceId],
       references: [workspace.id],
     }),
     channel: one(socialMediaChannels, {
-      fields: [calendarPostLinks.channelId],
+      fields: [calendarItemLinks.channelId],
       references: [socialMediaChannels.id],
     }),
     post: one(posts, {
-      fields: [calendarPostLinks.postId],
+      fields: [calendarItemLinks.postId],
       references: [posts.id],
+    }),
+    message: one(scheduledInboxMessages, {
+      fields: [calendarItemLinks.messageId],
+      references: [scheduledInboxMessages.id],
     }),
   }),
 );
@@ -184,8 +214,8 @@ export const calendarSyncStateRelations = relations(
 // =============================================================================
 // Inferred types
 // =============================================================================
-export type CalendarPostLink = typeof calendarPostLinks.$inferSelect;
-export type NewCalendarPostLink = typeof calendarPostLinks.$inferInsert;
+export type CalendarItemLink = typeof calendarItemLinks.$inferSelect;
+export type NewCalendarItemLink = typeof calendarItemLinks.$inferInsert;
 export type ExternalCalendarEvent = typeof externalCalendarEvents.$inferSelect;
 export type NewExternalCalendarEvent =
   typeof externalCalendarEvents.$inferInsert;

--- a/src/inbox/inbox.module.ts
+++ b/src/inbox/inbox.module.ts
@@ -31,6 +31,7 @@ import { ScheduledMessagesService } from './services/scheduled-messages.service'
 import { SlackBackfillService } from './services/slack-backfill.service';
 import { ChannelsModule } from '../channels/channels.module';
 import { MediaModule } from '../media/media.module';
+import { CalendarSyncModule } from '../calendar-sync/calendar-sync.module';
 import { QUEUES } from '../queue/queue.module';
 
 @Module({
@@ -40,6 +41,11 @@ import { QUEUES } from '../queue/queue.module';
   imports: [
     forwardRef(() => ChannelsModule),
     MediaModule,
+    // Circular by design: scheduled messages push to calendars
+    // (CalendarPushSyncService) and calendars write back to scheduled messages
+    // (CalendarPullSyncService → ScheduledMessagesService). Same shape as
+    // PostsModule ↔ CalendarSyncModule.
+    forwardRef(() => CalendarSyncModule),
     BullModule.registerQueue(
       { name: QUEUES.INBOX_POLLING },
       { name: QUEUES.SCHEDULED_INBOX },

--- a/src/inbox/services/scheduled-messages.service.ts
+++ b/src/inbox/services/scheduled-messages.service.ts
@@ -25,6 +25,7 @@ import { workspace } from '../../drizzle/schema/workspace.schema';
 import { workspaceInvitation } from '../../drizzle/schema/workspace-invitation.schema';
 import { QUEUES } from '../../queue/queue.module';
 import { AnalyticsEventEmitter } from '../../realtime/analytics-event-emitter.service';
+import { CalendarPushSyncService } from '../../calendar-sync/services/calendar-push-sync.service';
 import type { CreateScheduledMessageDto } from '../dto/create-scheduled-message.dto';
 import type { UpdateScheduledMessageDto } from '../dto/update-scheduled-message.dto';
 import type { ListScheduledMessagesDto } from '../dto/list-scheduled-messages.dto';
@@ -69,7 +70,27 @@ export class ScheduledMessagesService {
   constructor(
     private readonly emitter: AnalyticsEventEmitter,
     @InjectQueue(QUEUES.SCHEDULED_INBOX) private readonly queue: Queue,
+    // InboxModule ↔ CalendarSyncModule is a circular module pair (scheduled
+    // messages push to calendars, calendars write back to scheduled messages)
+    // → forwardRef on both module imports. Mirrors PostService ↔ CalendarSync.
+    private readonly calendarPushSync: CalendarPushSyncService,
   ) {}
+
+  /**
+   * Fire-and-forget app→calendar push for a scheduled message. Never blocks or
+   * fails the originating inbox operation — calendar sync is best-effort and
+   * self-heals via backfill/reconcile. Errors are logged inside the push service.
+   * Mirrors `PostService.syncCalendarForPost`.
+   */
+  private syncCalendarForMessage(messageId: string): void {
+    void this.calendarPushSync.syncMessage(messageId).catch((error) => {
+      this.logger.warn(
+        `Calendar sync failed for scheduled message ${messageId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }
 
   // ──────────────────────────────────────────────────────────────────────────
   // Workspace access (mirrors InboxService.assertWorkspaceAccess)
@@ -330,6 +351,9 @@ export class ScheduledMessagesService {
       this.toEventBase(refreshed),
     );
 
+    // Mirror the new scheduled message onto the workspace's connected calendars.
+    this.syncCalendarForMessage(row.id);
+
     return this.toDto(refreshed, target.platform);
   }
 
@@ -340,7 +364,33 @@ export class ScheduledMessagesService {
     dto: UpdateScheduledMessageDto,
   ): Promise<ScheduledMessageDto> {
     await this.assertWorkspaceAccess(workspaceId, userId);
+    return this.applyUpdate(workspaceId, id, dto);
+  }
 
+  /**
+   * SYSTEM-INTERNAL update — same behaviour as `update()` (validation, BullMQ job
+   * re-arm, realtime event, calendar push) but WITHOUT the per-user workspace
+   * access check, because the caller is not a user.
+   *
+   * Used by the calendar write-back path (`CalendarPullSyncService`): when the
+   * user drags one of our events in Google/Outlook, the reschedule arrives with
+   * no authenticated user, and `createdByUserId` is nullable so it cannot be
+   * relied on as a stand-in. The provider event is itself the authorization —
+   * it only exists because this workspace connected that calendar.
+   */
+  async updateFromCalendar(
+    workspaceId: string,
+    id: string,
+    dto: UpdateScheduledMessageDto,
+  ): Promise<ScheduledMessageDto> {
+    return this.applyUpdate(workspaceId, id, dto);
+  }
+
+  private async applyUpdate(
+    workspaceId: string,
+    id: string,
+    dto: UpdateScheduledMessageDto,
+  ): Promise<ScheduledMessageDto> {
     const existing = await db.query.scheduledInboxMessages.findFirst({
       where: and(
         eq(scheduledInboxMessages.id, id),
@@ -413,6 +463,11 @@ export class ScheduledMessagesService {
       this.toEventBase(row),
     );
 
+    // Reflect the new time/text on connected calendars. When the update ORIGINATED
+    // from a calendar move the pull service has already stamped the link with the
+    // hash of exactly this body, so this push is a no-op (no ping-pong).
+    this.syncCalendarForMessage(id);
+
     return this.toDto(row, channel?.platform as SupportedPlatform | undefined);
   }
 
@@ -422,6 +477,31 @@ export class ScheduledMessagesService {
     id: string,
   ): Promise<{ success: true }> {
     await this.assertWorkspaceAccess(workspaceId, userId);
+    return this.applyCancel(workspaceId, id);
+  }
+
+  /**
+   * SYSTEM-INTERNAL cancel — identical to `cancel()` (BullMQ delayed-job removal,
+   * status → 'cancelled', realtime event) minus the per-user access check. See
+   * `updateFromCalendar()` for why the calendar write-back path needs this.
+   *
+   * NOTE: no calendar push hook here — the caller (the pull service) is reacting
+   * to the event ALREADY being deleted in the provider, and it drops the link row
+   * itself. Pushing would only chase a 404.
+   */
+  async cancelFromCalendar(
+    workspaceId: string,
+    id: string,
+  ): Promise<{ success: true }> {
+    return this.applyCancel(workspaceId, id, { pushToCalendar: false });
+  }
+
+  private async applyCancel(
+    workspaceId: string,
+    id: string,
+    options: { pushToCalendar?: boolean } = {},
+  ): Promise<{ success: true }> {
+    const { pushToCalendar = true } = options;
 
     const existing = await db.query.scheduledInboxMessages.findFirst({
       where: and(
@@ -455,6 +535,12 @@ export class ScheduledMessagesService {
       channelId: existing.channelId,
       threadKey: existing.threadKey,
     });
+
+    // A cancelled message must NOT keep a live calendar event — syncMessage sees
+    // a non-pending row and removes the event + link on every calendar.
+    if (pushToCalendar) {
+      this.syncCalendarForMessage(id);
+    }
 
     return { success: true };
   }
@@ -594,6 +680,8 @@ export class ScheduledMessagesService {
       ...this.toEventBase(row),
       inboxItemId,
     });
+    // Sent → no longer a *scheduled* item; its calendar event is removed.
+    this.syncCalendarForMessage(id);
   }
 
   async markFailed(id: string, error: string): Promise<void> {
@@ -612,6 +700,8 @@ export class ScheduledMessagesService {
       ...this.toEventBase(row),
       errorMessage: row.errorMessage ?? error,
     });
+    // Terminally failed → the calendar event would be a lie; remove it.
+    this.syncCalendarForMessage(id);
   }
 
   /** Between BullMQ retries — keep the row claimable by the next attempt. */

--- a/src/posts/services/post.service.ts
+++ b/src/posts/services/post.service.ts
@@ -396,7 +396,7 @@ export class PostService {
     }
 
     // Load the calendar link rows into memory BEFORE deleting the post:
-    // calendar_post_links cascade-delete with the post, so afterwards we'd lose
+    // calendar_item_links cascade-delete with the post, so afterwards we'd lose
     // the external event ids. This is a fast DB read; if it fails we still
     // delete the post (calendar cleanup is best-effort and self-heals via
     // reconcile). The provider deletes themselves run in the BACKGROUND below,


### PR DESCRIPTION
Scheduled replies and DMs already appeared on Schedura's own calendar but never reached the user's — only posts did. Close the gap so a connected calendar shows everything that is going out, not just half of it.

The link table was hard-bound to posts (`post_id uuid NOT NULL` → posts), so it could not hold a message at all. Generalise it to `calendar_item_links` as an exclusive arc: `post_id` and `message_id` both nullable, both real FKs, and a CHECK that exactly one is set. The database — not convention — now guarantees every link points at exactly one owner, and cascade-delete keeps working for both.

External moves reschedule the message and external deletes CANCEL it (a message has no draft state, so cancel is the honest translation of "delete"). Both go through ScheduledMessagesService's existing update/cancel paths rather than writing to the table directly, because those paths also re-arm or remove the BullMQ delayed job — the message would otherwise still fire at its old time.

Backward compatibility was the binding constraint: live events already sit in a real calendar tagged `schedura_post_id`, so posts keep that tag byte-for-byte and messages get a parallel `schedura_message_id`. The post summary path is unchanged too — HTML stripping is applied only to message bodies, so existing events don't churn their content hash and re-push.

Migration is hand-written and in-place (RENAME + ALTER, never DROP/CREATE): the table holds live rows.