### PR TITLE
fix(channels): drop ads scopes from Facebook base connect (Invalid Sc…

### DIFF
--- a/src/drizzle/schema/channels.schema.ts
+++ b/src/drizzle/schema/channels.schema.ts
@@ -417,13 +417,13 @@ export const PLATFORM_CONFIG: Record<
       // Must be enabled in Meta App Console + submitted for App Review; existing
       // Facebook channels must RECONNECT to gain the scope.
       'pages_messaging',
-      // === Ads Phase 1 additions ===
-      // Must be approved in Meta App Console before existing users will see them.
-      'ads_management',
-      'ads_read',
-      'leads_retrieval',
-      'pages_manage_ads',
-      'business_management',
+      // Ads scopes (ads_management, ads_read, leads_retrieval, pages_manage_ads,
+      // business_management) are intentionally NOT requested at base connect.
+      // They live only in facebookScopesFor('ads') for the incremental ads/Boost
+      // upgrade of an already-connected Page. A Facebook app that has no ads use
+      // case configured rejects the whole base connect with "Invalid Scopes" if
+      // they are present here, so keeping them out lets publishing/comments/
+      // messenger connect cleanly on a publishing-only Facebook app.
     ],
   },
   instagram: {


### PR DESCRIPTION
…opes)

A publishing-only Facebook app has no ads use case, so Meta rejects the whole connect with "Invalid Scopes: ads_management, ads_read, leads_retrieval, pages_manage_ads" when the base connect requests them. These scopes already live in facebookScopesFor('ads') for the incremental ads/Boost upgrade of an already-connected Page, so removing them from the base connect is behaviour-preserving for ads and unblocks FB connect on the dedicated FB app. Base connect now requests exactly the 8 review scopes (public_profile + 6 core Pages + pages_messaging).