### PR TITLE
fix(analytics): don't drop old public TikTok videos by the since window

### DIFF
--- a/src/channels/analytics/adapters/tiktok/tiktok-analytics.adapter.spec.ts
+++ b/src/channels/analytics/adapters/tiktok/tiktok-analytics.adapter.spec.ts
@@ -86,7 +86,11 @@ describe('TikTokAnalyticsAdapter', () => {
     }
   });
 
-  it('fetchRecentPosts filters videos by since timestamp', async () => {
+  it('fetchRecentPosts surfaces every public video TikTok returns, regardless of age', async () => {
+    // TikTok's /video/list returns only public videos, newest-first, capped at
+    // 20 — a creator's public catalogue is often older than any rolling window,
+    // so the adapter must NOT drop videos by `since` (that left channels
+    // looking empty even when public videos existed).
     const sinceDate = new Date('2024-01-15T00:00:00Z');
     const sinceUnix = sinceDate.getTime() / 1000;
 
@@ -102,7 +106,7 @@ describe('TikTokAnalyticsAdapter', () => {
         },
         {
           id: 'old',
-          create_time: sinceUnix - 3600,
+          create_time: sinceUnix - 3600, // months-old public video
           view_count: 500,
           like_count: 20,
           comment_count: 2,
@@ -120,8 +124,11 @@ describe('TikTokAnalyticsAdapter', () => {
 
     expect(result.status).toBe('success');
     if (result.status === 'success') {
-      expect(result.data.posts).toHaveLength(1);
-      expect(result.data.posts[0].platformPostId).toBe('new');
+      expect(result.data.posts).toHaveLength(2);
+      expect(result.data.posts.map((p) => p.platformPostId)).toEqual([
+        'new',
+        'old',
+      ]);
       expect(result.quotaCostUsed).toBe(2);
     }
   });

--- a/src/channels/analytics/adapters/tiktok/tiktok-analytics.adapter.ts
+++ b/src/channels/analytics/adapters/tiktok/tiktok-analytics.adapter.ts
@@ -123,9 +123,13 @@ export class TikTokAnalyticsAdapter implements PlatformAnalyticsAdapter {
         accessToken: channel.accessToken,
         maxCount: Math.min(opts.limit, 20),
       });
-      const sinceMs = opts.since.getTime();
+      // TikTok's /video/list already returns only PUBLIC videos, newest-first,
+      // capped at 20 per page. Do NOT drop by `opts.since` here: a creator's
+      // public catalogue is often older than any rolling window (e.g. videos
+      // posted months ago), and filtering them out leaves the channel looking
+      // empty even though public videos exist. The page cap is the bound; we
+      // surface whatever public videos TikTok returns.
       const posts: RecentPost[] = resp.videos
-        .filter((v) => v.create_time * 1000 >= sinceMs)
         .map((v) => ({
           platformPostId: v.id,
           publishedAt: new Date(v.create_time * 1000),


### PR DESCRIPTION
TikTok's /video/list returns only public videos, newest-first, capped at 20 — with no inherent date restriction. The adapter additionally filtered them by `opts.since` (a rolling 7/30-day window), so a creator whose public videos were posted months ago saw an empty "Top Videos" list even though the videos exist and are public. Remove the per-video since filter and surface whatever public videos TikTok returns (bounded by the 20-item page cap). Dedup by platformPostId still prevents duplicate inserts.