### PR TITLE
feat(posts): calendar/planner reads full post history, not just sched…

### DIFF
--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -72,7 +72,9 @@ export class PostsController {
   }
 
   /**
-   * Get scheduled posts for calendar view.
+   * Get posts for the calendar view — scheduled, publishing, published, failed
+   * and partially published. Drafts are excluded: they carry no date.
+   *
    * MUST be declared before the ':postId' routes below — otherwise NestJS
    * matches the literal "calendar" segment as a :postId and the query fails
    * with "invalid input syntax for type uuid: calendar".
@@ -87,18 +89,21 @@ export class PostsController {
       throw new Error('from and to date parameters are required');
     }
 
-    const scheduledPosts = await this.postService.getScheduledPosts(
+    const calendarPosts = await this.postService.getCalendarPosts(
       workspaceId,
       new Date(from),
       new Date(to),
     );
 
-    // Group by date for calendar display
-    const byDate: Record<string, typeof scheduledPosts> = {};
+    // Group by the date the post actually occupies. `publishedAt` first: a post
+    // published immediately has no `scheduledAt`, so keying on that alone
+    // dropped every "post now" from this map entirely.
+    const byDate: Record<string, typeof calendarPosts> = {};
 
-    for (const post of scheduledPosts) {
-      if (post.scheduledAt) {
-        const dateKey = post.scheduledAt.toISOString().split('T')[0];
+    for (const post of calendarPosts) {
+      const occurredAt = post.publishedAt ?? post.scheduledAt;
+      if (occurredAt) {
+        const dateKey = occurredAt.toISOString().split('T')[0];
         if (!byDate[dateKey]) {
           byDate[dateKey] = [];
         }
@@ -107,9 +112,9 @@ export class PostsController {
     }
 
     return {
-      posts: scheduledPosts,
+      posts: calendarPosts,
       byDate,
-      total: scheduledPosts.length,
+      total: calendarPosts.length,
     };
   }
 

--- a/src/posts/services/post.service.ts
+++ b/src/posts/services/post.service.ts
@@ -936,7 +936,10 @@ export class PostService {
   }
 
   /**
-   * Get scheduled posts for calendar view
+   * Get scheduled posts only — upcoming work, nothing that already ran.
+   *
+   * Kept scheduled-only for the chatbot's "list scheduled posts" tool, which
+   * answers "what's coming up". The calendar uses `getCalendarPosts` below.
    */
   async getScheduledPosts(
     workspaceId: string,
@@ -955,6 +958,55 @@ export class PostService {
         ),
       )
       .orderBy(posts.scheduledAt);
+  }
+
+  /**
+   * Every post that occupies a point in time, for the calendar view.
+   *
+   * Deliberately broader than `getScheduledPosts`: the calendar used to receive
+   * `scheduled` only, which made it a forecast rather than a record — you could
+   * not see what actually went out. The frontend was already built for the full
+   * range (per-status colours, bar styling and a `?statuses=` filter) and simply
+   * never received it.
+   *
+   * `draft` is excluded on purpose: a draft has no date, so it cannot be placed
+   * on a grid. Drafts are listed separately in the calendar's own sidebar.
+   *
+   * Dates come from `COALESCE(published_at, scheduled_at)`, not `scheduled_at`
+   * alone. A post published immediately has no `scheduled_at` at all — its time
+   * lives only in `published_at` — so ranging on `scheduled_at` would have kept
+   * every "post now" invisible even after the status filter was lifted. Where a
+   * post was scheduled for one time and actually went out at another, the
+   * calendar shows when it *happened*, which is what a record means.
+   *
+   * A post with neither timestamp falls out of the range comparison, which is
+   * correct — it has no place on a calendar.
+   */
+  async getCalendarPosts(
+    workspaceId: string,
+    fromDate: Date,
+    toDate: Date,
+  ): Promise<(typeof posts.$inferSelect)[]> {
+    const occurredAt = sql`COALESCE(${posts.publishedAt}, ${posts.scheduledAt})`;
+
+    return await db
+      .select()
+      .from(posts)
+      .where(
+        and(
+          eq(posts.workspaceId, workspaceId),
+          inArray(posts.status, [
+            'scheduled',
+            'publishing',
+            'published',
+            'failed',
+            'partially_published',
+          ]),
+          gte(occurredAt, fromDate),
+          lte(occurredAt, toDate),
+        ),
+      )
+      .orderBy(occurredAt);
   }
 
   /**


### PR DESCRIPTION
…uled

getCalendarPosts returns scheduled, publishing, published, failed and partially_published within a date range, ordered by COALESCE(publishedAt, scheduledAt) so "sent now" posts surface too. The chatbot's getScheduledPosts is kept as-is. This is what lets the frontend Calendar become the Planner: one dataset behind calendar, list and table.