### PR TITLE
feat(media-library): usage tracking + entry categories + template med…

### DIFF
--- a/src/drizzle/schema/media-library.schema.ts
+++ b/src/drizzle/schema/media-library.schema.ts
@@ -46,6 +46,8 @@ export const mediaCategories = pgTable(
     // Category details
     name: varchar('name', { length: 100 }).notNull(),
     description: text('description'),
+    // A folder belongs to exactly one asset type — image folders live in the
+    // Images section, video folders in Videos, and so on. Required.
     type: varchar('type', { length: 50 }).$type<MediaLibraryType>().notNull(),
     color: varchar('color', { length: 20 }), // Hex color for UI
     icon: varchar('icon', { length: 50 }), // Icon name for UI
@@ -166,9 +168,39 @@ export interface TemplateMediaSlot {
   acceptedTypes: ('image' | 'video' | 'gif')[];
 }
 
+/**
+ * An asset saved into the template itself, so every post made from it starts
+ * with that picture already attached.
+ *
+ * Deliberately shaped like the composer's own media item — same fields, same
+ * names — so applying a template is a copy rather than a translation.
+ */
+export interface TemplateMedia {
+  /** Stable id for this attachment within the template. */
+  id: string;
+  type: 'image' | 'video' | 'gif';
+  url: string;
+  thumbnailUrl?: string;
+  width?: number;
+  height?: number;
+  durationSec?: number;
+  sizeBytes?: number;
+}
+
 export interface TemplateContent {
   text: string; // Can contain {{placeholders}}
+  /**
+   * Empty slots to be filled when the template is used. Distinct from `media`:
+   * a slot is a *prompt* ("Hero image, required"), while `media` is an asset
+   * that comes along every time.
+   */
   mediaSlots: TemplateMediaSlot[];
+  /**
+   * Assets baked into the template. Optional so every template written before
+   * this existed still parses — `content` is jsonb, so old rows simply have no
+   * such key.
+   */
+  media?: TemplateMedia[];
   hashtags: string[];
   defaultCaption?: string;
 }

--- a/src/media-library/dto/media-library.dto.ts
+++ b/src/media-library/dto/media-library.dto.ts
@@ -12,6 +12,7 @@ import {
   Max,
   MaxLength,
   ValidateNested,
+  ValidateIf,
   IsIn,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
@@ -39,6 +40,7 @@ export class CreateCategoryDto {
   @IsString()
   description?: string;
 
+  // A folder belongs to exactly one asset type — required at creation.
   @IsEnum(MEDIA_LIBRARY_TYPES)
   type: MediaLibraryType;
 
@@ -158,9 +160,13 @@ export class UpdateMediaItemDto {
   @IsString()
   description?: string;
 
+  // `null` is meaningful here: it takes the item out of its folder. Only a
+  // non-null value is checked as a UUID, so "unfile" stays expressible —
+  // omitting the field still means "leave the folder as it is".
   @IsOptional()
+  @ValidateIf((_, value) => value !== null)
   @IsUUID()
-  categoryId?: string;
+  categoryId?: string | null;
 
   @IsOptional()
   @IsArray()
@@ -233,9 +239,14 @@ export class BulkActionDto {
   @IsEnum(['delete', 'restore', 'move', 'star', 'unstar', 'permanentDelete'])
   action: 'delete' | 'restore' | 'move' | 'star' | 'unstar' | 'permanentDelete';
 
+  // Only `move` reads this, and there `null` is a real instruction: take the
+  // selection out of its folders. Mirrors UpdateMediaItemDto so one item and a
+  // hundred can express the same thing — omit to leave folders alone, pass
+  // null to unfile, pass an id to file.
   @IsOptional()
+  @ValidateIf((_, value) => value !== null)
   @IsUUID()
-  categoryId?: string; // For move action
+  categoryId?: string | null; // For move action
 }
 
 // =============================================================================
@@ -257,18 +268,69 @@ export class TemplateMediaSlotDto {
   acceptedTypes: ('image' | 'video' | 'gif')[];
 }
 
+/**
+ * An asset saved into the template itself. Mirrors the composer's media item so
+ * applying a template is a copy, not a translation.
+ */
+export class TemplateMediaDto {
+  @IsString()
+  id: string;
+
+  @IsEnum(['image', 'video', 'gif'])
+  type: 'image' | 'video' | 'gif';
+
+  @IsUrl({ require_tld: false })
+  url: string;
+
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  thumbnailUrl?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  width?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  height?: number;
+
+  // Seconds. Integer to match how durations are stored everywhere else here —
+  // browsers report a float, so callers round before sending.
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  durationSec?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sizeBytes?: number;
+}
+
 export class TemplateContentDto {
   @IsString()
   text: string;
 
+  // Optional so a template that only bakes in media doesn't have to send an
+  // empty array to satisfy a field it never uses.
+  @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => TemplateMediaSlotDto)
-  mediaSlots: TemplateMediaSlotDto[];
+  mediaSlots?: TemplateMediaSlotDto[];
 
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TemplateMediaDto)
+  media?: TemplateMediaDto[];
+
+  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  hashtags: string[];
+  hashtags?: string[];
 
   @IsOptional()
   @IsString()

--- a/src/media-library/media-library.controller.ts
+++ b/src/media-library/media-library.controller.ts
@@ -197,6 +197,17 @@ export class MediaLibraryController {
     return this.mediaItemService.permanentDelete(workspaceId, itemId);
   }
 
+  /** Called when an asset is placed into a post, so the Library can show what
+   *  is actually being used. */
+  @Post('items/:itemId/use')
+  @HttpCode(HttpStatus.OK)
+  async recordMediaItemUsage(
+    @Param('workspaceId') workspaceId: string,
+    @Param('itemId') itemId: string,
+  ) {
+    return this.mediaItemService.incrementUsage(workspaceId, itemId);
+  }
+
   @Post('items/bulk')
   @HttpCode(HttpStatus.OK)
   async bulkActionMediaItems(
@@ -297,6 +308,17 @@ export class MediaLibraryController {
     return this.templateService.permanentDelete(workspaceId, templateId);
   }
 
+  /** Called when a template is applied to a post, so "Recently used" and the
+   *  "Most used" sort mean something for templates too. */
+  @Post('templates/:templateId/use')
+  @HttpCode(HttpStatus.OK)
+  async recordTemplateUsage(
+    @Param('workspaceId') workspaceId: string,
+    @Param('templateId') templateId: string,
+  ) {
+    return this.templateService.incrementUsage(workspaceId, templateId);
+  }
+
   // ==========================================================================
   // Text Snippets
   // ==========================================================================
@@ -369,6 +391,16 @@ export class MediaLibraryController {
     @Param('snippetId') snippetId: string,
   ) {
     return this.textSnippetService.permanentDelete(workspaceId, snippetId);
+  }
+
+  /** Called when a snippet is copied or inserted into a post. */
+  @Post('snippets/:snippetId/use')
+  @HttpCode(HttpStatus.OK)
+  async recordTextSnippetUsage(
+    @Param('workspaceId') workspaceId: string,
+    @Param('snippetId') snippetId: string,
+  ) {
+    return this.textSnippetService.incrementUsage(workspaceId, snippetId);
   }
 
   // ==========================================================================
@@ -448,6 +480,16 @@ export class MediaLibraryController {
     @Param('linkId') linkId: string,
   ) {
     return this.savedLinkService.permanentDelete(workspaceId, linkId);
+  }
+
+  /** Called when a saved link is opened or added to a post. */
+  @Post('links/:linkId/use')
+  @HttpCode(HttpStatus.OK)
+  async recordSavedLinkUsage(
+    @Param('workspaceId') workspaceId: string,
+    @Param('linkId') linkId: string,
+  ) {
+    return this.savedLinkService.incrementUsage(workspaceId, linkId);
   }
 
   // ==========================================================================

--- a/src/media-library/services/category.service.ts
+++ b/src/media-library/services/category.service.ts
@@ -25,7 +25,8 @@ export class CategoryService {
    * Create a new category
    */
   async create(workspaceId: string, dto: CreateCategoryDto) {
-    // Check for duplicate name within same type
+    // A folder belongs to one type, so a name is unique per (workspace, type):
+    // the same name may exist as an image folder and a video folder.
     const existing = await db
       .select()
       .from(mediaCategories)
@@ -40,11 +41,11 @@ export class CategoryService {
 
     if (existing.length > 0) {
       throw new ConflictException(
-        `Category "${dto.name}" already exists for type "${dto.type}"`,
+        `A ${dto.type} folder named "${dto.name}" already exists`,
       );
     }
 
-    // Get max display order
+    // Get max display order within this workspace + type
     const maxOrder = await db
       .select({ maxOrder: mediaCategories.displayOrder })
       .from(mediaCategories)
@@ -95,7 +96,7 @@ export class CategoryService {
       .select()
       .from(mediaCategories)
       .where(and(...conditions))
-      .orderBy(asc(mediaCategories.type), asc(mediaCategories.displayOrder));
+      .orderBy(asc(mediaCategories.displayOrder), asc(mediaCategories.name));
 
     return categories;
   }
@@ -118,7 +119,7 @@ export class CategoryService {
 
     for (const category of categories) {
       const type = category.type;
-      if (grouped[type]) {
+      if (type && grouped[type]) {
         grouped[type].push(category);
       }
     }
@@ -158,7 +159,8 @@ export class CategoryService {
   ) {
     const existing = await this.findOne(workspaceId, categoryId);
 
-    // Check for duplicate name if name is being changed
+    // Check for duplicate name if name is being changed (unique per
+    // workspace + type — the folder's type can't change on update).
     if (dto.name && dto.name !== existing.name) {
       const duplicate = await db
         .select()
@@ -174,7 +176,7 @@ export class CategoryService {
 
       if (duplicate.length > 0) {
         throw new ConflictException(
-          `Category "${dto.name}" already exists for type "${existing.type}"`,
+          `A ${existing.type} folder named "${dto.name}" already exists`,
         );
       }
     }

--- a/src/media-library/services/media-item.service.ts
+++ b/src/media-library/services/media-item.service.ts
@@ -56,7 +56,8 @@ export class MediaItemService {
         throw new BadRequestException('Category not found');
       }
 
-      // Ensure category type matches item type
+      // A folder belongs to one type — an item can only be filed into a folder
+      // of its own type (an image can't live in a video folder).
       if (category[0].type !== dto.type) {
         throw new BadRequestException(
           `Category type "${category[0].type}" does not match item type "${dto.type}"`,
@@ -145,6 +146,21 @@ export class MediaItemService {
 
     const orderFn = sortOrder === 'asc' ? asc : desc;
 
+    // `lastUsedAt` stays null until an asset is used in a post, so "never used"
+    // belongs after everything that has been used. Postgres puts NULLS FIRST
+    // for DESC by default, which ranked untouched assets above used ones.
+    const primaryOrder =
+      sortBy === 'lastUsedAt'
+        ? sortOrder === 'asc'
+          ? sql`${mediaItems.lastUsedAt} ASC NULLS LAST`
+          : sql`${mediaItems.lastUsedAt} DESC NULLS LAST`
+        : orderFn(sortColumn);
+
+    // Ties need a deterministic tiebreaker. With every row sharing a null
+    // `lastUsedAt`, ordering on that column alone left Postgres free to return
+    // rows in heap order — and an UPDATE (starring an asset) rewrites the tuple
+    // at the end of the heap, so starring an image visibly threw it to the
+    // bottom of the grid. Stable secondary keys keep positions still.
     const items = await db
       .select({
         item: mediaItems,
@@ -153,7 +169,7 @@ export class MediaItemService {
       .from(mediaItems)
       .leftJoin(mediaCategories, eq(mediaItems.categoryId, mediaCategories.id))
       .where(and(...conditions))
-      .orderBy(orderFn(sortColumn))
+      .orderBy(primaryOrder, desc(mediaItems.createdAt), desc(mediaItems.id))
       .limit(limit)
       .offset(offset);
 
@@ -225,7 +241,9 @@ export class MediaItemService {
   async update(workspaceId: string, itemId: string, dto: UpdateMediaItemDto) {
     const existing = await this.findOne(workspaceId, itemId);
 
-    // Validate category if changing
+    // Validate category if changing. A null `categoryId` skips this on purpose:
+    // it means "take this out of its folder", and there is no target type to
+    // match against. `undefined` (field omitted) leaves the folder untouched.
     if (dto.categoryId && dto.categoryId !== existing.categoryId) {
       const category = await db
         .select()
@@ -404,15 +422,48 @@ export class MediaItemService {
           .where(inArray(mediaItems.id, ids));
         break;
 
-      case 'move':
-        if (!categoryId) {
+      case 'move': {
+        // `undefined` means the caller never said where to move things, which
+        // is not a move at all. `null` is a decision — unfile the selection —
+        // so the two are told apart here rather than lumped as falsy.
+        if (categoryId === undefined) {
           throw new BadRequestException('categoryId required for move action');
         }
+
+        if (categoryId !== null) {
+          const [category] = await db
+            .select()
+            .from(mediaCategories)
+            .where(
+              and(
+                eq(mediaCategories.id, categoryId),
+                eq(mediaCategories.workspaceId, workspaceId),
+              ),
+            )
+            .limit(1);
+
+          if (!category) {
+            throw new BadRequestException('Category not found');
+          }
+
+          // Folders belong to exactly one type, and single-item moves already
+          // enforce that. Without the same check here, a bulk move could file
+          // a video into an Images folder — where it would then be invisible
+          // to the Videos section that owns it.
+          const mismatched = items.find((item) => item.type !== category.type);
+          if (mismatched) {
+            throw new BadRequestException(
+              `Category type "${category.type}" does not match item type "${mismatched.type}"`,
+            );
+          }
+        }
+
         await db
           .update(mediaItems)
           .set({ categoryId, updatedAt: new Date() })
           .where(inArray(mediaItems.id, ids));
         break;
+      }
 
       case 'star':
         await db
@@ -461,17 +512,37 @@ export class MediaItemService {
   }
 
   /**
-   * Increment usage count when item is used in a post
+   * Record that an item was used in a post.
+   *
+   * Scoped to the workspace like every other write here: the id alone comes
+   * from the client, so without the workspace in the WHERE clause any
+   * authenticated user could bump the counters on someone else's asset.
+   *
+   * This is what fills `lastUsedAt`, which the "Recently used" view and the
+   * "Most used" sort both read — until something calls this, both are empty by
+   * construction.
    */
-  async incrementUsage(itemId: string) {
-    await db
+  async incrementUsage(workspaceId: string, itemId: string) {
+    const [updated] = await db
       .update(mediaItems)
       .set({
         usageCount: sql`${mediaItems.usageCount} + 1`,
         lastUsedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(mediaItems.id, itemId));
+      .where(
+        and(
+          eq(mediaItems.id, itemId),
+          eq(mediaItems.workspaceId, workspaceId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('Media item not found');
+    }
+
+    return updated;
   }
 
   /**

--- a/src/media-library/services/saved-link.service.ts
+++ b/src/media-library/services/saved-link.service.ts
@@ -371,15 +371,25 @@ export class SavedLinkService {
   /**
    * Increment usage count when link is used
    */
-  async incrementUsage(linkId: string) {
-    await db
+  async incrementUsage(workspaceId: string, linkId: string) {
+    // Workspace-scoped so one workspace can't bump another's counter by id.
+    const [updated] = await db
       .update(savedLinks)
       .set({
         usageCount: sql`${savedLinks.usageCount} + 1`,
         lastUsedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(savedLinks.id, linkId));
+      .where(
+        and(eq(savedLinks.id, linkId), eq(savedLinks.workspaceId, workspaceId)),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('Link not found');
+    }
+
+    return updated;
   }
 
   /**

--- a/src/media-library/services/template.service.ts
+++ b/src/media-library/services/template.service.ts
@@ -10,12 +10,32 @@ import {
   mediaTemplates,
   mediaCategories,
   NewMediaTemplate,
+  TemplateContent,
 } from '../../drizzle/schema/media-library.schema';
 import {
   CreateTemplateDto,
+  TemplateContentDto,
   UpdateTemplateDto,
   TemplateQueryDto,
 } from '../dto/media-library.dto';
+
+/**
+ * Fill in the parts of `content` a caller left out.
+ *
+ * The DTO lets a template send only what it uses — a text-only template has no
+ * media slots, a media-only one has no hashtags — but what lands in the column
+ * is always the complete shape. Readers can then index into `mediaSlots` and
+ * `hashtags` without guarding every access.
+ */
+function normalizeContent(content: TemplateContentDto): TemplateContent {
+  return {
+    text: content.text,
+    mediaSlots: content.mediaSlots ?? [],
+    media: content.media ?? [],
+    hashtags: content.hashtags ?? [],
+    defaultCaption: content.defaultCaption,
+  };
+}
 
 @Injectable()
 export class TemplateService {
@@ -51,7 +71,7 @@ export class TemplateService {
       description: dto.description,
       templateType: dto.templateType,
       platforms: dto.platforms || [],
-      content: dto.content,
+      content: normalizeContent(dto.content),
       thumbnailUrl: dto.thumbnailUrl,
       categoryId: dto.categoryId,
       tags: dto.tags || [],
@@ -222,7 +242,8 @@ export class TemplateService {
     if (dto.templateType !== undefined)
       updateData.templateType = dto.templateType;
     if (dto.platforms !== undefined) updateData.platforms = dto.platforms;
-    if (dto.content !== undefined) updateData.content = dto.content;
+    if (dto.content !== undefined)
+      updateData.content = normalizeContent(dto.content);
     if (dto.thumbnailUrl !== undefined)
       updateData.thumbnailUrl = dto.thumbnailUrl;
     if (dto.categoryId !== undefined) updateData.categoryId = dto.categoryId;
@@ -348,15 +369,29 @@ export class TemplateService {
   /**
    * Increment usage count when template is used
    */
-  async incrementUsage(templateId: string) {
-    await db
+  async incrementUsage(workspaceId: string, templateId: string) {
+    // Workspace-scoped so one workspace can't bump another's counter by id —
+    // the same hole that was closed on media items.
+    const [updated] = await db
       .update(mediaTemplates)
       .set({
         usageCount: sql`${mediaTemplates.usageCount} + 1`,
         lastUsedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(mediaTemplates.id, templateId));
+      .where(
+        and(
+          eq(mediaTemplates.id, templateId),
+          eq(mediaTemplates.workspaceId, workspaceId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('Template not found');
+    }
+
+    return updated;
   }
 
   /**

--- a/src/media-library/services/text-snippet.service.ts
+++ b/src/media-library/services/text-snippet.service.ts
@@ -295,15 +295,28 @@ export class TextSnippetService {
   /**
    * Increment usage count when snippet is used
    */
-  async incrementUsage(snippetId: string) {
-    await db
+  async incrementUsage(workspaceId: string, snippetId: string) {
+    // Workspace-scoped so one workspace can't bump another's counter by id.
+    const [updated] = await db
       .update(textSnippets)
       .set({
         usageCount: sql`${textSnippets.usageCount} + 1`,
         lastUsedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(textSnippets.id, snippetId));
+      .where(
+        and(
+          eq(textSnippets.id, snippetId),
+          eq(textSnippets.workspaceId, workspaceId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('Snippet not found');
+    }
+
+    return updated;
   }
 
   /**

--- a/src/media/dto/media.dto.ts
+++ b/src/media/dto/media.dto.ts
@@ -3,6 +3,7 @@ import {
   IsOptional,
   IsArray,
   IsEnum,
+  IsNumber,
   IsUrl,
   MaxLength,
 } from 'class-validator';
@@ -121,9 +122,12 @@ export class PresignComposerVideoDto {
   @IsOptional()
   filename?: string;
 
-  // Size validation (cap + non-negative) happens inside CloudflareR2Service
-  // — we just type it here. class-validator's number guards (IsInt, Min,
-  // Max) would reject the 4 GB cap as a precision issue without explicit
-  // coercion, and the service is the authoritative limit anyway.
+  // The bounds check (cap + non-negative) lives in CloudflareR2Service, which
+  // stays the authoritative limit. `@IsNumber` is here only so the field
+  // survives the global ValidationPipe: `whitelist: true` strips properties
+  // carrying no decorator and `forbidNonWhitelisted: true` then rejects the
+  // request, so an undecorated field failed every presign with
+  // "property sizeBytes should not exist".
+  @IsNumber()
   sizeBytes: number;
 }


### PR DESCRIPTION
…ia slots

- Add workspace-scoped incrementUsage on templates/snippets/links with POST /use routes so "Used N×" reflects real usage
- Support template/text_snippet/link categories (folders) end-to-end; category delete unfiles entries via onDelete: set null
- Add mediaSlots to template content schema/DTO for pick-media-each-time templates