### PR TITLE
fix(calendar): push composer-scheduled posts immediately and title Yo…

### DIFF
--- a/src/calendar-sync/calendar-sync.mapper.spec.ts
+++ b/src/calendar-sync/calendar-sync.mapper.spec.ts
@@ -57,6 +57,24 @@ describe('calendar-sync.mapper', () => {
       expect(input.summary).toBe('(untitled post)');
     });
 
+    it('uses fallbackTitle when content is empty (e.g. YouTube title-only post)', () => {
+      const input = postToEventInput({
+        ...basePost,
+        content: null,
+        fallbackTitle: 'My YouTube video title',
+      });
+      expect(input.summary).toBe('My YouTube video title');
+    });
+
+    it('prefers content over fallbackTitle when both are present', () => {
+      const input = postToEventInput({
+        ...basePost,
+        content: 'Caption wins',
+        fallbackTitle: 'Ignored title',
+      });
+      expect(input.summary).toBe('Caption wins');
+    });
+
     it('throws when the post has no scheduledAt', () => {
       expect(() =>
         postToEventInput({ ...basePost, scheduledAt: null }),

--- a/src/calendar-sync/calendar-sync.mapper.ts
+++ b/src/calendar-sync/calendar-sync.mapper.ts
@@ -24,6 +24,10 @@ export interface PostForMapping {
   workspaceId: string;
   content: string | null;
   scheduledAt: Date | null;
+  // Used for the event title when `content` is empty. Title-only platforms
+  // (YouTube, Pinterest) keep their real title in platformContent, not in the
+  // shared caption — without this such posts show up as "(untitled post)".
+  fallbackTitle?: string | null;
 }
 
 // Minimal scheduled-inbox-message shape the mapper needs. Same rationale as
@@ -74,14 +78,20 @@ function truncate(collapsed: string): string {
 }
 
 /**
- * Derive a concise, single-line event title from post content.
+ * Derive a concise, single-line event title. Prefers the post's caption, then
+ * falls back to a platform/draft title (for title-only posts like YouTube whose
+ * caption is empty), then to a generic placeholder.
  */
-function toSummary(content: string | null): string {
+function toSummary(
+  content: string | null,
+  fallbackTitle?: string | null,
+): string {
   const collapsed = collapse(content);
-  if (collapsed.length === 0) {
+  const source = collapsed.length > 0 ? collapsed : collapse(fallbackTitle);
+  if (source.length === 0) {
     return EMPTY_SUMMARY_FALLBACK;
   }
-  return truncate(collapsed);
+  return truncate(source);
 }
 
 /**
@@ -123,7 +133,7 @@ export function postToEventInput(post: PostForMapping): EventInput {
   const endTime = new Date(startTime.getTime() + DEFAULT_EVENT_DURATION_MS);
 
   return {
-    summary: toSummary(post.content),
+    summary: toSummary(post.content, post.fallbackTitle),
     startTime,
     endTime,
     privateProps: {

--- a/src/calendar-sync/services/calendar-push-sync.service.ts
+++ b/src/calendar-sync/services/calendar-push-sync.service.ts
@@ -62,6 +62,36 @@ type ItemRef =
   | { kind: 'message'; messageId: string };
 
 /**
+ * Best display title for a post whose caption (`content`) is empty. Title-only
+ * platforms keep their title in `platformContent.<platform>.platformSpecific.title`
+ * (YouTube, Pinterest); the composer also mirrors a draft-level title into
+ * `metadata.title`. Returns the first non-empty of those, else null so the
+ * mapper falls back to its generic placeholder.
+ */
+function resolvePostTitle(post: {
+  platformContent?: unknown;
+  metadata?: unknown;
+}): string | null {
+  const pc = post.platformContent as
+    | Record<string, { platformSpecific?: { title?: unknown } } | undefined>
+    | null
+    | undefined;
+  if (pc && typeof pc === 'object') {
+    for (const key of Object.keys(pc)) {
+      const title = pc[key]?.platformSpecific?.title;
+      if (typeof title === 'string' && title.trim().length > 0) {
+        return title.trim();
+      }
+    }
+  }
+  const meta = post.metadata as { title?: unknown } | null | undefined;
+  if (meta && typeof meta.title === 'string' && meta.title.trim().length > 0) {
+    return meta.title.trim();
+  }
+  return null;
+}
+
+/**
  * CalendarPushSyncService — app→calendar push.
  *
  * When a scheduled ITEM (a post, or a scheduled inbox message) is
@@ -129,6 +159,7 @@ export class CalendarPushSyncService {
       workspaceId: post.workspaceId,
       content: post.content,
       scheduledAt: post.scheduledAt,
+      fallbackTitle: resolvePostTitle(post),
     });
 
     await this.syncItem(

--- a/src/posts/composer/composer.module.ts
+++ b/src/posts/composer/composer.module.ts
@@ -15,9 +15,19 @@ import { QueueModule } from '../../queue/queue.module';
 import { ChannelsModule } from '../../channels/channels.module';
 import { DrizzleModule } from '../../drizzle/drizzle.module';
 import { PostsModule } from '../posts.module';
+import { CalendarSyncModule } from '../../calendar-sync/calendar-sync.module';
 
 @Module({
-  imports: [DrizzleModule, ChannelsModule, PostsModule, QueueModule],
+  imports: [
+    DrizzleModule,
+    ChannelsModule,
+    PostsModule,
+    QueueModule,
+    // For CalendarPushSyncService — reflect composer-scheduled drafts on
+    // connected calendars immediately (ComposerModule is not part of the
+    // PostsModule <-> CalendarSyncModule cycle, so a plain import is safe).
+    CalendarSyncModule,
+  ],
   controllers: [ComposerController],
   providers: [
     ComposerValidatorService,

--- a/src/posts/composer/services/composer-scheduling.service.ts
+++ b/src/posts/composer/services/composer-scheduling.service.ts
@@ -12,6 +12,7 @@ import { posts } from '../../../drizzle/schema/posts.schema';
 import { QUEUES } from '../../../queue/queue.module';
 import type { ScheduleDraftDto } from '../dto/schedule-draft.dto';
 import type { ChannelTarget } from '../types/draft.types';
+import { CalendarPushSyncService } from '../../../calendar-sync/services/calendar-push-sync.service';
 
 export interface ScheduleResult {
   postId: string;
@@ -33,7 +34,23 @@ export class ComposerSchedulingService {
     @Inject(DRIZZLE) private readonly db: any,
     @InjectQueue(QUEUES.POST_PUBLISHING)
     private readonly publishingQueue: Queue,
+    private readonly calendarPushSync: CalendarPushSyncService,
   ) {}
+
+  /**
+   * Fire-and-forget app→calendar push for a composer-scheduled draft. Mirrors
+   * PostService.syncCalendarForPost: never blocks or fails the schedule call —
+   * calendar sync is best-effort and self-heals via the 15-min reconcile poll.
+   */
+  private syncCalendarForPost(postId: string): void {
+    void this.calendarPushSync.syncPost(postId).catch((error) => {
+      this.logger.warn(
+        `Calendar sync failed for scheduled draft ${postId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }
 
   async schedule(
     workspaceId: string,
@@ -140,6 +157,10 @@ export class ComposerSchedulingService {
       `Scheduled draft ${dto.draftId} for ${scheduledAt.toISOString()} (delay=${delay}ms)`,
     );
 
+    // Reflect the newly scheduled post on connected calendars immediately —
+    // otherwise it only appears on the next 15-min reconcile poll.
+    this.syncCalendarForPost(dto.draftId);
+
     return {
       postId: dto.draftId,
       scheduledAt: scheduledAt.toISOString(),
@@ -160,6 +181,16 @@ export class ComposerSchedulingService {
       .update(posts)
       .set({ status: 'draft', scheduledAt: null, updatedAt: new Date() })
       .where(and(eq(posts.id, draftId), eq(posts.workspaceId, workspaceId)));
+
+    // The draft is no longer scheduled — remove its calendar event(s) now
+    // instead of waiting for the reconcile poll to prune the stale event.
+    void this.calendarPushSync.removePostEvent(draftId).catch((error) => {
+      this.logger.warn(
+        `Calendar event removal failed for cancelled draft ${draftId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
 
     return { success: true };
   }


### PR DESCRIPTION
…uTube events

Two calendar-sync bugs reported from the composer:

1. Scheduling a post from the composer did not appear on the connected Google/Outlook calendar until the next 15-min reconcile poll. ComposerSchedulingService.schedule()/cancel() never triggered the app->calendar push (only the legacy PostService.createPost path did). Fire CalendarPushSyncService.syncPost on schedule and removePostEvent on cancel, mirroring PostService.syncCalendarForPost. Wire CalendarSyncModule into ComposerModule for the dependency.

2. A scheduled YouTube post produced an event titled "(untitled post)". The mapper derived the event summary from post.content only, but title-only platforms (YouTube, Pinterest) keep their title in platformContent[platform].platformSpecific.title, not the caption. Add a fallbackTitle to the mapper (used when content is empty) and resolve it from platformContent/metadata in the push service. Covers both Google and Outlook (shared mapper).

Adds mapper tests for the fallbackTitle path.