### PR TITLE
fix(tiktok): default video publish to Direct Post, not Creator Inbox …

### DIFF
--- a/src/posts/publishers/tiktok.publisher.spec.ts
+++ b/src/posts/publishers/tiktok.publisher.spec.ts
@@ -1,0 +1,88 @@
+import { TikTokPublisher } from './tiktok.publisher';
+import { TikTokService } from '../../channels/services/tiktok.service';
+import { TikTokQuotaService } from '../../channels/services/tiktok-quota.service';
+import { TikTokMediaProxyService } from '../../media/tiktok-media-proxy.service';
+import { PublishOptions } from './base.publisher';
+
+/**
+ * Focused on the video publish path (Bug A): the default MUST be TikTok Direct
+ * Post (postVideoFromUrl → /post/publish/video/init/), which lands on the
+ * creator's profile with the privacy they chose. The Creator Inbox draft path
+ * (uploadVideoFromUrl → /post/publish/inbox/video/init/) is opt-in only.
+ */
+describe('TikTokPublisher video publish path', () => {
+  let publisher: TikTokPublisher;
+  let tiktokService: jest.Mocked<Pick<
+    TikTokService,
+    'queryCreatorInfo' | 'postVideoFromUrl' | 'uploadVideoFromUrl'
+  >>;
+  let quotaService: jest.Mocked<Pick<TikTokQuotaService, 'reserveSlot'>>;
+  let mediaProxy: jest.Mocked<Pick<TikTokMediaProxyService, 'mintProxyToken'>>;
+
+  const baseOptions = (metadata: Record<string, any>): PublishOptions =>
+    ({
+      content: 'hello',
+      mediaItems: [
+        {
+          type: 'video',
+          url: 'https://res.cloudinary.com/x/video/upload/v1/a.mp4',
+        } as any,
+      ],
+      accessToken: 'tok',
+      metadata,
+      channelMetadata: {},
+      platformAccountId: 'acc-1',
+      channelId: 1,
+    }) as PublishOptions;
+
+  beforeEach(() => {
+    tiktokService = {
+      queryCreatorInfo: jest.fn().mockResolvedValue({ creatorUsername: 'bob' }),
+      postVideoFromUrl: jest.fn().mockResolvedValue({ publishId: 'direct-1' }),
+      uploadVideoFromUrl: jest.fn().mockResolvedValue({ publishId: 'draft-1' }),
+    } as any;
+    quotaService = { reserveSlot: jest.fn().mockResolvedValue(undefined) } as any;
+    mediaProxy = { mintProxyToken: jest.fn().mockReturnValue('signed-token') } as any;
+
+    publisher = new TikTokPublisher(
+      tiktokService as unknown as TikTokService,
+      quotaService as unknown as TikTokQuotaService,
+      mediaProxy as unknown as TikTokMediaProxyService,
+    );
+  });
+
+  it('defaults to Direct Post (postVideoFromUrl) when no draft flag is set', async () => {
+    const result = await publisher.publish(baseOptions({ privacy: 'private' }));
+
+    expect(tiktokService.postVideoFromUrl).toHaveBeenCalledTimes(1);
+    expect(tiktokService.uploadVideoFromUrl).not.toHaveBeenCalled();
+    expect(result.platformPostId).toBe('direct-1');
+  });
+
+  it('sends the video through the verified media proxy URL for Direct Post', async () => {
+    await publisher.publish(baseOptions({ privacy: 'public' }));
+
+    const [, videoUrl] = tiktokService.postVideoFromUrl.mock.calls[0];
+    expect(mediaProxy.mintProxyToken).toHaveBeenCalledWith(
+      'https://res.cloudinary.com/x/video/upload/v1/a.mp4',
+    );
+    expect(videoUrl).toContain('/api/tiktok-media/signed-token');
+  });
+
+  it('honors the user-selected privacy in the Direct Post call', async () => {
+    await publisher.publish(baseOptions({ privacy: 'public' }));
+
+    const [, , opts] = tiktokService.postVideoFromUrl.mock.calls[0];
+    expect(opts.privacyLevel).toBe('PUBLIC_TO_EVERYONE');
+  });
+
+  it('uses the Inbox draft path only when useDraftUpload is explicitly true', async () => {
+    const result = await publisher.publish(
+      baseOptions({ privacy: 'private', useDraftUpload: true }),
+    );
+
+    expect(tiktokService.uploadVideoFromUrl).toHaveBeenCalledTimes(1);
+    expect(tiktokService.postVideoFromUrl).not.toHaveBeenCalled();
+    expect(result.platformPostId).toBe('draft-1');
+  });
+});

