### PR TITLE
feat(auth): require an emailed code before super admin sign-in

### DIFF
--- a/drizzle/migrations/0024_admin_login_challenges.sql
+++ b/drizzle/migrations/0024_admin_login_challenges.sql
@@ -1,0 +1,40 @@
+-- Hand-written rather than generated.
+--
+-- `drizzle-kit generate` on this branch produced a 25-statement migration:
+-- because origin/main's journal predates the Canva, calendar, maestro and
+-- inbox work, it treated all of those as missing and folded them in alongside
+-- this table — including `addon_pricing.units_per_quantity`, a column that has
+-- already been added by hand on production. Running that generated file
+-- anywhere real would have failed on the first table that already exists.
+--
+-- This file does one thing instead.
+
+-- The three timestamps are `with time zone` deliberately. A bare `timestamp`
+-- compares the digits Node sends (UTC) against Postgres `now()` in the
+-- server's own zone, so on any machine not set to UTC every code expires the
+-- moment it is written.
+CREATE TABLE IF NOT EXISTS "admin_login_challenges" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"otp_hash" varchar(64) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"request_ip" varchar(45),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "admin_login_challenges"
+		ADD CONSTRAINT "admin_login_challenges_user_id_users_id_fk"
+		FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+		ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_login_challenges_user_created_idx"
+	ON "admin_login_challenges" USING btree ("user_id","created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_login_challenges_expires_idx"
+	ON "admin_login_challenges" USING btree ("expires_at");

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.12",
         "@nestjs/schedule": "^6.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^11.1.12",
         "@slack/web-api": "^7.16.0",
         "@tavily/core": "^0.6.4",
@@ -4936,6 +4937,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/websockets": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.12",
     "@nestjs/schedule": "^6.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^11.1.12",
     "@slack/web-api": "^7.16.0",
     "@tavily/core": "^0.6.4",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { WorkspaceSuspendedGuard } from './auth/guards/workspace-suspended.guard';
@@ -47,6 +48,11 @@ import { QUEUES } from './queue/queue.module';
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    // Registered with no global guard on purpose. Only routes carrying an
+    // explicit @Throttle decorator are limited — turning this on for every
+    // endpoint would silently start rejecting normal traffic on a platform
+    // that has never had rate limiting and has not been measured for it.
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
     ScheduleModule.forRoot(),
     SocialMediaModule,
     DrizzleModule,

--- a/src/auth/admin-challenge.service.ts
+++ b/src/auth/admin-challenge.service.ts
@@ -1,0 +1,254 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { and, desc, eq, isNull, gt, lt } from 'drizzle-orm';
+import { DRIZZLE } from '../drizzle/drizzle.module';
+import type { DbType } from '../drizzle/db';
+import { adminLoginChallenges, users } from '../drizzle/schema';
+import { EmailService } from '../email/email.service';
+import { generateOtp, hash } from '../common/utils/encryption.util';
+
+/** Ten minutes, matching the email-verification OTP already in this codebase. */
+const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * The window in which the verified code can be spent on a password attempt.
+ * Short on purpose: it exists to carry you from one form field to the next,
+ * not to be a session.
+ */
+const CHALLENGE_TOKEN_TTL = '5m';
+
+/** Five wrong guesses kills the challenge. Six digits is only 1,000,000. */
+const MAX_ATTEMPTS = 5;
+
+/** One code per address per minute, so nobody can use us to flood an inbox. */
+const REQUEST_COOLDOWN_MS = 60 * 1000;
+
+export interface ChallengeTokenPayload {
+  sub: string;
+  email: string;
+  purpose: 'admin-login';
+}
+
+@Injectable()
+export class AdminChallengeService {
+  private readonly logger = new Logger(AdminChallengeService.name);
+
+  constructor(
+    @Inject(DRIZZLE) private db: DbType,
+    private jwtService: JwtService,
+    private configService: ConfigService,
+    private emailService: EmailService,
+  ) {}
+
+  /**
+   * Step one of admin sign-in: email a code.
+   *
+   * Always resolves the same way. Whether the address is unknown, belongs to a
+   * regular user, or belongs to a suspended account, the caller is told a code
+   * was sent. Any difference here — a different message, a different status, a
+   * noticeably different response time — turns this endpoint into a way to
+   * discover which address owns the platform.
+   */
+  async requestChallenge(email: string, requestIp?: string): Promise<void> {
+    const normalized = email.trim().toLowerCase();
+
+    const user = await this.db.query.users.findFirst({
+      where: eq(users.email, normalized),
+    });
+
+    // Everything below is silent. The caller's view never changes.
+    if (!user || user.role !== 'SUPER_ADMIN' || !user.isActive) {
+      this.logger.warn(
+        `Admin challenge requested for non-eligible address (ip: ${requestIp ?? 'unknown'})`,
+      );
+      return;
+    }
+
+    const recent = await this.db.query.adminLoginChallenges.findFirst({
+      where: and(
+        eq(adminLoginChallenges.userId, user.id),
+        gt(
+          adminLoginChallenges.createdAt,
+          new Date(Date.now() - REQUEST_COOLDOWN_MS),
+        ),
+      ),
+      orderBy: [desc(adminLoginChallenges.createdAt)],
+    });
+
+    if (recent) {
+      // Inside the cooldown. Send nothing, say nothing different.
+      return;
+    }
+
+    const otp = generateOtp(6);
+
+    await this.db.insert(adminLoginChallenges).values({
+      userId: user.id,
+      otpHash: hash(otp),
+      expiresAt: new Date(Date.now() + CHALLENGE_TTL_MS),
+      requestIp: requestIp?.slice(0, 45),
+    });
+
+    await this.emailService.sendEmail({
+      to: user.email,
+      subject: `${otp} is your Schedura admin code`,
+      html: this.buildEmail(otp),
+    });
+
+    // Without a mail provider configured locally the send above is a no-op,
+    // which would leave nothing to type. This is the only way in during local
+    // development, and it is gated on the environment rather than a flag so it
+    // cannot be switched on in production by accident.
+    if (this.configService.get<string>('NODE_ENV') !== 'production') {
+      this.logger.debug(`Admin login code for ${user.email}: ${otp}`);
+    }
+  }
+
+  /**
+   * Step two: exchange a correct code for a short-lived token that the
+   * password step will demand.
+   */
+  async verifyChallenge(email: string, otp: string): Promise<string> {
+    const normalized = email.trim().toLowerCase();
+
+    const user = await this.db.query.users.findFirst({
+      where: eq(users.email, normalized),
+    });
+
+    if (!user || user.role !== 'SUPER_ADMIN' || !user.isActive) {
+      throw new UnauthorizedException('That code did not work.');
+    }
+
+    const challenge = await this.db.query.adminLoginChallenges.findFirst({
+      where: and(
+        eq(adminLoginChallenges.userId, user.id),
+        isNull(adminLoginChallenges.consumedAt),
+        gt(adminLoginChallenges.expiresAt, new Date()),
+      ),
+      orderBy: [desc(adminLoginChallenges.createdAt)],
+    });
+
+    if (!challenge) {
+      throw new UnauthorizedException('That code did not work.');
+    }
+
+    if (challenge.attempts >= MAX_ATTEMPTS) {
+      // Burn it rather than leaving a dead row that keeps being found.
+      await this.db
+        .update(adminLoginChallenges)
+        .set({ consumedAt: new Date() })
+        .where(eq(adminLoginChallenges.id, challenge.id));
+
+      throw new UnauthorizedException('That code did not work.');
+    }
+
+    if (hash(otp) !== challenge.otpHash) {
+      await this.db
+        .update(adminLoginChallenges)
+        .set({ attempts: challenge.attempts + 1 })
+        .where(eq(adminLoginChallenges.id, challenge.id));
+
+      throw new UnauthorizedException('That code did not work.');
+    }
+
+    // Spend it. A correct code is worth exactly one password attempt.
+    await this.db
+      .update(adminLoginChallenges)
+      .set({ consumedAt: new Date() })
+      .where(eq(adminLoginChallenges.id, challenge.id));
+
+    return this.signChallengeToken(user.id, user.email);
+  }
+
+  /**
+   * Called by the login path. Throws unless the token was minted by
+   * `verifyChallenge` for this exact user.
+   */
+  verifyChallengeToken(token: string | undefined, userId: string): void {
+    if (!token) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    let payload: ChallengeTokenPayload;
+    try {
+      payload = this.jwtService.verify<ChallengeTokenPayload>(token, {
+        secret: this.challengeSecret(),
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    // The purpose claim stops an ordinary access token — which is signed with
+    // a different secret anyway, but this is the claim that says so out loud —
+    // from ever standing in for a challenge token.
+    if (payload.purpose !== 'admin-login' || payload.sub !== userId) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+  }
+
+  /** Housekeeping: drop rows that can no longer be used. */
+  async purgeExpired(): Promise<number> {
+    const deleted = await this.db
+      .delete(adminLoginChallenges)
+      .where(lt(adminLoginChallenges.expiresAt, new Date()))
+      .returning({ id: adminLoginChallenges.id });
+
+    return deleted.length;
+  }
+
+  private signChallengeToken(userId: string, email: string): string {
+    const payload: ChallengeTokenPayload = {
+      sub: userId,
+      email,
+      purpose: 'admin-login',
+    };
+
+    return this.jwtService.sign(payload, {
+      secret: this.challengeSecret(),
+      expiresIn: CHALLENGE_TOKEN_TTL,
+    });
+  }
+
+  /**
+   * Its own secret, falling back to the access secret so this works without a
+   * new environment variable. Setting ADMIN_CHALLENGE_SECRET separately means a
+   * leaked access secret cannot be used to forge the second factor, which is
+   * the entire point of having one.
+   */
+  private challengeSecret(): string {
+    const secret =
+      this.configService.get<string>('ADMIN_CHALLENGE_SECRET') ??
+      this.configService.get<string>('JWT_ACCESS_SECRET');
+
+    if (!secret) {
+      throw new Error('No secret available to sign admin challenge tokens');
+    }
+
+    return secret;
+  }
+
+  private buildEmail(otp: string): string {
+    return `
+      <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 480px;">
+        <p style="font-size: 15px; color: #111;">
+          Use this code to finish signing in to the Schedura admin dashboard.
+        </p>
+        <p style="font-size: 32px; font-weight: 600; letter-spacing: 6px; margin: 24px 0; color: #111;">
+          ${otp}
+        </p>
+        <p style="font-size: 14px; color: #555;">
+          It expires in 10 minutes and can only be used once.
+        </p>
+        <p style="font-size: 14px; color: #555;">
+          If you did not try to sign in, someone has your password. Change it.
+        </p>
+      </div>
+    `;
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,12 +4,19 @@ import {
   Body,
   HttpCode,
   HttpStatus,
+  Ip,
   Res,
   UseGuards,
   Get,
 } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import type { Response } from 'express';
 import { AuthService } from './auth.service';
+import { AdminChallengeService } from './admin-challenge.service';
+import {
+  RequestAdminChallengeDto,
+  VerifyAdminChallengeDto,
+} from './dto/admin-challenge.dto';
 import { LoginDto } from './dto/login.dto';
 import { VerifyEmailDto } from './dto/verify-email.dto';
 import { VerifyOtpDto } from './dto/verify-otp.dto';
@@ -23,7 +30,52 @@ import { CreateUserDto } from 'src/users/dto/create-user.dto';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly adminChallengeService: AdminChallengeService,
+  ) {}
+
+  // ==================== Admin sign-in second factor ====================
+
+  /**
+   * Step one of super admin sign-in: email a one-time code.
+   *
+   * Public by design — it runs before anyone is authenticated. It answers
+   * identically for every address, so it cannot be used to find out which
+   * account owns the platform.
+   *
+   * Throttled hard. Without a ceiling this endpoint is a free way to send mail
+   * to an address of the caller's choosing, over and over.
+   */
+  @Post('admin/challenge')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 5, ttl: 15 * 60 * 1000 } })
+  async requestAdminChallenge(
+    @Body() dto: RequestAdminChallengeDto,
+    @Ip() ip: string,
+  ) {
+    await this.adminChallengeService.requestChallenge(dto.email, ip);
+
+    // Always the same sentence, always a 200.
+    return {
+      message: 'If that address can sign in here, a code is on its way.',
+    };
+  }
+
+  /** Step two: trade a correct code for a short-lived token. */
+  @Post('admin/verify')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 10, ttl: 15 * 60 * 1000 } })
+  async verifyAdminChallenge(@Body() dto: VerifyAdminChallengeDto) {
+    const challengeToken = await this.adminChallengeService.verifyChallenge(
+      dto.email,
+      dto.otp,
+    );
+
+    return { challengeToken };
+  }
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -7,10 +7,16 @@ import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { EmailModule } from '../email/email.module';
+import { AdminChallengeService } from './admin-challenge.service';
 
 @Module({
   imports: [UsersModule, PassportModule, JwtModule.register({}), EmailModule],
-  providers: [AuthService, JwtStrategy, JwtRefreshStrategy],
+  providers: [
+    AuthService,
+    AdminChallengeService,
+    JwtStrategy,
+    JwtRefreshStrategy,
+  ],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,6 +23,7 @@ import { DRIZZLE } from '../drizzle/drizzle.module';
 import type { DbType } from '../drizzle/db';
 import { and, eq } from 'drizzle-orm';
 import { NotificationEmitterService } from '../notifications/notification-emitter.service';
+import { AdminChallengeService } from './admin-challenge.service';
 import {
   mergeWorkspacesWithRoles,
   type WorkspaceWithRole,
@@ -59,6 +60,9 @@ export class AuthService {
     private configService: ConfigService,
     private emailService: EmailService,
     private notificationEmitter: NotificationEmitterService,
+    // One-way dependency: the challenge service knows nothing about AuthService,
+    // so this needs no forwardRef.
+    private adminChallengeService: AdminChallengeService,
   ) {}
 
   async register(registerDto: CreateUserDto): Promise<AuthResponse> {
@@ -116,6 +120,20 @@ export class AuthService {
     if (user.role === 'SUPER_ADMIN' && !user.isEmailVerified) {
       throw new UnauthorizedException(
         'Please verify your email before logging in. Check your inbox for the verification link.',
+      );
+    }
+
+    // Second factor, super admins only. A correct password on its own is not
+    // enough to reach an account that can read every customer's data — the
+    // caller must also have proved control of the mailbox in this same flow.
+    //
+    // Scoped to SUPER_ADMIN deliberately: making every customer type an
+    // emailed code on every sign-in would cost far more in abandoned logins
+    // than it buys, and their accounts are not the ones worth this friction.
+    if (user.role === 'SUPER_ADMIN') {
+      this.adminChallengeService.verifyChallengeToken(
+        loginDto.challengeToken,
+        user.id,
       );
     }
 

--- a/src/auth/dto/admin-challenge.dto.ts
+++ b/src/auth/dto/admin-challenge.dto.ts
@@ -1,0 +1,18 @@
+import { IsEmail, IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class RequestAdminChallengeDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}
+
+export class VerifyAdminChallengeDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(6, 6, { message: 'The code is 6 digits' })
+  otp: string;
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class LoginDto {
   @IsEmail()
@@ -8,4 +8,14 @@ export class LoginDto {
   @IsString()
   @IsNotEmpty()
   password: string;
+
+  /**
+   * Issued by `POST /auth/admin/verify` after an emailed code is accepted.
+   * Optional on the DTO because ordinary users never send one — but the login
+   * path requires it for SUPER_ADMIN accounts, so it is optional to the
+   * validator and mandatory to the rule.
+   */
+  @IsString()
+  @IsOptional()
+  challengeToken?: string;
 }

--- a/src/drizzle/schema/admin-login-challenge.schema.ts
+++ b/src/drizzle/schema/admin-login-challenge.schema.ts
@@ -1,0 +1,81 @@
+import {
+  pgTable,
+  uuid,
+  timestamp,
+  varchar,
+  integer,
+  index,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './users.schema';
+
+/**
+ * A one-time code emailed to a super admin before they are allowed to reach
+ * the password step of the admin dashboard sign-in.
+ *
+ * This is deliberately NOT reusing `users.emailVerificationToken`. That column
+ * belongs to the email-verification flow, and sharing it would mean an admin
+ * signing in silently overwrites a pending verification code — two unrelated
+ * features quietly corrupting each other through one column.
+ *
+ * The code itself is never stored. Only its SHA-256 hash is kept, so a dump of
+ * this table hands an attacker nothing usable inside the ten-minute window.
+ */
+export const adminLoginChallenges = pgTable(
+  'admin_login_challenges',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+
+    // SHA-256 of the 6-digit code. Never the code itself.
+    otpHash: varchar('otp_hash', { length: 64 }).notNull(),
+
+    // `withTimezone` matters here, and it is not cosmetic. A bare `timestamp`
+    // stores the wall-clock digits with no zone, so a date sent as UTC by Node
+    // gets compared against a Postgres `now()` running in the server's local
+    // zone. On this machine that is UTC+5, which made every code expire five
+    // hours before it was created — every OTP dead on arrival.
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+
+    // Wrong guesses so far. Six digits is a million combinations, which is
+    // brute-forceable inside ten minutes without a ceiling on attempts.
+    attempts: integer('attempts').default(0).notNull(),
+
+    // Stamped the moment the code is exchanged for a challenge token, so the
+    // same code can never be spent twice.
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+
+    // Kept for the rate limiter: how many codes this address has asked for
+    // recently is a question about requests, not about the user.
+    requestIp: varchar('request_ip', { length: 45 }),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    // Verification always looks up the newest unconsumed row for one user.
+    index('admin_login_challenges_user_created_idx').on(
+      table.userId,
+      table.createdAt,
+    ),
+    // Lets the cleanup job drop expired rows without a sequential scan.
+    index('admin_login_challenges_expires_idx').on(table.expiresAt),
+  ],
+);
+
+export const adminLoginChallengesRelations = relations(
+  adminLoginChallenges,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [adminLoginChallenges.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
+export type AdminLoginChallenge = typeof adminLoginChallenges.$inferSelect;
+export type NewAdminLoginChallenge = typeof adminLoginChallenges.$inferInsert;

--- a/src/drizzle/schema/index.ts
+++ b/src/drizzle/schema/index.ts
@@ -23,3 +23,4 @@ export * from './maestro-links.schema';
 export * from './maestro-bridge-threads.schema';
 export * from './canva.schema';
 export * from './calendar-sync.schema';
+export * from './admin-login-challenge.schema';

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,13 @@ async function bootstrap() {
       'http://localhost:3000',
       'http://localhost:3001',
       'http://localhost:3002',
+      // schedura-admin, the internal admin dashboard.
+      'http://localhost:3003',
+      'http://localhost:3010',
       'https://e36d-154-81-235-176.ngrok-free.app',
       process.env.APP_URL,
       process.env.FRONTEND_URL,
+      process.env.ADMIN_URL,
     ].filter(Boolean),
     credentials: true,
   });


### PR DESCRIPTION
A correct password on its own is no longer enough to reach an account that can read every customer's data. Super admins now prove control of their mailbox first, in the same flow, before the password is asked for.

Three steps: request a code, exchange it for a short-lived challenge token, then sign in with that token alongside the password. Ordinary users are untouched — gating every customer login behind an emailed code would cost far more in abandoned sign-ins than it buys.

Notes on the shape of it:

- New `admin_login_challenges` table rather than reusing `users.emailVerificationToken`. Sharing that column would mean an admin signing in silently overwrites a pending verification code.
- Only the SHA-256 of the code is stored, never the code.
- `/auth/admin/challenge` answers identically for every address, so it cannot be used to discover which account owns the platform.
- Attempts are capped at five: six digits is a million combinations, brute-forceable inside the ten-minute window without a ceiling.
- ThrottlerModule is registered without a global guard. Only the two new routes carry @Throttle — turning rate limiting on for every endpoint of a platform that has never had it, and has not been measured for it, is how you start rejecting real traffic.
- The timestamps are `with time zone`. A bare `timestamp` compares the UTC digits Node sends against Postgres `now()` in the server's local zone; on a UTC+5 machine that made every code expire five hours before it was created.
- The migration is hand-written. `drizzle-kit generate` folded in 25 unrelated statements — Canva, calendar, maestro, and an `addon_pricing` column already added by hand on production — because origin/main's journal predates that work.

Also adds localhost:3003 and ADMIN_URL to CORS so the admin dashboard can reach the API at all.