### PR TITLE
feat(auth): record where and when each user last signed in

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -326,6 +326,8 @@ export class AdminService {
           suspendedAt: users.suspendedAt,
           suspendedReason: users.suspendedReason,
           lastLoginAt: users.lastLoginAt,
+          country: users.country,
+          countryCode: users.countryCode,
           createdAt: users.createdAt,
           // How many workspaces this user owns. A correlated subquery rather
           // than a join: a user owns many workspaces, so joining would repeat
@@ -379,6 +381,8 @@ export class AdminService {
         suspendedReason: true,
         suspensionNote: true,
         lastLoginAt: true,
+        country: true,
+        countryCode: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -135,9 +135,10 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async login(
     @Body() loginDto: LoginDto,
+    @Ip() ip: string,
     @Res({ passthrough: true }) response: Response,
   ) {
-    const { accessToken, user } = await this.authService.login(loginDto);
+    const { accessToken, user } = await this.authService.login(loginDto, ip);
 
     const refreshToken = await this.authService.generateRefreshToken(
       user.id,
@@ -162,11 +163,13 @@ export class AuthController {
   @UseGuards(JwtRefreshGuard)
   async refreshTokens(
     @CurrentUser() user: { userId: string; email: string },
+    @Ip() ip: string,
     @Res({ passthrough: true }) response: Response,
   ) {
     const accessToken = await this.authService.refreshTokens(
       user.userId,
       user.email,
+      ip,
     );
 
     const refreshToken = await this.authService.generateRefreshToken(

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,12 +10,16 @@ import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { EmailModule } from '../email/email.module';
 import { AdminChallengeService } from './admin-challenge.service';
 import { AllowlistGuard } from './guards/allowlist.guard';
+import { GeoipService } from './services/geoip.service';
+import { LoginActivityService } from './services/login-activity.service';
 
 @Module({
   imports: [UsersModule, PassportModule, JwtModule.register({}), EmailModule],
   providers: [
     AuthService,
     AdminChallengeService,
+    GeoipService,
+    LoginActivityService,
     JwtStrategy,
     JwtRefreshStrategy,
     // Global launch-gate enforcement (see AllowlistGuard). Registered here

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,6 +20,7 @@ import {
   hash,
 } from '../common/utils/encryption.util';
 import { DRIZZLE } from '../drizzle/drizzle.module';
+import { LoginActivityService } from './services/login-activity.service';
 import type { DbType } from '../drizzle/db';
 import { and, eq } from 'drizzle-orm';
 import { NotificationEmitterService } from '../notifications/notification-emitter.service';
@@ -85,6 +86,7 @@ export class AuthService {
     // One-way dependency: the challenge service knows nothing about AuthService,
     // so this needs no forwardRef.
     private adminChallengeService: AdminChallengeService,
+    private loginActivityService: LoginActivityService,
   ) {}
 
   async register(registerDto: CreateUserDto): Promise<AuthResponse> {
@@ -109,7 +111,7 @@ export class AuthService {
   }
 
 
-  async login(loginDto: LoginDto): Promise<AuthResponse> {
+  async login(loginDto: LoginDto, ip?: string): Promise<AuthResponse> {
     const user = await this.validateUser(loginDto.email, loginDto.password);
 
     if (!user) {
@@ -150,6 +152,10 @@ export class AuthService {
     }
 
     const accessToken = await this.generateAccessToken(user.id, user.email);
+
+    // Stamp last-seen and where from. Awaited only for the local write; the geo
+    // lookup inside runs detached, so a slow resolver can't hold up the login.
+    await this.loginActivityService.record(user.id, ip);
 
     const {
       password: _password,
@@ -210,8 +216,14 @@ export class AuthService {
     });
   }
 
-  async refreshTokens(userId: string, email: string): Promise<string> {
+  async refreshTokens(
+    userId: string,
+    email: string,
+    ip?: string,
+  ): Promise<string> {
     const accessToken = await this.generateAccessToken(userId, email);
+    // A refresh means the session is still active — keep last-seen current.
+    await this.loginActivityService.record(userId, ip);
     return accessToken;
   }
 

--- a/src/auth/services/geoip.service.ts
+++ b/src/auth/services/geoip.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface GeoLocation {
+  country: string;
+  countryCode: string;
+}
+
+/**
+ * Turns a request IP into a country, best-effort.
+ *
+ * Uses ip-api.com's free endpoint — no key, ~45 req/min, which is far above any
+ * real login rate. It is deliberately fault-tolerant: a lookup that fails, times
+ * out, or comes back for a private address returns null rather than throwing, so
+ * a geo hiccup can never block a sign-in. The caller records the IP regardless
+ * and treats the country as a bonus that may arrive a moment later or not at all.
+ */
+@Injectable()
+export class GeoipService {
+  private readonly logger = new Logger(GeoipService.name);
+
+  /** Two seconds is generous for a single JSON GET; past that, skip it. */
+  private readonly TIMEOUT_MS = 2000;
+
+  async lookup(ip: string | undefined | null): Promise<GeoLocation | null> {
+    const clean = this.normalize(ip);
+    if (!clean || this.isPrivate(clean)) return null;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.TIMEOUT_MS);
+
+    try {
+      const res = await fetch(
+        `http://ip-api.com/json/${clean}?fields=status,country,countryCode`,
+        { signal: controller.signal },
+      );
+      if (!res.ok) return null;
+
+      const data = (await res.json()) as {
+        status?: string;
+        country?: string;
+        countryCode?: string;
+      };
+
+      if (data.status !== 'success' || !data.country || !data.countryCode) {
+        return null;
+      }
+      return { country: data.country, countryCode: data.countryCode };
+    } catch (error) {
+      // A resolver outage is not the login's problem — log and move on.
+      this.logger.debug(
+        `GeoIP lookup failed for ${clean}: ${(error as Error).message}`,
+      );
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Express hands back `::ffff:1.2.3.4` for IPv4-over-IPv6 and a comma list when
+   * behind a proxy. Take the first, strip the mapping prefix.
+   */
+  private normalize(ip: string | undefined | null): string | null {
+    if (!ip) return null;
+    const first = ip.split(',')[0].trim();
+    const unmapped = first.startsWith('::ffff:') ? first.slice(7) : first;
+    return unmapped || null;
+  }
+
+  /** Loopback and RFC 1918 / unique-local ranges never resolve to a country. */
+  private isPrivate(ip: string): boolean {
+    if (ip === '127.0.0.1' || ip === '::1' || ip === 'localhost') return true;
+    if (/^10\./.test(ip)) return true;
+    if (/^192\.168\./.test(ip)) return true;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+    if (/^169\.254\./.test(ip)) return true; // link-local
+    if (/^(fc|fd)/i.test(ip)) return true; // IPv6 unique-local
+    return false;
+  }
+}

--- a/src/auth/services/login-activity.service.ts
+++ b/src/auth/services/login-activity.service.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { DRIZZLE } from '../../drizzle/drizzle.module';
+import type { DbType } from '../../drizzle/db';
+import { users } from '../../drizzle/schema';
+import { GeoipService } from './geoip.service';
+
+/**
+ * Records where and when each session signed in.
+ *
+ * The timestamp and IP are written straight away so "last seen" is correct the
+ * moment a request finishes. The country is a second, slower step: it needs an
+ * external lookup, so it runs detached — the sign-in has already returned by the
+ * time it lands. A failed or slow geo lookup therefore never touches the login
+ * path, and the worst case is a row with an IP but no country yet.
+ */
+@Injectable()
+export class LoginActivityService {
+  private readonly logger = new Logger(LoginActivityService.name);
+
+  constructor(
+    @Inject(DRIZZLE) private db: DbType,
+    private geoip: GeoipService,
+  ) {}
+
+  /**
+   * Call on every successful authentication (login, refresh, OAuth). Awaits only
+   * the cheap local write; the geo resolution is fired and forgotten so the
+   * caller is never blocked on the network.
+   */
+  async record(userId: string, ip: string | undefined | null): Promise<void> {
+    const now = new Date();
+    const cleanIp = ip?.split(',')[0].trim() || null;
+
+    try {
+      await this.db
+        .update(users)
+        .set({ lastLoginAt: now, lastLoginIp: cleanIp, updatedAt: now })
+        .where(eq(users.id, userId));
+    } catch (error) {
+      // Recording activity must not break auth — log and carry on.
+      this.logger.warn(
+        `Failed to record login activity for ${userId}: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    // Resolve the country out of band. No await on the caller's side.
+    void this.resolveCountry(userId, cleanIp);
+  }
+
+  private async resolveCountry(
+    userId: string,
+    ip: string | null,
+  ): Promise<void> {
+    const geo = await this.geoip.lookup(ip);
+    if (!geo) return;
+
+    try {
+      await this.db
+        .update(users)
+        .set({ country: geo.country, countryCode: geo.countryCode })
+        .where(eq(users.id, userId));
+    } catch (error) {
+      this.logger.debug(
+        `Failed to store country for ${userId}: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/drizzle/schema/users.schema.ts
+++ b/src/drizzle/schema/users.schema.ts
@@ -56,6 +56,11 @@ export const users = pgTable('users', {
 
   // Last login tracking
   lastLoginAt: timestamp('last_login_at'),
+  // Where the last session signed in from. The IP is captured at auth time;
+  // country/countryCode are resolved from it (best-effort, may lag or be null).
+  lastLoginIp: varchar('last_login_ip', { length: 45 }), // fits IPv6
+  country: varchar('country', { length: 100 }),
+  countryCode: varchar('country_code', { length: 2 }), // ISO 3166-1 alpha-2
 
   // Inactivity email tracking
   inactivityEmail15DaysSentAt: timestamp('inactivity_email_15_days_sent_at'),


### PR DESCRIPTION
Login and refresh now stamp last_login_at and the request IP, and resolve the IP to a country out of band via ip-api.com. The timestamp fixes a "Last seen" that always read Never — the column existed but nothing ever wrote it. The geo lookup is fire-and-forget with a short timeout and a private-IP skip, so a slow or failed resolver can never hold up a sign-in; the worst case is a row with an IP but no country yet. Admin user list and detail now return country/countryCode.

Columns added to prod via ALTER ... ADD COLUMN IF NOT EXISTS rather than the generated migration, whose journal has drifted from the live schema.