### PR TITLE
feat(calendar): tell open calendars when a provider-side change lands

### DIFF
--- a/src/calendar-sync/services/calendar-pull-sync.delete.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.delete.spec.ts
@@ -33,6 +33,7 @@ import { GoogleCalendarService } from '../../channels/services/google-calendar.s
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { PostService } from '../../posts/services/post.service';
 import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
+import { AnalyticsEventEmitter } from '../../realtime/analytics-event-emitter.service';
 import { posts } from '../../drizzle/schema/posts.schema';
 import { scheduledInboxMessages } from '../../drizzle/schema/scheduled-inbox-messages.schema';
 import {
@@ -141,6 +142,7 @@ describe('CalendarPullSyncService — external delete write-back (never hard-del
       pushSync,
       postService,
       scheduledMessages,
+      { emit: jest.fn() } as unknown as AnalyticsEventEmitter,
     ) as unknown as PullSyncInternals;
   });
 

--- a/src/calendar-sync/services/calendar-pull-sync.message.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.message.spec.ts
@@ -37,6 +37,7 @@ import { GoogleCalendarService } from '../../channels/services/google-calendar.s
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { PostService } from '../../posts/services/post.service';
 import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
+import { AnalyticsEventEmitter } from '../../realtime/analytics-event-emitter.service';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import { posts } from '../../drizzle/schema/posts.schema';
 import { scheduledInboxMessages } from '../../drizzle/schema/scheduled-inbox-messages.schema';
@@ -188,6 +189,7 @@ describe('CalendarPullSyncService — owned-event dispatch (post vs scheduled me
         updateFromCalendar,
         cancelFromCalendar,
       } as unknown as ScheduledMessagesService,
+      { emit: jest.fn() } as unknown as AnalyticsEventEmitter,
     ) as unknown as PullSyncInternals;
   });
 

--- a/src/calendar-sync/services/calendar-pull-sync.reconcile.spec.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.reconcile.spec.ts
@@ -49,13 +49,17 @@ import { GoogleCalendarService } from '../../channels/services/google-calendar.s
 import { OutlookCalendarService } from '../../channels/services/outlook-calendar.service';
 import { PostService } from '../../posts/services/post.service';
 import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
+import { AnalyticsEventEmitter } from '../../realtime/analytics-event-emitter.service';
 import { socialMediaChannels } from '../../drizzle/schema/channels.schema';
 import {
   calendarSyncState,
   externalCalendarEvents,
 } from '../../drizzle/schema/calendar-sync.schema';
 import { fetchGoogleCalendarDelta } from '../providers/google-delta.util';
-import { CalendarDeltaResult } from '../providers/delta.types';
+import {
+  CalendarDeltaResult,
+  NormalizedExternalEvent,
+} from '../providers/delta.types';
 import { CalendarPushSyncService } from './calendar-push-sync.service';
 import { CalendarPullSyncService } from './calendar-pull-sync.service';
 
@@ -109,6 +113,22 @@ function deltaResult(
   };
 }
 
