### PR TITLE
chore: serve TikTok domain-verification file for the Schedura app

### DIFF
--- a/src/site-verification/site-verification.controller.spec.ts
+++ b/src/site-verification/site-verification.controller.spec.ts
@@ -29,4 +29,15 @@ describe('SiteVerificationController', () => {
       'tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi',
     );
   });
+
+  it('serves the Schedura-app TikTok verification file as plain text', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/tiktokuHAM3GjcFEfCi0gU2j3XQ9XEH8vpG7vh.txt')
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.text).toBe(
+      'tiktok-developers-site-verification=uHAM3GjcFEfCi0gU2j3XQ9XEH8vpG7vh',
+    );
+  });
 });

--- a/src/site-verification/site-verification.controller.ts
+++ b/src/site-verification/site-verification.controller.ts
@@ -22,10 +22,24 @@ export class SiteVerificationController {
     process.env.TIKTOK_SITE_VERIFICATION ??
     'tiktok-developers-site-verification=BWGOXBTMJ4RXb76i56qZc99OfEZIAzIi';
 
+  // The "Schedura" TikTok app (Content Posting API, video.publish) verifies
+  // `api.schedura.ai` — the media-proxy domain TikTok pulls video from — via
+  // its own URL-prefix signature file, distinct from the legacy app above.
+  private static readonly TIKTOK_VERIFICATION_SCHEDURA =
+    process.env.TIKTOK_SITE_VERIFICATION_SCHEDURA ??
+    'tiktok-developers-site-verification=uHAM3GjcFEfCi0gU2j3XQ9XEH8vpG7vh';
+
   @Get('tiktokBWGOXBTMJ4RXb76i56qZc99OfEZIAzIi.txt')
   @Header('Content-Type', 'text/plain; charset=utf-8')
   @Header('Cache-Control', 'public, max-age=3600')
   getTikTokVerification(): string {
     return SiteVerificationController.TIKTOK_VERIFICATION;
+  }
+
+  @Get('tiktokuHAM3GjcFEfCi0gU2j3XQ9XEH8vpG7vh.txt')
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=3600')
+  getTikTokVerificationSchedura(): string {
+    return SiteVerificationController.TIKTOK_VERIFICATION_SCHEDURA;
   }
 }


### PR DESCRIPTION
The new "Schedura" TikTok app (Content Posting API, video.publish) verifies api.schedura.ai — the media-proxy domain TikTok pulls video from for PULL_FROM_URL — via its own URL-prefix signature file. Add a second root route serving that file (env-overridable token) alongside the legacy app's file so both keep resolving.