### PR TITLE
feat(inbox): enrich Facebook comment avatars on the realtime webhook …

### DIFF
--- a/src/channels/services/facebook.service.ts
+++ b/src/channels/services/facebook.service.ts
@@ -1168,6 +1168,45 @@ export class FacebookService {
   }
 
   /**
+   * Fetch a comment author's profile picture URL.
+   *
+   * The FB `feed` comment webhook payload carries only `from.{id,name}` — no
+   * picture — so realtime, webhook-ingested comments would render without an
+   * avatar. Polling gets the picture via `from{picture}` on the comment edge;
+   * this mirrors that with a single `GET /{comment-id}?fields=from{picture}`
+   * so both paths surface the same avatar. Best-effort: returns null on any
+   * failure and the caller keeps the null (UI falls back to initials).
+   */
+  async getCommentAuthorPicture(
+    commentId: string,
+    pageAccessToken: string,
+  ): Promise<string | null> {
+    try {
+      const url = new URL(`${this.graphApiUrl}/${commentId}`);
+      url.searchParams.set('fields', 'from{picture}');
+      url.searchParams.set('access_token', pageAccessToken);
+
+      const res = await fetch(url.toString());
+      if (!res.ok) {
+        const err = await res.text();
+        this.logger.warn(
+          `getCommentAuthorPicture failed for comment=${commentId}: ${res.status} ${err}`,
+        );
+        return null;
+      }
+      const data = (await res.json()) as {
+        from?: { picture?: { data?: { url?: string } } };
+      };
+      return data.from?.picture?.data?.url ?? null;
+    } catch (err) {
+      this.logger.warn(
+        `getCommentAuthorPicture threw for comment=${commentId}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
    * List Messenger conversations on this Page.
    *
    * Endpoint: GET /<page-id>/conversations

--- a/src/channels/webhooks.controller.ts
+++ b/src/channels/webhooks.controller.ts
@@ -671,6 +671,7 @@ export class WebhooksController {
     authorPlatformId?: string;
     authorHandle?: string;
     authorDisplayName?: string;
+    authorAvatarUrl?: string | null;
     text: string;
     eventTime: Date;
   }): Promise<void> {
@@ -697,6 +698,32 @@ export class WebhooksController {
       return;
     }
 
+    // Comment webhooks carry only the author's id + name, not their avatar, so
+    // realtime comments would render without a profile picture. Fetch it here —
+    // after the our-post check above, so we never spend an API call on foreign
+    // comments — to match the avatar that polling surfaces via `from{picture}`.
+    let authorAvatarUrl: string | null = args.authorAvatarUrl ?? null;
+    if (
+      !authorAvatarUrl &&
+      args.platform === 'facebook' &&
+      args.authorPlatformId
+    ) {
+      try {
+        const token = await this.channelService.getAccessToken(
+          channel.id,
+          channel.workspaceId,
+        );
+        authorAvatarUrl = await this.facebookService.getCommentAuthorPicture(
+          args.platformItemId,
+          token,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Facebook comment avatar enrichment failed for ${args.platformItemId}: ${(err as Error).message}`,
+        );
+      }
+    }
+
     await this.inbox.upsertComment({
       workspaceId: channel.workspaceId,
       channelId: channel.id,
@@ -708,6 +735,7 @@ export class WebhooksController {
       authorPlatformId: args.authorPlatformId,
       authorHandle: args.authorHandle,
       authorDisplayName: args.authorDisplayName,
+      authorAvatarUrl,
       text: args.text,
       fromMe: false, // webhooks don't fire for our own comments; safe default
       platformCreatedAt: args.eventTime,


### PR DESCRIPTION
…path

FB `feed` comment webhooks carry only from.{id,name} — no picture — so realtime comments rendered without an avatar while polled ones (which fetch from{picture}) had it. Add FacebookService.getCommentAuthorPicture and call it in ingestFromWebhook AFTER the our-post check (so no API call is spent on foreign comments), passing authorAvatarUrl through to upsertComment. Webhook and polling now surface the same avatar without waiting for the next poll.