+/** A plain inbound event the customer created on their own calendar. */
+function externalEvent(externalEventId: string): NormalizedExternalEvent {
+  return {
+    externalEventId,
+    calendarId: 'primary',
+    title: 'Dentist',
+    startsAt: new Date(Date.now() + DAY_MS),
+    endsAt: new Date(Date.now() + DAY_MS + 30 * 60 * 1000),
+    isAllDay: false,
+    externalUpdatedAt: new Date(),
+    isOurs: false,
+    etag: 'etag-1',
+    raw: {},
+  };
+}
+
 /** The `set` payloads of every UPDATE against `calendar_sync_state`. */
 function syncStateUpdates(): Array<Record<string, unknown>> {
   return dbMock.__state.updates
@@ -118,6 +138,7 @@ function syncStateUpdates(): Array<Record<string, unknown>> {
 
 describe('CalendarPullSyncService.reconcile', () => {
   let service: CalendarPullSyncService;
+  let emit: jest.Mock;
 
   function seedState(over: Record<string, unknown> = {}) {
     dbMock.__state.selectByTable.set(socialMediaChannels, [CHANNEL]);
@@ -137,6 +158,8 @@ describe('CalendarPullSyncService.reconcile', () => {
       getPrimaryCalendar: jest.fn().mockResolvedValue({ id: 'primary' }),
     } as unknown as GoogleCalendarService;
 
+    emit = jest.fn();
+
     service = new CalendarPullSyncService(
       channelService,
       googleCalendarService,
@@ -150,6 +173,7 @@ describe('CalendarPullSyncService.reconcile', () => {
         updateFromCalendar: jest.fn(),
         cancelFromCalendar: jest.fn(),
       } as unknown as ScheduledMessagesService,
+      { emit } as unknown as AnalyticsEventEmitter,
     );
   });
 
@@ -240,5 +264,37 @@ describe('CalendarPullSyncService.reconcile', () => {
     const last = syncStateUpdates().at(-1);
     expect(last).toMatchObject({ syncToken: 'fresh-token' });
     expect(last?.lastFullSyncAt).toBeInstanceOf(Date);
+  });
+
+  // ===========================================================================
+  // Realtime signal — an open calendar view has no other way to learn that the
+  // customer changed something on Google/Outlook.
+  // ===========================================================================
+
+  it('signals the workspace when the pull brought back changes', async () => {
+    seedState();
+    fetchGoogleDeltaMock.mockResolvedValue(
+      deltaResult({ changed: [externalEvent('evt-1')], deleted: ['evt-gone'] }),
+    );
+
+    await service.reconcile(CHANNEL_ID);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('ws-1', 'calendar.external.changed', {
+      workspaceId: 'ws-1',
+      channelId: CHANNEL_ID,
+      provider: 'google',
+      changed: 1,
+      deleted: 1,
+    });
+  });
+
+  it('stays silent on a quiet poll — no change, no refetch', async () => {
+    seedState();
+    fetchGoogleDeltaMock.mockResolvedValue(deltaResult()); // changed: [], deleted: []
+
+    await service.reconcile(CHANNEL_ID);
+
+    expect(emit).not.toHaveBeenCalled();
   });
 });

--- a/src/calendar-sync/services/calendar-pull-sync.service.ts
+++ b/src/calendar-sync/services/calendar-pull-sync.service.ts
@@ -24,6 +24,7 @@ import { OutlookCalendarService } from '../../channels/services/outlook-calendar
 import { CalendarPreconditionFailedError } from '../../channels/services/calendar-precondition.error';
 import { PostService } from '../../posts/services/post.service';
 import { ScheduledMessagesService } from '../../inbox/services/scheduled-messages.service';
+import { AnalyticsEventEmitter } from '../../realtime/analytics-event-emitter.service';
 import { fetchGoogleCalendarDelta } from '../providers/google-delta.util';
 import { fetchOutlookCalendarDelta } from '../providers/outlook-delta.util';
 import {
@@ -130,6 +131,8 @@ export class CalendarPullSyncService {
     // InboxModule ↔ CalendarSyncModule is circular for the same reason.
     @Inject(forwardRef(() => ScheduledMessagesService))
     private readonly scheduledMessages: ScheduledMessagesService,
+    // RealtimeModule is @Global, so no module import is needed for this.
+    private readonly events: AnalyticsEventEmitter,
   ) {}
 
   /**
@@ -238,6 +241,25 @@ export class CalendarPullSyncService {
       this.logger.log(
         `Calendar pull for channel ${channelId} (${provider}): ${delta.changed.length} changed, ${delta.deleted.length} deleted, full=${isFullSync}, truncated=${delta.truncated}`,
       );
+
+      // Tell any open calendar view to refetch. Without this the browser only
+      // learns about a provider-side change when the tab regains focus, which is
+      // why a Google event created in the next tab never appeared until reload.
+      //
+      // The signal is intentionally coarse — it fires on the raw delta, so an
+      // event WE pushed and then read back echoes one redundant refetch. That is
+      // the cheap direction to be wrong in: invalidateQueries only refetches
+      // queries that are actually mounted, so a workspace with no calendar open
+      // pays nothing, and we never miss a real change.
+      if (delta.changed.length > 0 || delta.deleted.length > 0) {
+        this.events.emit(channel.workspaceId, 'calendar.external.changed', {
+          workspaceId: channel.workspaceId,
+          channelId,
+          provider,
+          changed: delta.changed.length,
+          deleted: delta.deleted.length,
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(

--- a/src/realtime/types/analytics-events.types.ts
+++ b/src/realtime/types/analytics-events.types.ts
@@ -23,7 +23,8 @@ export type AnalyticsEventName =
   | 'ad.insights.updated'
   | 'lead.created'
   | 'lead.delivered'
-  | 'maestro.bridge.message';
+  | 'maestro.bridge.message'
+  | 'calendar.external.changed';
 
 export interface ChannelSnapshotUpdatedPayload {
   workspaceId: string;
@@ -222,6 +223,24 @@ export interface MaestroBridgeMessagePayload {
   text?: string;
 }
 
+/**
+ * A pull from a connected Google/Outlook calendar brought back changes — the
+ * customer created, moved or deleted something on the provider's side, so an
+ * open calendar view is now stale.
+ *
+ * Deliberately carries no event data. The calendar view is a windowed query and
+ * the client already knows how to fetch its own window; all it needs is the
+ * signal to go do it.
+ */
+export interface CalendarExternalChangedPayload {
+  workspaceId: string;
+  channelId: number;
+  provider: 'google' | 'outlook';
+  /** Counts, for diagnosing a chatty channel from the logs — not for rendering. */
+  changed: number;
+  deleted: number;
+}
+
 export type AnalyticsEventPayloadMap = {
   'channel.snapshot.updated': ChannelSnapshotUpdatedPayload;
   'post.metrics.updated': PostMetricsUpdatedPayload;
@@ -243,4 +262,5 @@ export type AnalyticsEventPayloadMap = {
   'lead.created': LeadCreatedPayload;
   'lead.delivered': LeadDeliveredPayload;
   'maestro.bridge.message': MaestroBridgeMessagePayload;
+  'calendar.external.changed': CalendarExternalChangedPayload;
 };


### PR DESCRIPTION
A pull from Google/Outlook wrote the change to our DB and stopped there. The browser had no way to hear about it: the calendar query only refetches on window focus, so an event created in the next tab stayed invisible until a manual reload.

The pull now emits calendar.external.changed to the workspace room whenever a delta brings back changes. RealtimeModule is @Global, so the emitter injects without a module import.

The signal fires on the raw delta, so an event WE pushed and then read back echoes one redundant refetch. That is the cheap direction to be wrong in: invalidateQueries only refetches mounted queries, so a workspace with no calendar open pays nothing, and we never miss a real change.

The three pull-sync specs constructed the service positionally and so left the emitter undefined — and because the emit sits inside the try block whose catch logs "Calendar pull failed", the resulting TypeError was swallowed and the suite stayed green while never running the new code. They now pass a mock, and the reconcile spec asserts both that a change signals and that a quiet poll does not.