### PR TITLE
fix(whatsapp): ask for the two-step PIN instead of returning a 500

### DIFF
--- a/src/channels/services/whatsapp-onboarding.service.spec.ts
+++ b/src/channels/services/whatsapp-onboarding.service.spec.ts
@@ -1,5 +1,9 @@
 import { ConflictException, BadRequestException } from '@nestjs/common';
-import { WhatsAppOnboardingService } from './whatsapp-onboarding.service';
+import {
+  WhatsAppOnboardingService,
+  WHATSAPP_PIN_REQUIRED,
+} from './whatsapp-onboarding.service';
+import { WhatsAppApiError, WA_ERROR_PIN_MISMATCH } from './whatsapp.service';
 import { isChannelHealthy } from './channel.service';
 
 function makeService(overrides: {
@@ -246,6 +250,67 @@ describe('WhatsAppOnboardingService.completeEmbeddedSignup', () => {
         // No verified_name available, so the channel falls back to the number id.
         expect.objectContaining({ accountName: '111', platformAccountId: '111' }),
       );
+    });
+  });
+
+  // A number with two-step verification on rejects our PIN, and only the customer
+  // knows theirs. That is a question to ask — never a 500 to bury.
+  describe('two-step verification PIN', () => {
+    const rejectsWithPinMismatch = () =>
+      jest
+        .fn()
+        .mockRejectedValue(
+          new WhatsAppApiError('Two step verification PIN Mismatch', WA_ERROR_PIN_MISMATCH),
+        );
+
+    it('asks for the PIN rather than failing the request outright', async () => {
+      const { service, channels } = makeService({
+        whatsapp: { registerPhoneNumber: rejectsWithPinMismatch() },
+      });
+      await expect(
+        service.completeEmbeddedSignup('ws-A', 'u1', input),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(channels.createChannel).not.toHaveBeenCalled();
+    });
+
+    it('marks the 400 so the client can reveal a PIN field', async () => {
+      const { service } = makeService({
+        whatsapp: { registerPhoneNumber: rejectsWithPinMismatch() },
+      });
+      const err: BadRequestException = await service
+        .completeEmbeddedSignup('ws-A', 'u1', input)
+        .catch((e) => e);
+      expect(err.getResponse()).toMatchObject({
+        code: WHATSAPP_PIN_REQUIRED,
+        message: expect.stringContaining('two-step verification'),
+      });
+    });
+
+    it('says the PIN was wrong when the caller already supplied one', async () => {
+      const { service, whatsapp } = makeService({
+        whatsapp: { registerPhoneNumber: rejectsWithPinMismatch() },
+      });
+      const err: BadRequestException = await service
+        .completeEmbeddedSignup('ws-A', 'u1', { ...input, pin: '123456' })
+        .catch((e) => e);
+      expect(whatsapp.registerPhoneNumber).toHaveBeenCalledWith('biz', '111', '123456');
+      expect(err.getResponse()).toMatchObject({
+        code: WHATSAPP_PIN_REQUIRED,
+        message: expect.stringMatching(/doesn't match/i),
+      });
+    });
+
+    it('leaves every other register failure alone', async () => {
+      const { service } = makeService({
+        whatsapp: {
+          registerPhoneNumber: jest
+            .fn()
+            .mockRejectedValue(new WhatsAppApiError('Rate limit hit', 4)),
+        },
+      });
+      await expect(
+        service.completeEmbeddedSignup('ws-A', 'u1', input),
+      ).rejects.toThrow('Rate limit hit');
     });
   });
 });

--- a/src/channels/services/whatsapp-onboarding.service.ts
+++ b/src/channels/services/whatsapp-onboarding.service.ts
@@ -4,10 +4,20 @@ import {
   ConflictException,
   BadRequestException,
 } from '@nestjs/common';
-import { WhatsAppService } from './whatsapp.service';
+import {
+  WhatsAppService,
+  WhatsAppApiError,
+  WA_ERROR_PIN_MISMATCH,
+} from './whatsapp.service';
 import { ChannelService, isChannelHealthy } from './channel.service';
 import { InboxService } from '../../inbox/inbox.service';
 import type { ChannelResponseDto } from '../dto/channel.dto';
