### PR TITLE
fix(inbox): fan out realtime webhooks to every workspace sharing an a…

### DIFF
--- a/src/channels/analytics/youtube-pubsubhubbub.controller.ts
+++ b/src/channels/analytics/youtube-pubsubhubbub.controller.ts
@@ -106,18 +106,17 @@ export class YouTubePubSubHubbubController {
     );
 
     // Resolve to our internal channel
-    const rows = await this.db
+    const rows = (await this.db
       .select({
         id: socialMediaChannels.id,
         workspaceId: socialMediaChannels.workspaceId,
       })
       .from(socialMediaChannels)
-      .where(eq(socialMediaChannels.platformAccountId, parsed.channelId))
-      .limit(1);
+      .where(
+        eq(socialMediaChannels.platformAccountId, parsed.channelId),
+      )) as Array<{ id: number; workspaceId: string }>;
 
-    const channel = rows[0] as { id: number; workspaceId: string } | undefined;
-
-    if (!channel) {
+    if (rows.length === 0) {
       this.logger.warn(
         `PubSubHubbub POST: no channel found for ytChannelId=${parsed.channelId} — ignoring`,
       );
@@ -125,16 +124,21 @@ export class YouTubePubSubHubbubController {
       return;
     }
 
-    // Enqueue an immediate recent-posts-sync (sinceDays=1, limit=5)
-    await this.queue.add('channel-recent-posts-sync', {
-      channelId: Number(channel.id),
-      workspaceId: channel.workspaceId,
-      sinceDays: 1,
-      limit: 5,
-    });
+    // Fan out to EVERY workspace that connected this YouTube channel — the same
+    // channel can be connected by more than one workspace, and a single-row
+    // lookup would sync the new upload for only one of them.
+    for (const channel of rows) {
+      // Enqueue an immediate recent-posts-sync (sinceDays=1, limit=5)
+      await this.queue.add('channel-recent-posts-sync', {
+        channelId: Number(channel.id),
+        workspaceId: channel.workspaceId,
+        sinceDays: 1,
+        limit: 5,
+      });
+    }
 
     this.logger.log(
-      `PubSubHubbub POST: enqueued recent-posts-sync for channelId=${channel.id} (videoId=${parsed.videoId})`,
+      `PubSubHubbub POST: enqueued recent-posts-sync for ${rows.length} channel(s) (ytChannelId=${parsed.channelId}, videoId=${parsed.videoId})`,
     );
 
     res.status(200).send('ok');

--- a/src/channels/webhooks.controller.ts
+++ b/src/channels/webhooks.controller.ts
@@ -373,12 +373,15 @@ export class WebhooksController {
     const otherPartyId = fromMe ? recipientId : senderId;
     const conversationId = `${accountId}:${otherPartyId}`;
 
-    // Look up channel + workspace by platform account id.
-    const channel = await this.inbox.findChannelByPlatformAccount(
+    // Fan out to EVERY workspace this account is connected to. Platform
+    // webhooks fire only once per event, so resolving a single channel would
+    // silently drop the DM for every other workspace that shares this account
+    // (e.g. an agency and its client both connect the same Page).
+    const channels = await this.inbox.findChannelsByPlatformAccount(
       source as SupportedPlatform,
       accountId,
     );
-    if (!channel) {
+    if (channels.length === 0) {
       this.logger.warn(
         `${source} DM webhook: NO CHANNEL FOUND for platform=${source} platformAccountId=${accountId}. ` +
           `Check that the connected channel's platformAccountId matches this id ` +
@@ -386,9 +389,6 @@ export class WebhooksController {
       );
       return;
     }
-    this.logger.log(
-      `${source} DM webhook: matched channel=${channel.id} workspace=${channel.workspaceId}`,
-    );
 
     // Timestamp parsing — FB Messenger sends ms, IG samples sometimes show
     // seconds. Auto-detect: anything below 10^12 is seconds.
@@ -401,9 +401,11 @@ export class WebhooksController {
     }
 
     // Enrich author info for inbound messages (not echoes). The webhook payload
-    // only contains the platform id of the sender — name + avatar come from
-    // the User Profile API. Best-effort: if the call fails, we still ingest
-    // the row with null author fields and surface "Unknown" in the UI.
+    // only contains the platform id of the sender — name + avatar come from the
+    // User Profile API. The profile is identical for every workspace, so we
+    // resolve it once (using any connected channel's token) instead of per
+    // workspace. Best-effort: on failure we ingest null author fields and
+    // surface "Unknown" in the UI.
     let authorHandle: string | null = null;
     let authorDisplayName: string | null = null;
     let authorAvatarUrl: string | null = null;
@@ -411,8 +413,8 @@ export class WebhooksController {
     if (!fromMe) {
       try {
         const token = await this.channelService.getAccessToken(
-          channel.id,
-          channel.workspaceId,
+          channels[0].id,
+          channels[0].workspaceId,
         );
         if (source === 'facebook') {
           const profile = await this.facebookService.getMessengerUserProfile(
@@ -442,25 +444,27 @@ export class WebhooksController {
       }
     }
 
-    await this.inbox.upsertDm({
-      workspaceId: channel.workspaceId,
-      channelId: channel.id,
-      platform: source as SupportedPlatform,
-      conversationId,
-      platformItemId: mid,
-      platformParentId: (message.reply_to?.mid as string | undefined) ?? null,
-      authorPlatformId: otherPartyId,
-      authorHandle,
-      authorDisplayName,
-      authorAvatarUrl,
-      text,
-      fromMe,
-      platformCreatedAt: createdAt,
-      metadata: { raw: event },
-    });
+    for (const channel of channels) {
+      await this.inbox.upsertDm({
+        workspaceId: channel.workspaceId,
+        channelId: channel.id,
+        platform: source as SupportedPlatform,
+        conversationId,
+        platformItemId: mid,
+        platformParentId: (message.reply_to?.mid as string | undefined) ?? null,
+        authorPlatformId: otherPartyId,
+        authorHandle,
+        authorDisplayName,
+        authorAvatarUrl,
+        text,
+        fromMe,
+        platformCreatedAt: createdAt,
+        metadata: { raw: event },
+      });
+    }
 
     this.logger.log(
-      `${source} DM ingested: convo=${conversationId} mid=${mid} fromMe=${fromMe}`,
+      `${source} DM ingested: convo=${conversationId} mid=${mid} fromMe=${fromMe} channels=${channels.length}`,
     );
   }
 
@@ -584,22 +588,16 @@ export class WebhooksController {
       return;
     }
 
-    const channel = await this.inbox.findChannelByPlatformAccount(
+    // Fan out to EVERY workspace this Threads account is connected to. The
+    // per-channel "our post" check routes the reply to whichever workspace(s)
+    // published the post.
+    const channels = await this.inbox.findChannelsByPlatformAccount(
       'threads',
       ownerId,
     );
-    if (!channel) {
+    if (channels.length === 0) {
       this.logger.warn(
         `Threads reply webhook: no connected channel for owner_id ${ownerId}`,
-      );
-      return;
-    }
-
-    // Only ingest replies on posts we published via Schedura (Phase 1 scope).
-    const ourPostId = await this.inbox.findOurPostId(channel.id, platformPostId);
-    if (!ourPostId) {
-      this.logger.verbose(
-        `Threads reply webhook ignored: post ${platformPostId} not from Schedura`,
       );
       return;
     }
@@ -630,30 +628,44 @@ export class WebhooksController {
       ? new Date(value.timestamp as string)
       : new Date();
 
-    await this.inbox.upsertComment({
-      workspaceId: channel.workspaceId,
-      channelId: channel.id,
-      platform: 'threads',
-      platformItemId,
-      platformParentId: parentId,
-      platformPostId,
-      ourPostId,
-      authorHandle: authorUsername ?? null,
-      authorDisplayName: authorUsername ?? null,
-      authorAvatarUrl:
-        (value?.profile_picture_url as string | undefined) ?? null,
-      text: (value?.text as string | undefined) ?? '',
-      fromMe,
-      isMention,
-      platformCreatedAt: createdAt,
-      metadata: {
-        permalink: value?.permalink,
-        shortcode: value?.shortcode,
-      },
-    });
+    for (const channel of channels) {
+      // Only ingest replies on posts THIS workspace published (Phase 1 scope).
+      const ourPostId = await this.inbox.findOurPostId(
+        channel.id,
+        platformPostId,
+      );
+      if (!ourPostId) {
+        this.logger.verbose(
+          `Threads reply webhook ignored: post ${platformPostId} not from Schedura (channel ${channel.id})`,
+        );
+        continue;
+      }
+
+      await this.inbox.upsertComment({
+        workspaceId: channel.workspaceId,
+        channelId: channel.id,
+        platform: 'threads',
+        platformItemId,
+        platformParentId: parentId,
+        platformPostId,
+        ourPostId,
+        authorHandle: authorUsername ?? null,
+        authorDisplayName: authorUsername ?? null,
+        authorAvatarUrl:
+          (value?.profile_picture_url as string | undefined) ?? null,
+        text: (value?.text as string | undefined) ?? '',
+        fromMe,
+        isMention,
+        platformCreatedAt: createdAt,
+        metadata: {
+          permalink: value?.permalink,
+          shortcode: value?.shortcode,
+        },
+      });
+    }
 
     this.logger.log(
-      `Threads reply webhook ingested: reply=${platformItemId} post=${platformPostId} fromMe=${fromMe} isMention=${isMention}`,
+      `Threads reply webhook ingested: reply=${platformItemId} post=${platformPostId} fromMe=${fromMe} isMention=${isMention} channels=${channels.length}`,
     );
   }
 
@@ -675,71 +687,77 @@ export class WebhooksController {
     text: string;
     eventTime: Date;
   }): Promise<void> {
-    const channel = await this.inbox.findChannelByPlatformAccount(
+    // Fan out to EVERY workspace this account is connected to. The per-channel
+    // "our post" check below routes the comment to whichever workspace(s)
+    // actually published the post — resolving a single channel would drop the
+    // comment entirely whenever the wrong workspace won the lookup.
+    const channels = await this.inbox.findChannelsByPlatformAccount(
       args.platform,
       args.platformAccountIdToMatch,
     );
-    if (!channel) {
+    if (channels.length === 0) {
       this.logger.warn(
         `Webhook for ${args.platform} account ${args.platformAccountIdToMatch}: channel not connected`,
       );
       return;
     }
 
-    // Only ingest comments on posts published via Schedura.
-    const ourPostId = await this.inbox.findOurPostId(
-      channel.id,
-      args.platformPostId,
-    );
-    if (!ourPostId) {
-      this.logger.verbose(
-        `Webhook ignored: ${args.platform} post ${args.platformPostId} not from Schedura`,
+    for (const channel of channels) {
+      // Only ingest comments on posts THIS workspace published via Schedura.
+      const ourPostId = await this.inbox.findOurPostId(
+        channel.id,
+        args.platformPostId,
       );
-      return;
-    }
-
-    // Comment webhooks carry only the author's id + name, not their avatar, so
-    // realtime comments would render without a profile picture. Fetch it here —
-    // after the our-post check above, so we never spend an API call on foreign
-    // comments — to match the avatar that polling surfaces via `from{picture}`.
-    let authorAvatarUrl: string | null = args.authorAvatarUrl ?? null;
-    if (
-      !authorAvatarUrl &&
-      args.platform === 'facebook' &&
-      args.authorPlatformId
-    ) {
-      try {
-        const token = await this.channelService.getAccessToken(
-          channel.id,
-          channel.workspaceId,
+      if (!ourPostId) {
+        this.logger.verbose(
+          `Webhook ignored: ${args.platform} post ${args.platformPostId} not from Schedura (channel ${channel.id})`,
         );
-        authorAvatarUrl = await this.facebookService.getCommentAuthorPicture(
-          args.platformItemId,
-          token,
-        );
-      } catch (err) {
-        this.logger.warn(
-          `Facebook comment avatar enrichment failed for ${args.platformItemId}: ${(err as Error).message}`,
-        );
+        continue;
       }
-    }
 
-    await this.inbox.upsertComment({
-      workspaceId: channel.workspaceId,
-      channelId: channel.id,
-      platform: args.platform,
-      platformItemId: args.platformItemId,
-      platformParentId: args.platformParentId,
-      platformPostId: args.platformPostId,
-      ourPostId,
-      authorPlatformId: args.authorPlatformId,
-      authorHandle: args.authorHandle,
-      authorDisplayName: args.authorDisplayName,
-      authorAvatarUrl,
-      text: args.text,
-      fromMe: false, // webhooks don't fire for our own comments; safe default
-      platformCreatedAt: args.eventTime,
-    });
+      // Comment webhooks carry only the author's id + name, not their avatar, so
+      // realtime comments would render without a profile picture. Fetch it here —
+      // after the our-post check above, so we never spend an API call on foreign
+      // comments — to match the avatar that polling surfaces via `from{picture}`.
+      let authorAvatarUrl: string | null = args.authorAvatarUrl ?? null;
+      if (
+        !authorAvatarUrl &&
+        args.platform === 'facebook' &&
+        args.authorPlatformId
+      ) {
+        try {
+          const token = await this.channelService.getAccessToken(
+            channel.id,
+            channel.workspaceId,
+          );
+          authorAvatarUrl = await this.facebookService.getCommentAuthorPicture(
+            args.platformItemId,
+            token,
+          );
+        } catch (err) {
+          this.logger.warn(
+            `Facebook comment avatar enrichment failed for ${args.platformItemId}: ${(err as Error).message}`,
+          );
+        }
+      }
+
+      await this.inbox.upsertComment({
+        workspaceId: channel.workspaceId,
+        channelId: channel.id,
+        platform: args.platform,
+        platformItemId: args.platformItemId,
+        platformParentId: args.platformParentId,
+        platformPostId: args.platformPostId,
+        ourPostId,
+        authorPlatformId: args.authorPlatformId,
+        authorHandle: args.authorHandle,
+        authorDisplayName: args.authorDisplayName,
+        authorAvatarUrl,
+        text: args.text,
+        fromMe: false, // webhooks don't fire for our own comments; safe default
+        platformCreatedAt: args.eventTime,
+      });
+    }
   }
 
   // ==========================================================================

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -1891,22 +1891,43 @@ export class InboxService {
   // Lookup helpers used by webhook handlers
   // ==========================================================================
 
-  async findChannelByPlatformAccount(
+  /**
+   * Every channel row that holds this (platform, platformAccountId), across ALL
+   * workspaces, ordered by channel id.
+   *
+   * The same external account (e.g. one Facebook Page) can legitimately be
+   * connected to more than one workspace — an agency and its client are both
+   * admins of the same Page. Platform webhooks fire only ONCE per event, so any
+   * inbound-event handler MUST fan the event out to every matching channel here;
+   * resolving to a single row silently drops the event for every other workspace.
+   */
+  async findChannelsByPlatformAccount(
     platform: SupportedPlatform,
     platformAccountId: string,
   ) {
-    const matches = await db.query.socialMediaChannels.findMany({
+    return db.query.socialMediaChannels.findMany({
       where: and(
         eq(socialMediaChannels.platform, platform),
         eq(socialMediaChannels.platformAccountId, platformAccountId),
       ),
       orderBy: (c, { asc }) => asc(c.id),
     });
-    if (matches.length > 1) {
-      this.logger.warn(
-        `findChannelByPlatformAccount: ${matches.length} rows for ${platform}/${platformAccountId} — routing to the lowest channel id (${matches[0].id}). This should not happen; a cross-workspace duplicate slipped past the connect guard.`,
-      );
-    }
+  }
+
+  /**
+   * @deprecated Resolves to a single channel and therefore drops the event for
+   * every other workspace when the same account is connected more than once.
+   * Prefer {@link findChannelsByPlatformAccount} and fan out. Kept only for
+   * callers that are provably 1:1.
+   */
+  async findChannelByPlatformAccount(
+    platform: SupportedPlatform,
+    platformAccountId: string,
+  ) {
+    const matches = await this.findChannelsByPlatformAccount(
+      platform,
+      platformAccountId,
+    );
     return matches[0];
   }
 

--- a/src/inbox/processors/discord-ingest.processor.ts
+++ b/src/inbox/processors/discord-ingest.processor.ts
@@ -53,14 +53,29 @@ export class DiscordIngestProcessor extends WorkerHost {
   ): Promise<void> {
     const { type, message: msg } = job.data;
 
-    const channel = await this.resolveChannel(msg.guild_id);
-    if (!channel) {
+    const channels = await this.resolveChannels(msg.guild_id);
+    if (channels.length === 0) {
       this.logger.warn(
         `No Discord channel row for guild ${msg.guild_id ?? '(dm)'} — skipping`,
       );
       return;
     }
 
+    // Fan out to EVERY workspace this guild is connected to (a guild can be
+    // linked by more than one workspace); a single-row lookup would drop the
+    // message for the others.
+    for (const channel of channels) {
+      await this.ingestForChannel(channel, type, msg);
+    }
+  }
+
+  /** Ingest one Discord gateway event into a single channel/workspace. Called
+   *  once per matching channel by {@link process}. */
+  private async ingestForChannel(
+    channel: { id: number; workspaceId: string },
+    type: 'create' | 'update' | 'delete' | 'ask',
+    msg: any,
+  ): Promise<void> {
     if (type === 'delete') {
       await this.inbox.softDeleteDmByPlatformItemId({
         workspaceId: channel.workspaceId,
@@ -149,12 +164,14 @@ export class DiscordIngestProcessor extends WorkerHost {
     });
   }
 
-  /** Resolve the Schedura channel row for an event. Guild messages map by
-   *  `guild_id`; DMs (no guild) attribute to the most-recently-connected Discord
-   *  channel (Phase 1 routing — see design doc open question). */
-  private async resolveChannel(guildId?: string) {
+  /** Resolve the Schedura channel rows for an event. Guild messages fan out to
+   *  EVERY channel mapped to `guild_id`; DMs (no guild) can't be attributed to a
+   *  specific workspace with a shared bot, so they keep the Phase-1 behaviour of
+   *  the most-recently-connected Discord channel as a single-element list (proper
+   *  per-workspace DM routing needs per-workspace bots — tracked separately). */
+  private async resolveChannels(guildId?: string) {
     if (guildId) {
-      const [c] = await db
+      return db
         .select()
         .from(socialMediaChannels)
         .where(
@@ -162,9 +179,7 @@ export class DiscordIngestProcessor extends WorkerHost {
             eq(socialMediaChannels.platform, 'discord'),
             eq(socialMediaChannels.platformAccountId, guildId),
           ),
-        )
-        .limit(1);
-      return c ?? null;
+        );
     }
     const [c] = await db
       .select()
@@ -172,6 +187,6 @@ export class DiscordIngestProcessor extends WorkerHost {
       .where(eq(socialMediaChannels.platform, 'discord'))
       .orderBy(desc(socialMediaChannels.id))
       .limit(1);
-    return c ?? null;
+    return c ? [c] : [];
   }
 }

--- a/src/inbox/processors/slack-ingest.processor.ts
+++ b/src/inbox/processors/slack-ingest.processor.ts
@@ -38,26 +38,8 @@ export class SlackIngestProcessor extends WorkerHost {
 
     if (!teamId || !event) return;
 
-    // Resolve the Schedura channel row for this Slack workspace.
-    const [channel] = await db
-      .select()
-      .from(socialMediaChannels)
-      .where(
-        and(
-          eq(socialMediaChannels.platform, 'slack'),
-          eq(socialMediaChannels.platformAccountId, teamId),
-        ),
-      )
-      .limit(1);
-
-    if (!channel) {
-      this.logger.warn(
-        `No Schedura channel for Slack team ${teamId} — ignoring event`,
-      );
-      return;
-    }
-
-    // Skip bot messages (including our own).
+    // Skip channel-independent non-messages up front (identical for every
+    // workspace, so we test them once before fanning out).
     if (event.bot_id || event.subtype === 'bot_message') return;
 
     // We handle plain `message` events only in Phase 1.
@@ -67,6 +49,38 @@ export class SlackIngestProcessor extends WorkerHost {
     // carries a real user id and text, so we ingest it as a plain message).
     if (event.subtype && event.subtype !== 'channel_join') return;
 
+    // Fan out to EVERY Schedura channel connected to this Slack team — the same
+    // team can be installed by more than one workspace, and resolving a single
+    // channel would drop the event for the others.
+    const channels = await db
+      .select()
+      .from(socialMediaChannels)
+      .where(
+        and(
+          eq(socialMediaChannels.platform, 'slack'),
+          eq(socialMediaChannels.platformAccountId, teamId),
+        ),
+      );
+
+    if (channels.length === 0) {
+      this.logger.warn(
+        `No Schedura channel for Slack team ${teamId} — ignoring event`,
+      );
+      return;
+    }
+
+    for (const channel of channels) {
+      await this.ingestForChannel(channel, event);
+    }
+  }
+
+  /** Ingest one Slack `message` event into a single Schedura channel/workspace.
+   *  Called once per matching channel by {@link process} so a Slack team
+   *  installed by multiple workspaces reaches every inbox. */
+  private async ingestForChannel(
+    channel: { id: number; workspaceId: string },
+    event: any,
+  ): Promise<void> {
     // Decrypt the bot token before calling Slack APIs.
     const accessToken = await this.channelService
       .getAccessToken(channel.id, channel.workspaceId)

--- a/src/inbox/services/whatsapp-ingest.service.ts
+++ b/src/inbox/services/whatsapp-ingest.service.ts
@@ -18,6 +18,11 @@ export class WhatsAppIngestService {
 
   async ingest(payload: any): Promise<void> {
     for (const m of parseWhatsAppMessages(payload)) {
+      // Single-channel resolution is intentional here (no cross-workspace
+      // fan-out): WhatsApp phone numbers are enforced globally unique at connect
+      // time — Embedded Signup rejects a phone_number_id another workspace
+      // already owns — so a number maps to exactly one channel. Fanning out would
+      // also re-download the same media per channel for zero benefit.
       const channel = await this.inbox.findChannelByPlatformAccount(
         'whatsapp',
         m.phoneNumberId,


### PR DESCRIPTION
…ccount

The same external account (a Facebook Page, IG account, Threads profile, Slack team, Discord guild, or YouTube channel) can legitimately be connected to more than one workspace (agency + client). Platform webhooks fire once per event, but every inbound handler resolved a single channel (findChannelByPlatformAccount -> matches[0], or an inline .limit(1)), so only the lowest-id workspace received realtime DMs/comments; the others silently missed them until the next poll.

Add findChannelsByPlatformAccount (returns all matches) and fan every realtime ingest path out over all matching channels:
- FB/IG Messenger DMs, FB/IG comments, Threads replies (webhooks.controller)
- Slack message events (extracted ingestForChannel helper)
- Discord guild messages (resolveChannels + ingestForChannel helper)
- YouTube PubSubHubbub upload notifications

For comments/replies the per-channel "our post" check now routes each event to whichever workspace actually published the post.

Intentionally left single-resolution (documented in code): WhatsApp (phone numbers are globally unique at connect) and Discord DMs (no guild to key on with a shared bot; needs per-workspace bots, tracked separately).