### PR TITLE
fix(analytics): make TikTok channel detail page show stats, videos an…

### DIFF
--- a/src/channels/analytics/handlers/channel-profile-snapshot.handler.ts
+++ b/src/channels/analytics/handlers/channel-profile-snapshot.handler.ts
@@ -96,6 +96,17 @@ export class ChannelProfileSnapshotHandler {
       // then override with the fresh counts. Both common aliases are written so the frontend
       // normalizer finds the right key regardless of platform.
       const platformMetricsData = snapshotData.platformMetrics ?? {};
+      // Write BOTH the singular and plural aliases for every count. Frontend
+      // normalizers differ per platform: YouTube reads `subscriberCount`,
+      // TikTok/Pinterest read the SINGULAR `followerCount` + `followingCount`
+      // + `likesCount` + `isVerified`. Previously only the plural
+      // `followersCount` and `videoCount` were written, so the TikTok header
+      // silently showed 0 for Followers/Following/Likes (only Videos matched).
+      const totalLikes =
+        (platformMetricsData as any).totalLikes ??
+        (platformMetricsData as any).likesCount ??
+        channel.metadata?.likesCount ??
+        null;
       await this.db
         .update(socialMediaChannels)
         .set({
@@ -103,6 +114,13 @@ export class ChannelProfileSnapshotHandler {
             ...(channel.metadata ?? {}),
             subscriberCount: snapshotData.followersCount ?? null,
             followersCount: snapshotData.followersCount ?? null,
+            followerCount: snapshotData.followersCount ?? null,
+            followingCount: snapshotData.followingCount ?? null,
+            likesCount: totalLikes,
+            isVerified:
+              (platformMetricsData as any).isVerified ??
+              channel.metadata?.isVerified ??
+              null,
             videoCount: snapshotData.totalPostsCount ?? null,
             totalPostsCount: snapshotData.totalPostsCount ?? null,
             viewCount:

--- a/src/channels/analytics/handlers/channel-recent-posts-sync.handler.ts
+++ b/src/channels/analytics/handlers/channel-recent-posts-sync.handler.ts
@@ -8,6 +8,7 @@ import {
   type SupportedPlatform,
 } from '../../../drizzle/schema/channels.schema';
 import { posts as postsTable } from '../../../drizzle/schema/posts.schema';
+import { postMetricSnapshots } from '../../../drizzle/schema/post-metric-snapshots.schema';
 import { channelSyncState } from '../../../drizzle/schema/channel-sync-state.schema';
 import { QUEUES } from '../../../queue/queue.module';
 import { AdapterRegistryService } from '../services/adapter-registry.service';
@@ -163,6 +164,30 @@ export class ChannelRecentPostsSyncHandler {
 
       created += 1;
       const newPostId = inserted[0].id as string;
+
+      // fetchRecentPosts already returned this post's engagement (likes /
+      // comments / shares / views) inline. Persist it as a first snapshot NOW so
+      // the overview graph and Top Videos populate immediately, instead of
+      // staying empty until the deferred per-post metric job runs (up to 1h
+      // later). The deferred trail below still runs and appends fresher points.
+      const m = rp.metrics;
+      if (m) {
+        await this.db.insert(postMetricSnapshots).values({
+          postId: newPostId,
+          channelId,
+          snapshotAt: new Date(),
+          ageBucket: '30m',
+          likesCount: m.likesCount ?? null,
+          commentsCount: m.commentsCount ?? null,
+          sharesCount: m.sharesCount ?? null,
+          impressionsCount: m.impressionsCount ?? null,
+          reachCount: m.reachCount ?? null,
+          platformMetrics: m.platformMetrics ?? {},
+          metricsSchemaVersion: 1,
+          fetchedAt: new Date(),
+          syncStatus: 'success',
+        });
+      }
 
       // Enqueue post-metric-snapshot trail starting at first bucket
       const pollingProfile = adapter.pollingProfile;

--- a/src/channels/analytics/schedulers/channel-snapshots.scheduler.ts
+++ b/src/channels/analytics/schedulers/channel-snapshots.scheduler.ts
@@ -76,7 +76,10 @@ export class ChannelSnapshotsScheduler {
         {
           channelId: r.id,
           workspaceId: r.workspaceId,
-          sinceDays: 7,
+          // Look back 30 days (not 7) so posts uploaded natively on the platform
+          // aren't missed if a day's run is skipped or the account posts in bursts.
+          // Dedup by platformPostId makes re-scanning already-known posts a no-op.
+          sinceDays: 30,
           limit: 50,
         },
         { delay: i * 100 },

--- a/src/channels/analytics/services/analytics.service.ts
+++ b/src/channels/analytics/services/analytics.service.ts
@@ -434,7 +434,11 @@ export class AnalyticsService {
     await this.queue.add('channel-recent-posts-sync', {
       channelId,
       workspaceId,
-      sinceDays: 7,
+      // A user pressing "Refresh" expects to see everything recent, not just the
+      // last week — a public account whose newest posts are 2-3 weeks old would
+      // otherwise keep showing nothing. 30 days with the adapter's 20-item cap
+      // keeps the quota cost bounded.
+      sinceDays: 30,
       limit: 50,
     });
 


### PR DESCRIPTION
…d metrics

The channel detail page showed 0 Followers/Following/Likes and "No videos yet" for a connected TikTok account with public videos. Four defects, all in the sync pipeline (not TikTok's API):

- Profile-snapshot handler wrote only the plural `followersCount` + `videoCount` to channels.metadata, but the TikTok/Pinterest frontend normalizer reads the SINGULAR `followerCount` + `followingCount` + `likesCount` + `isVerified`. Only videoCount matched, so the header showed just "Videos". Write all aliases, and propagate followingCount / likesCount (from platformMetrics totalLikes) / isVerified, which were never written.
- Recent-posts sync discovery looked back only 7 days on manual refresh and the daily cron, so a public account whose newest posts are older than a week was never re-discovered after connect. Widen both to 30 days (20-item cap bounds cost; dedup by platformPostId makes re-scans a no-op).
- Recent-posts handler already had each post's engagement inline but discarded it and deferred the first metric fetch up to 1h, leaving the overview graph and Top Videos empty in the meantime. Persist a first post_metric_snapshots row immediately from the metrics already returned; the deferred trail still appends fresher points.