+
+/**
+ * Machine-readable marker on the 400 body. The client keys the "enter your PIN"
+ * retry off this rather than the prose, which is free to change.
+ */
+export const WHATSAPP_PIN_REQUIRED = 'WHATSAPP_PIN_REQUIRED';
 
 export interface EmbeddedSignupInput {
   code: string;
@@ -111,11 +121,7 @@ export class WhatsAppOnboardingService {
     );
 
     // 5. Register the phone number for Cloud API (idempotent).
-    await this.whatsapp.registerPhoneNumber(
-      accessToken,
-      phoneNumberId,
-      input.pin ?? '000000',
-    );
+    await this.registerNumber(accessToken, phoneNumberId, input.pin);
 
     // 6. Subscribe our app to the WABA — BLOCKING. A channel that never
     //    receives webhooks is worse than a visible failure.
@@ -140,6 +146,45 @@ export class WhatsAppOnboardingService {
         connectMethod: 'embedded_signup',
       },
     });
+  }
+
+  /**
+   * Register the number for Cloud API. A number that already has two-step
+   * verification on rejects our PIN, and the customer is the only one who knows
+   * theirs — so that is a question to ask, not a 500 to bury. Everything else
+   * bubbles up unchanged.
+   *
+   * On a number with two-step verification OFF, Meta adopts whatever PIN we send
+   * as its PIN, which is why the default is a fixed '000000'.
+   */
+  private async registerNumber(
+    accessToken: string,
+    phoneNumberId: string,
+    pin: string | undefined,
+  ): Promise<void> {
+    try {
+      await this.whatsapp.registerPhoneNumber(
+        accessToken,
+        phoneNumberId,
+        pin ?? '000000',
+      );
+    } catch (err) {
+      const isPinMismatch =
+        err instanceof WhatsAppApiError && err.code === WA_ERROR_PIN_MISMATCH;
+      if (!isPinMismatch) throw err;
+
+      this.logger.warn(
+        `Register rejected our PIN for phone=${phoneNumberId} (two-step verification is on; pin ${
+          pin ? 'supplied' : 'defaulted'
+        })`,
+      );
+      throw new BadRequestException({
+        code: WHATSAPP_PIN_REQUIRED,
+        message: pin
+          ? "That PIN doesn't match this number's two-step verification PIN. Check it and try again."
+          : 'This number has two-step verification turned on. Enter its 6-digit PIN and connect again — or turn two-step verification off in WhatsApp Manager (Account tools → Phone numbers → gear icon).',
+      });
+    }
   }
 
   /**

--- a/src/channels/services/whatsapp.service.ts
+++ b/src/channels/services/whatsapp.service.ts
@@ -3,6 +3,24 @@ import { Injectable, Logger } from '@nestjs/common';
 export const GRAPH_API_VERSION = 'v21.0';
 export const WHATSAPP_GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
+/** The number already has two-step verification on, and our PIN is not its PIN. */
+export const WA_ERROR_PIN_MISMATCH = 133005;
+
+/**
+ * A Graph error that carries Meta's numeric code. Callers branch on `code` rather
+ * than pattern-matching `message`, which is prose Meta is free to reword or
+ * localise.
+ */
+export class WhatsAppApiError extends Error {
+  constructor(
+    message: string,
+    readonly code: number | null,
+  ) {
+    super(message);
+    this.name = 'WhatsAppApiError';
+  }
+}
+
 @Injectable()
 export class WhatsAppService {
   private readonly logger = new Logger(WhatsAppService.name);
@@ -197,7 +215,11 @@ export class WhatsAppService {
     if (res.ok) return;
     const msg = (data?.error?.message as string) || '';
     if (/already\s+registered/i.test(msg)) return; // idempotent
-    throw new Error(msg || `Phone number register failed (${res.status})`);
+    const code = typeof data?.error?.code === 'number' ? data.error.code : null;
+    throw new WhatsAppApiError(
+      msg || `Phone number register failed (${res.status})`,
+      code,
+    );
   }
 
   /**


### PR DESCRIPTION
Registering a number whose two-step verification is already on rejects our default PIN with Meta error 133005. registerPhoneNumber threw a plain Error, so Nest turned a condition the customer can fix into "Internal server error" — which is what every customer bringing a number off the WhatsApp Business app would have seen.

registerPhoneNumber now throws a WhatsAppApiError carrying Meta's numeric code, so callers branch on the code rather than pattern-matching prose Meta is free to reword. Onboarding maps 133005 to a 400 tagged WHATSAPP_PIN_REQUIRED, which the client keys its "enter your PIN" retry off. A supplied-but-wrong PIN says so; every other register failure still bubbles up untouched.