### PR TITLE
feat(campaigns): slot time move via updateEvent newTime

### DIFF
--- a/src/campaigns/campaigns.service.spec.ts
+++ b/src/campaigns/campaigns.service.spec.ts
@@ -1233,10 +1233,18 @@ describe('CampaignsService write methods (mocked db)', () => {
               const rows = fixture.slotRows ?? [];
               const eqValues = extractEqValues(whereCond);
               const wantedStatus = eqValues['slot_status'];
-              const filtered =
-                typeof wantedStatus === 'string'
-                  ? rows.filter((r) => (r as { slotStatus?: string }).slotStatus === wantedStatus)
-                  : rows;
+              const wantedTime = eqValues['time'];
+              const filtered = rows
+                .filter((r) =>
+                  typeof wantedStatus === 'string'
+                    ? (r as { slotStatus?: string }).slotStatus === wantedStatus
+                    : true,
+                )
+                .filter((r) =>
+                  typeof wantedTime === 'string'
+                    ? (r as { time?: string }).time === wantedTime
+                    : true,
+                );
               return Promise.resolve(filtered);
             }
             if (name === 'social_media_channels') {
@@ -1962,6 +1970,154 @@ describe('CampaignsService write methods (mocked db)', () => {
       expect(publishing.materializeAndEnqueue).not.toHaveBeenCalled();
       const slotUpdate = updates.slotUpdates.find((u) => u.id === 'slot-1');
       expect((slotUpdate?.set.content as ChannelDayContentJson)?.caption).toBe('New caption');
+    });
+  });
+
+  // ==========================================================================
+  // updateEvent() — newTime move. dto.newTime moves a pre-launch slot's `time`
+  // column while preserving its merged content; it 409s on a collision with an
+  // existing slot at the target time, and 409s outright on a launched (active)
+  // campaign (pre-launch only — a launched move would need a re-materialize at
+  // the new fire time, out of scope here). Reuses launch's table-routed
+  // `buildFakeDb` fixture (declared above in this `describe('launch')`
+  // closure).
+  // ==========================================================================
+
+  describe('updateEvent — newTime move', () => {
+    const WORKSPACE_ID = 'ws-1';
+    const CAMPAIGN_ID = 'c-1';
+    const futureDate = '2099-06-15'; // far future -> always "due", never past-due
+
+    it('moves the slot to newTime and preserves merged content when the target time is free', async () => {
+      const publishing = makePublishingMock();
+      const slot = makeSlotRow({
+        date: futureDate,
+        channelId: '1',
+        time: '17:00',
+        slotStatus: 'pending',
+        content: content({ caption: 'hi' }),
+      });
+      const { db, updates } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'draft' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+        date: futureDate,
+        channelId: '1',
+        patch: { caption: 'bye' },
+        time: '17:00',
+        newTime: '18:00',
+      });
+
+      const slotUpdate = updates.slotUpdates.find((u) => u.id === 'slot-1');
+      expect(slotUpdate?.set).toMatchObject({ time: '18:00' });
+      expect((slotUpdate?.set.content as ChannelDayContentJson)?.caption).toBe('bye');
+    });
+
+    it('throws ConflictException when a slot already exists at newTime', async () => {
+      const publishing = makePublishingMock();
+      const slotAt17 = makeSlotRow({
+        id: 'slot-1',
+        date: futureDate,
+        channelId: '1',
+        time: '17:00',
+        slotStatus: 'pending',
+        content: content({ caption: 'hi' }),
+      });
+      const slotAt18 = makeSlotRow({
+        id: 'slot-2',
+        date: futureDate,
+        channelId: '1',
+        time: '18:00',
+        slotStatus: 'pending',
+        content: content({ caption: 'taken' }),
+      });
+      const { db, updates } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'draft' }),
+        dayRows: [],
+        slotRows: [slotAt17, slotAt18],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await expect(
+        service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+          date: futureDate,
+          channelId: '1',
+          patch: { caption: 'bye' },
+          time: '17:00',
+          newTime: '18:00',
+        }),
+      ).rejects.toThrow(/already exists for this channel/i);
+
+      expect(
+        updates.slotUpdates.find((u) => u.set.time === '18:00'),
+      ).toBeUndefined();
+    });
+
+    it('throws ConflictException when the campaign is launched (active) and newTime is set', async () => {
+      const publishing = makePublishingMock();
+      const slot = makeSlotRow({
+        date: futureDate,
+        channelId: '1',
+        time: '17:00',
+        slotStatus: 'scheduled',
+        content: content({ caption: 'hi' }),
+      });
+      const { db, updates } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'active' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await expect(
+        service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+          date: futureDate,
+          channelId: '1',
+          patch: { caption: 'bye' },
+          time: '17:00',
+          newTime: '18:00',
+        }),
+      ).rejects.toThrow(/before launching the campaign/i);
+
+      expect(
+        updates.slotUpdates.find((u) => u.id === 'slot-1' && u.set.time === '18:00'),
+      ).toBeUndefined();
+    });
+
+    it('leaves content-only behaviour unchanged when newTime is absent', async () => {
+      const publishing = makePublishingMock();
+      const slot = makeSlotRow({
+        date: futureDate,
+        channelId: '1',
+        time: '17:00',
+        slotStatus: 'pending',
+        content: content({ caption: 'hi' }),
+      });
+      const { db, updates } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'draft' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+        date: futureDate,
+        channelId: '1',
+        patch: { caption: 'x' },
+        time: '17:00',
+      });
+
+      const slotUpdate = updates.slotUpdates.find((u) => u.id === 'slot-1');
+      expect((slotUpdate?.set.content as ChannelDayContentJson)?.caption).toBe('x');
+      expect(slotUpdate?.set.time).toBeUndefined();
     });
   });
 

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -141,6 +141,7 @@ export interface UpdateEventDto {
   channelId: string;
   patch: Partial<ChannelDayContentJson>;
   time?: string; // HH:mm — disambiguates a multi-time slot when provided
+  newTime?: string; // HH:mm — content-preserving move to this time (pre-launch only)
 }
 
 export interface RemoveEventDto {
@@ -1363,11 +1364,43 @@ export class CampaignsService {
 
     this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);
 
+    // Content-preserving time move. Pre-launch only: moving a launched slot
+    // would need a re-materialize at the new fire time (out of scope here), so
+    // reject it with a clear 409 — the picker is disabled there anyway.
+    const movingTime = !!dto.newTime && dto.newTime !== slot.time;
+    if (movingTime) {
+      if (campaignStatus === 'active') {
+        throw new ConflictException(
+          'Change this post’s time before launching the campaign.',
+        );
+      }
+      const [clash] = await db
+        .select({ id: campaignSlotContent.id })
+        .from(campaignSlotContent)
+        .where(
+          and(
+            eq(campaignSlotContent.campaignId, id),
+            eq(campaignSlotContent.date, dto.date),
+            eq(campaignSlotContent.channelId, dto.channelId),
+            eq(campaignSlotContent.time, dto.newTime!),
+          ),
+        );
+      if (clash) {
+        throw new ConflictException(
+          'A post already exists for this channel at that time on this day.',
+        );
+      }
+    }
+
     const mergedContent: ChannelDayContentJson = { ...slot.content, ...dto.patch };
 
     await db
       .update(campaignSlotContent)
-      .set({ content: mergedContent, updatedAt: new Date() })
+      .set({
+        content: mergedContent,
+        ...(movingTime ? { time: dto.newTime! } : {}),
+        updatedAt: new Date(),
+      })
       .where(eq(campaignSlotContent.id, slot.id));
 
     // Launched + still-scheduled: the enqueued post is stale — cancel & re-enqueue

--- a/src/campaigns/dto/campaigns.dto.ts
+++ b/src/campaigns/dto/campaigns.dto.ts
@@ -197,6 +197,12 @@ export class UpdateEventDto {
   @IsOptional()
   @Matches(/^\d{2}:\d{2}$/, { message: 'time must be HH:mm' })
   time?: string;
+
+  // Optional content-preserving time move: when present and different from the
+  // matched slot's current `time`, updateEvent moves the slot to this time.
+  @IsOptional()
+  @Matches(/^\d{2}:\d{2}$/, { message: 'newTime must be HH:mm' })
+  newTime?: string;
 }
 
 export class RemoveEventDto {


### PR DESCRIPTION
﻿## Campaign slot time edit — backend

Adds a content-preserving **time move** to campaign/drip slots before launch, backing the frontend time-edit + past-due feature.

### Changes
- `UpdateEventDto` gains optional `newTime` (`@Matches(/^\d{2}:\d{2}$/)`).
- `updateEvent`: when `newTime` is set and differs from the slot's current time, moves the slot's `time` column while preserving merged content.
  - **409** on unique-key collision `(campaignId, date, channelId, newTime)`.
  - **409** on a launched (`active`) campaign — pre-launch only; the picker is hidden there on the FE, this is defense-in-depth.
  - Collision + launched checks run **before** the single content+time `.set`, so a 409 leaves the row fully untouched (no half-apply).
- **No DB migration** — the `time` column and `(campaignId, date, channelId, time)` unique index already exist; logic only.

### Quality
- 116/116 campaigns tests green; `nest build` clean.
- Built via SDD with per-task + opus whole-branch review. The FE's `isSlotPastDue` mirrors this repo's `wallClockToUtc`, and the boundary rule agrees exactly (`>= now → due`).

Pairs with the frontend PR on `asad00712/schedura-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