--- a/src/posts/publishers/tiktok.publisher.ts
+++ b/src/posts/publishers/tiktok.publisher.ts
@@ -189,45 +189,50 @@ export class TikTokPublisher extends BasePublisher {
     // Video flow (existing)
     const videoItem = mediaItems[0];
     const title = content || metadata?.title || '';
-    const useDirectUpload = metadata?.useDirectUpload ?? true; // Default to direct upload for reliability
+    // TikTok exposes two publish paths:
+    //   Direct Post  (/post/publish/video/init/)        → lands on the profile
+    //                                                      with the privacy the
+    //                                                      user chose in Schedura.
+    //   Inbox upload (/post/publish/inbox/video/init/)   → lands as a DRAFT the
+    //                                                      user must open TikTok
+    //                                                      to finish and post.
+    // Schedura's whole point is publishing from the dashboard, so Direct Post is
+    // the default. Inbox upload is only used when a caller explicitly opts in
+    // (metadata.useDraftUpload === true).
+    const useDraftUpload = metadata?.useDraftUpload === true;
 
     this.logger.log(`Publishing TikTok video: ${videoItem.url}`);
 
+    const publishOptions = {
+      title,
+      privacyLevel,
+      disableDuet: metadata?.disableDuet ?? false,
+      disableStitch: metadata?.disableStitch ?? false,
+      disableComment: metadata?.disableComment ?? false,
+      videoCoverTimestampMs: metadata?.videoCoverTimestampMs ?? 1000,
+      brandContentToggle: metadata?.brandContentToggle ?? false,
+      brandOrganicToggle: metadata?.brandOrganicToggle ?? false,
+    };
+
     let result: { publishId: string };
 
-    if (useDirectUpload) {
-      // Download and upload directly to TikTok (more reliable)
+    if (useDraftUpload) {
+      // Opt-in: download and send to the Creator Inbox as a draft. Privacy and
+      // title are set by the user inside the TikTok app, not honored here.
       result = await this.tiktokService.uploadVideoFromUrl(
         accessToken,
         videoItem.url,
-        {
-          title,
-          privacyLevel,
-          disableDuet: metadata?.disableDuet ?? false,
-          disableStitch: metadata?.disableStitch ?? false,
-          disableComment: metadata?.disableComment ?? false,
-          videoCoverTimestampMs: metadata?.videoCoverTimestampMs ?? 1000,
-          brandContentToggle: metadata?.brandContentToggle ?? false,
-          brandOrganicToggle: metadata?.brandOrganicToggle ?? false,
-        },
+        publishOptions,
       );
     } else {
-      // Let TikTok pull from URL — must be on the verified domain, so wrap
-      // the original Cloudinary/R2 URL in a signed proxy token.
+      // Default: Direct Post. TikTok pulls from the URL, which must be on our
+      // verified domain, so wrap the original Cloudinary/R2 URL in a signed
+      // proxy token served from api.schedura.ai.
       const proxiedVideoUrl = `${proxyBase}/api/tiktok-media/${this.tiktokMediaProxy.mintProxyToken(videoItem.url)}`;
       result = await this.tiktokService.postVideoFromUrl(
         accessToken,
         proxiedVideoUrl,
-        {
-          title,
-          privacyLevel,
-          disableDuet: metadata?.disableDuet ?? false,
-          disableStitch: metadata?.disableStitch ?? false,
-          disableComment: metadata?.disableComment ?? false,
-          videoCoverTimestampMs: metadata?.videoCoverTimestampMs ?? 1000,
-          brandContentToggle: metadata?.brandContentToggle ?? false,
-          brandOrganicToggle: metadata?.brandOrganicToggle ?? false,
-        },
+        publishOptions,
       );
     }
 


### PR DESCRIPTION
…draft

The video path keyed on `metadata.useDirectUpload ?? true`, but that branch actually called uploadVideoFromUrl → /post/publish/inbox/video/init/, which sends the video to the Creator Inbox as a DRAFT ("edit before sharing" — the user must open TikTok to finish it). So every scheduled/published TikTok video silently became a draft and never reached the profile, and the user's chosen privacy/title were ignored (the inbox path sets them in-app).

Flip the default to real Direct Post (postVideoFromUrl → /post/publish/video/init/, PULL_FROM_URL via the verified api.schedura.ai proxy), which lands on the profile with the selected privacy. The inbox draft path is now explicit opt-in via metadata.useDraftUpload. Rename the flag so the semantics read correctly.

The separate admin test endpoint in channels.controller (dto.useDirectUpload) is unrelated and left unchanged.