### PR TITLE
feat(admin): live Platforms — OAuth scope picture + rate limits, hang-proofed

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -710,6 +710,16 @@ export class AdminController {
     return this.adminService.getChannelStats();
   }
 
+  // Per-platform OAuth picture: scopes we request vs. what each connected
+  // channel was actually granted, and how many channels are behind a scope we
+  // now ask for (the reconnect list). See getPlatformApps for what it can and
+  // can't answer.
+  @Get('platforms/apps')
+  @HttpCode(HttpStatus.OK)
+  async getPlatformApps() {
+    return this.adminService.getPlatformApps();
+  }
+
   @Get('analytics/posts')
   @HttpCode(HttpStatus.OK)
   async getPostStats() {

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -26,7 +26,13 @@ import {
   or,
   notInArray,
 } from 'drizzle-orm';
-import { INTEGRATION_PLATFORMS } from '../drizzle/schema';
+import {
+  INTEGRATION_PLATFORMS,
+  SUPPORTED_PLATFORMS,
+  CHANNEL_CATEGORY,
+  PLATFORM_CONFIG,
+  type SupportedPlatform,
+} from '../drizzle/schema';
 import {
   users,
   workspace,
@@ -1643,6 +1649,123 @@ export class AdminService {
   }
 
   /**
+   * One row per publishing platform, pairing the OAuth scopes we *request* at
+   * connect (declared in code, the source of truth) with what each connected
+   * channel was actually *granted* (its `token_scope`, recorded from the
+   * provider's token response).
+   *
+   * The point of the page is the gap. A channel connected before a platform's
+   * scope list grew still carries the old, shorter grant — it looks connected
+   * and healthy, yet a feature that needs the newer scope silently returns
+   * (#200) or its equivalent. That is exactly how a Slack workspace ran
+   * half-broken on six scopes for weeks without a single error surfacing. This
+   * counts, per platform, how many live channels are missing a scope we now ask
+   * for, so the fix ("these N channels must reconnect") is a number instead of a
+   * support ticket.
+   *
+   * Integrations (cloud storage, calendars) are excluded — they are not
+   * publishing channels and their scopes answer a different question.
+   *
+   * What this deliberately does NOT claim: app-review state (live / in review /
+   * not submitted) and platform app IDs are not modelled in this database — they
+   * live in each platform's developer console. The tab is honest about that
+   * rather than inventing a status.
+   */
+  async getPlatformApps() {
+    const publishingPlatforms = SUPPORTED_PLATFORMS.filter(
+      (p) => CHANNEL_CATEGORY[p] !== 'integration',
+    );
+
+    // token_scope is a single free-text string exactly as the provider echoed
+    // it back — space- or comma-separated, and null where a provider returned
+    // no scope field at all. Pull the raw scope plus connection status for every
+    // publishing channel in one query, then bucket in memory.
+    const rows = await this.db
+      .select({
+        platform: socialMediaChannels.platform,
+        tokenScope: socialMediaChannels.tokenScope,
+        connectionStatus: socialMediaChannels.connectionStatus,
+      })
+      .from(socialMediaChannels)
+      .where(notInArray(socialMediaChannels.platform, INTEGRATION_PLATFORMS));
+
+    const byPlatform = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const list = byPlatform.get(row.platform);
+      if (list) list.push(row);
+      else byPlatform.set(row.platform, [row]);
+    }
+
+    const platforms = publishingPlatforms.map((platform) => {
+      const config = PLATFORM_CONFIG[platform as SupportedPlatform];
+      const declaredScopes = config?.oauthScopes ?? [];
+      const channels = byPlatform.get(platform) ?? [];
+
+      const connected = channels.filter(
+        (c) => c.connectionStatus === 'connected',
+      ).length;
+      const broken = channels.filter((c) =>
+        ['expired', 'error', 'revoked'].includes(c.connectionStatus ?? ''),
+      ).length;
+
+      // A channel is "behind" when its granted scopes don't cover every scope we
+      // now request. Compared case-sensitively against the raw grant string —
+      // providers return scopes verbatim, so a substring test on the exact scope
+      // name is what actually matches. A null/empty grant means the provider
+      // told us nothing; we can't prove a gap, so it is counted separately as
+      // "unknown" rather than assumed broken.
+      let scopeGap = 0;
+      let scopeUnknown = 0;
+      for (const channel of channels) {
+        const granted = channel.tokenScope?.trim();
+        if (!granted) {
+          scopeUnknown += 1;
+          continue;
+        }
+        const missing = declaredScopes.some((scope) => !granted.includes(scope));
+        if (missing) scopeGap += 1;
+      }
+
+      return {
+        platform,
+        name: config?.name ?? platform,
+        category: CHANNEL_CATEGORY[platform as SupportedPlatform],
+        declaredScopes,
+        declaredScopeCount: declaredScopes.length,
+        channelCount: channels.length,
+        connected,
+        broken,
+        // Channels missing at least one currently-requested scope — the ones
+        // that need a reconnect to regain a feature.
+        scopeGap,
+        // Channels whose provider returned no scope string; we can't judge them.
+        scopeUnknown,
+      };
+    });
+
+    // The platforms that carry a real risk first: a scope gap on a connected
+    // channel is a live feature silently broken. Then by how many channels are
+    // affected, then alphabetically for a stable order.
+    platforms.sort(
+      (a, b) =>
+        Number(b.scopeGap > 0) - Number(a.scopeGap > 0) ||
+        b.scopeGap - a.scopeGap ||
+        b.channelCount - a.channelCount ||
+        a.name.localeCompare(b.name),
+    );
+
+    return {
+      platforms,
+      totals: {
+        platformCount: platforms.length,
+        connectedChannels: platforms.reduce((s, p) => s + p.connected, 0),
+        channelsBehind: platforms.reduce((s, p) => s + p.scopeGap, 0),
+        scopeUnknown: platforms.reduce((s, p) => s + p.scopeUnknown, 0),
+      },
+    };
+  }
+
+  /**
    * Every connected account across every customer, one page at a time.
    *
    * `needsAttention` is a filter rather than a stored flag, and it means the
@@ -1714,6 +1837,10 @@ export class AdminService {
           lastErrorAt: socialMediaChannels.lastErrorAt,
           consecutiveErrors: socialMediaChannels.consecutiveErrors,
           tokenExpiresAt: socialMediaChannels.tokenExpiresAt,
+          // Granted OAuth scopes as the provider echoed them at connect. Null
+          // where the provider returned none. Surfaced so the channels list can
+          // show which grant a broken channel is actually carrying.
+          tokenScope: socialMediaChannels.tokenScope,
           lastSyncedAt: socialMediaChannels.lastSyncedAt,
           isActive: socialMediaChannels.isActive,
           createdAt: socialMediaChannels.createdAt,

--- a/src/queue/rate-limiter.service.ts
+++ b/src/queue/rate-limiter.service.ts
@@ -280,34 +280,94 @@ export class RateLimiterService {
   }
 
   /**
-   * Get current rate limit status for all platforms
+   * Get current rate limit status for all platforms.
+   *
+   * The live counts come from Redis. When Redis is down or slow, ioredis retries
+   * every call forever, so a naive loop here hangs the whole admin request until
+   * something times it out at the edge (~23s → 500). Instead the entire Redis
+   * read races a short timeout: if it can't answer in time, every platform comes
+   * back with `current: null` (config known, live count unknown) rather than
+   * blocking. The caller and UI already treat null as "usage unknown", which is
+   * the honest state when the counter is unreachable.
    */
   async getAllRateLimitStatus(): Promise<
     Record<
       SupportedPlatform,
-      { current: number; max: number; remaining: number; windowMs: number }
+      {
+        current: number | null;
+        max: number;
+        remaining: number | null;
+        windowMs: number;
+        description: string;
+      }
     >
   > {
-    const status: any = {};
+    const now = Date.now();
+
+    // Read every platform's counter concurrently, and race the whole batch
+    // against a 2s ceiling. One slow key shouldn't hold the rest, and no key
+    // should hold the request.
+    const readAll = Promise.all(
+      Object.entries(PLATFORM_RATE_LIMITS).map(async ([platform, limit]) => {
+        const key = `ratelimit:global:${platform}`;
+        await this.redis.zremrangebyscore(key, 0, now - limit.windowMs);
+        const current = await this.redis.zcard(key);
+        return [platform, current] as const;
+      }),
+    );
+
+    let counts: Map<string, number> | null = null;
+    try {
+      const settled = await Promise.race([
+        readAll,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('Rate-limit counter read timed out')),
+            2000,
+          ),
+        ),
+      ]);
+      counts = new Map(settled);
+    } catch (error) {
+      this.logger.warn(
+        `Rate-limit status unavailable (Redis unreachable): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    const status: Record<
+      string,
+      {
+        current: number | null;
+        max: number;
+        remaining: number | null;
+        windowMs: number;
+        description: string;
+      }
+    > = {};
 
     for (const [platform, limit] of Object.entries(PLATFORM_RATE_LIMITS)) {
-      const key = `ratelimit:global:${platform}`;
-      const now = Date.now();
-      const windowStart = now - limit.windowMs;
-
-      await this.redis.zremrangebyscore(key, 0, windowStart);
-      const currentCount = await this.redis.zcard(key);
-
+      const current = counts?.get(platform) ?? null;
       status[platform] = {
-        current: currentCount,
+        current,
         max: limit.maxRequests,
-        remaining: Math.max(0, limit.maxRequests - currentCount),
+        remaining: current === null ? null : Math.max(0, limit.maxRequests - current),
         windowMs: limit.windowMs,
         description: limit.description,
       };
     }
 
-    return status;
+    return status as Record<
+      SupportedPlatform,
+      {
+        current: number | null;
+        max: number;
+        remaining: number | null;
+        windowMs: number;
+        description: string;
+      }
+    >;
   }
 
   /**


### PR DESCRIPTION
## What

Backs the admin **Platforms** module with real data.

- **New `GET /admin/platforms/apps`.** Per publishing platform: the OAuth scopes we request at connect (from `PLATFORM_CONFIG`, the source of truth) vs. what each connected channel was actually granted (`token_scope`). Counts channels **behind** a scope we now ask for — the reconnect list, exactly the signal that would have caught the Slack six-scope regression — and separately channels whose provider echoed no scope (**unknown**, not assumed broken). Integrations excluded. Deliberately does **not** invent app-review state or app IDs — those live in each platform's developer console, not this DB.
- **`getAdminChannels` returns `token_scope`** so the channels list can show which grant a broken channel is carrying. Query change, no migration.
- **Rate-limiter hang fix.** `getAllRateLimitStatus` now reads every platform counter concurrently and races a 2s ceiling. With Redis down/slow it returns `current`/`remaining: null` (config known, live count unknown) instead of hanging the admin request into a ~23s 500 — the same hardening applied to queues and health.

## Verification

- `npm run build` green.
- Live-tested on a booted instance: `/admin/platforms/apps` → 200 with real channels (Slack carrying all 19 scopes, Discord/Threads reporting no grant → counted as unknown), 16 publishing platforms, integrations excluded. `/admin/rate-limits` with Redis **down** went from a 23s → 500 hang to a 2s 200 with null live counts.

## No migration

`token_scope` already exists on the channels table; this only reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)