### PR TITLE
fix(campaigns): strip colon from drip job id (BullMQ rejects ':' in c…

### DIFF
--- a/src/campaigns/campaign-publishing.service.spec.ts
+++ b/src/campaigns/campaign-publishing.service.spec.ts
@@ -27,8 +27,20 @@ describe('CampaignPublishingService', () => {
   it('enqueues with a delay derived from scheduledAt and a deterministic jobId', () => {
     const { service } = make();
     // buildJobId is a pure helper — assert its shape (used for idempotency).
+    // The time's colon is stripped: BullMQ custom job ids cannot contain ':'.
     expect(service.buildJobId('c1', '2026-09-02', '42', '09:00')).toBe(
-      'campaign-c1-2026-09-02-42-09:00',
+      'campaign-c1-2026-09-02-42-0900',
     );
+  });
+
+  it('produces distinct, colon-free job ids for two times on the same day/channel', () => {
+    const { service } = make();
+    const am = service.buildJobId('c1', '2026-09-02', '42', '09:00');
+    const pm = service.buildJobId('c1', '2026-09-02', '42', '17:00');
+    // Distinct (so multi-time drip slots don't collide) and free of ':' so
+    // BullMQ's Job.validateOptions doesn't throw "Custom Id cannot contain :".
+    expect(am).not.toBe(pm);
+    expect(am).not.toContain(':');
+    expect(pm).not.toContain(':');
   });
 });

--- a/src/campaigns/campaign-publishing.service.ts
+++ b/src/campaigns/campaign-publishing.service.ts
@@ -34,14 +34,18 @@ export class CampaignPublishingService {
 
   /** Deterministic per-(campaign,date,channel,time) job id → idempotent
    *  enqueue. Time is REQUIRED in the key so two same-day/same-channel drip
-   *  slots (e.g. 09:00 and 17:00) don't collide onto one job id. */
+   *  slots (e.g. 09:00 and 17:00) don't collide onto one job id. The time's
+   *  `:` is stripped — BullMQ rejects a custom job id containing ':'
+   *  (Job.validateOptions throws "Custom Id cannot contain :"). Removing just
+   *  the colon keeps ids distinct (0900 vs 1700) and deterministic. */
   buildJobId(
     campaignId: string,
     date: string,
     channelId: string,
     time: string,
   ): string {
-    return `campaign-${campaignId}-${date}-${channelId}-${time}`;
+    const safeTime = time.replace(/:/g, '');
+    return `campaign-${campaignId}-${date}-${channelId}-${safeTime}`;
   }
 
   buildTargets(channelId: string, platform: string): PostTarget[] {


### PR DESCRIPTION
…ustom id)

Launching a drip campaign threw "Custom Id cannot contain :" from BullMQ's Job.validateOptions. The multi-time job id embeds the slot time (HH:mm), and the ':' is illegal in a BullMQ custom job id. Strip the colon (09:00 -> 0900) so ids stay distinct per time and deterministic. Bulk was unaffected (its times only entered the id after multi-time drip was added).

Added a regression test asserting the id is colon-free and distinct across two times on the same day/channel.