### PR TITLE
feat(campaigns): launched scheduled slot time edit + past-time block

### DIFF
--- a/docs/superpowers/plans/2026-08-16-launched-slot-time-edit.md
+++ b/docs/superpowers/plans/2026-08-16-launched-slot-time-edit.md
@@ -1,0 +1,323 @@
+# Launched-Campaign Slot Time Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow changing a still-`scheduled` slot's time on a launched (`active`) campaign/drip — cancelling the enqueued job and re-enqueueing at the NEW time — while blocking moves to an already-past time (draft and launched alike).
+
+**Architecture:** One backend method (`updateEvent`) changes: relax the launched 409 for the time-move path, add a past-time block that reuses `computeSlotSchedule`, and fix a stale `slot.time` so the re-enqueued job fires at the new time. One small frontend addition: a "Saving reschedules this post." note in the time-edit popover when the campaign is active and the slot is scheduled.
+
+**Tech Stack:** Backend — NestJS, Drizzle ORM (Postgres), BullMQ, class-validator, Jest. Frontend — Vite 8 + React 19 + TypeScript + Tailwind 3 + shadcn (basecn/base-ui), TanStack Query v5.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-launched-slot-time-edit-design.md`
+
+## Global Constraints
+
+- **NO DB migration** — logic + existing columns only.
+- **shadcn-only** UI, theme tokens only (the FE note uses `text-muted-foreground`; no hex / arbitrary Tailwind colors).
+- **Never** `git add .` / `git add -A` — surgical `git add <path>` only (FE `.env` is git-TRACKED with secrets; BE `.env` is gitignored with secrets — never stage/expose either).
+- Commit/push only when the user explicitly asks; each task ends with a `git add <specific paths>` + commit, but do NOT push.
+- The implementer runs **no** `db:*` / `psql` / migration commands.
+- **Reuse `computeSlotSchedule`** for the past-time check so the block/skip boundary matches launch exactly — never a hand-rolled naive local-time compare.
+- **Backend-first** (Task 1-2 before Task 3).
+- Draft-campaign behaviour unchanged **except** past-time moves are now blocked (was: allowed-then-skipped-at-launch).
+- Branch `feat/launched-slot-time-edit` in both repos, off `main` (BE base `69ae97c`, FE base `3f664cc`).
+
+---
+
+### Task 1: Backend — relax launched guard + block past-time moves
+
+**Files:**
+- Modify: `src/campaigns/campaigns.service.ts` (`updateEvent`, the `movingTime` block ~1367-1393, plus capture `getOne` result at ~1340; local-interface comment at ~144)
+- Test: `src/campaigns/campaigns.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `computeSlotSchedule(schedule, slots, now)` (already imported in this file — it's used in the re-materialize block); `ConflictException` (already imported); `campaign.schedule` from `getOne`.
+- Produces: `updateEvent` no longer 409s a launched campaign's `newTime` move; instead a past `newTime` (draft or launched) → 409 "already passed". The re-materialize block (Task 2) then runs for a launched scheduled move.
+
+**Design note (read before coding):** The `movingTime` block currently does `if (campaignStatus === 'active') throw ...` then a collision check. Replace the launched-throw with a **past-time** check (applies to both draft and launched) placed BEFORE the collision check. Reuse `computeSlotSchedule` with a single `(dto.date, dto.newTime)` slot: if it lands in `pastDue`, throw. `assertLaunchedSlotEditable` (already called at ~1365) still 409s a launched published/fired/skipped slot, so only `scheduled`/`pending` reach this block on a launched campaign — no extra status guard needed here.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/campaigns/campaigns.service.spec.ts`. First READ the existing spec's `db`/Drizzle mock harness (the `describe('updateEvent — newTime move')` block ~1986 and `loadServiceWithFakeDb` helper) and reuse it exactly — do not invent a new style. The suite mocks `computeSlotSchedule`? Check: if `computeSlotSchedule` is the real imported function, the fake `now`/`schedule.timezone` in fixtures must make a "past" time actually past. If the suite mocks `publishing.materializeAndEnqueue`/`cancelSlotJob`, reuse those mocks.
+
+Add these cases (this task covers the guard/past-time; Task 2 covers the successful re-enqueue):
+
+```ts
+// In describe('updateEvent — newTime move', ...) or a sibling describe:
+
+it('throws ConflictException when newTime is in the past (draft campaign)', async () => {
+  // draft campaign, slot @ '17:00', dto.newTime a time already passed for dto.date
+  // (build the fixture so computeSlotSchedule returns it in pastDue — e.g. a past
+  // date/time relative to the test's `now`, in schedule.timezone).
+  // Assert: rejects toThrow(/already passed/i); no db.update writing time; no re-enqueue.
+})
+
+it('throws ConflictException when newTime is in the past (launched/active campaign)', async () => {
+  // campaign.status='active', slot.slotStatus='scheduled', dto.newTime in the past.
+  // Assert: rejects toThrow(/already passed/i); no cancelSlotJob, no materializeAndEnqueue.
+})
+
+it('does NOT throw the launched-409 for a future newTime move on an active scheduled slot', async () => {
+  // campaign.status='active', slot.slotStatus='scheduled', dto.newTime a FUTURE time,
+  // target free. Assert: does NOT reject with the old "Change this post's time before
+  // launching" message (that guard is gone). (The full re-enqueue assertions live in Task 2;
+  // here just assert it no longer throws that specific 409.)
+})
+```
+
+Also UPDATE (do not just delete) the existing `it('throws ConflictException when the campaign is launched (active) and newTime is set')` (~2062) — its premise is now inverted. Rename/repurpose it into the "does NOT throw the launched-409" test above (or delete it and rely on the new one). Note in the report which you did.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- campaigns.service`
+Expected: the new past-time cases FAIL (no past-time check exists yet); the "does NOT throw launched-409" case FAILS (the 409 still fires today).
+
+- [ ] **Step 3: Capture the `getOne` result**
+
+In `updateEvent`, change line ~1340 from:
+```ts
+    await this.getOne(workspaceId, id);
+```
+to:
+```ts
+    const campaign = await this.getOne(workspaceId, id);
+```
+(`campaign.schedule` is used by the past-time check below and by Task 2's re-materialize.)
+
+- [ ] **Step 4: Replace the launched-throw with a past-time block**
+
+In the `movingTime` block (currently starts ~1370 `const movingTime = ...`), replace the `if (campaignStatus === 'active') throw ...` with a past-time check, keeping the existing collision check after it:
+
+```ts
+    const movingTime = !!dto.newTime && dto.newTime !== slot.time;
+    if (movingTime) {
+      // Block moving to a time that has already passed — draft & launched alike.
+      // Reuse the launch due/past-due split so the boundary is identical.
+      const { pastDue } = computeSlotSchedule(
+        campaign.schedule,
+        [{ date: dto.date, time: dto.newTime! }],
+        new Date(),
+      );
+      if (pastDue.length > 0) {
+        throw new ConflictException(
+          'This time has already passed — pick a future time.',
+        );
+      }
+      // Collision: another slot already occupies the target time.
+      const [clash] = await db
+        .select({ id: campaignSlotContent.id })
+        .from(campaignSlotContent)
+        .where(
+          and(
+            eq(campaignSlotContent.campaignId, id),
+            eq(campaignSlotContent.date, dto.date),
+            eq(campaignSlotContent.channelId, dto.channelId),
+            eq(campaignSlotContent.time, dto.newTime!),
+          ),
+        );
+      if (clash) {
+        throw new ConflictException(
+          'A post already exists for this channel at that time on this day.',
+        );
+      }
+    }
+```
+
+(The collision `db.select` block is unchanged from what's already there — keep it verbatim; only the leading `if (campaignStatus === 'active') throw` is removed and the past-time check added above it.)
+
+- [ ] **Step 5: Update the stale comment**
+
+In `src/campaigns/campaigns.service.ts:144` (the local `UpdateEventDto` interface), change the `newTime` comment from `// HH:mm — content-preserving move to this time (pre-launch only)` to:
+```ts
+  newTime?: string; // HH:mm — content-preserving time move (blocked if past; re-enqueues a launched scheduled slot)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npm run test -- campaigns.service`
+Expected: the three new/updated cases PASS; the rest of the campaigns suite stays green (the draft future-move, draft collision, no-newTime cases). Note: Task 2's re-enqueue assertions may still be failing/absent — that's expected; this task only makes the guard/past-time behaviour correct.
+
+- [ ] **Step 7: Verify the backend compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "feat(campaigns): allow launched scheduled time move; block past-time moves"
+```
+
+---
+
+### Task 2: Backend — fix stale `slot.time`, re-enqueue at the new time
+
+**Files:**
+- Modify: `src/campaigns/campaigns.service.ts` (`updateEvent` re-materialize block ~1406-1454)
+- Test: `src/campaigns/campaigns.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `dto.newTime` / `slot.time`; `campaign.schedule` (captured in Task 1 Step 3); `cancelAndClearSlotPost`, `computeSlotSchedule`, `publishing.materializeAndEnqueue` (all existing).
+- Produces: on a launched `scheduled` slot with a `newTime` move, the re-materialized job is enqueued at the **new** time.
+
+**Design note (the bug):** The re-materialize block reads `slot.time` at two points — `computeSlotSchedule([{ date: slot.date, time: slot.time }], ...)` (~1421) and `materializeAndEnqueue({ time: slot.time })` (~1447). After a move, the DB row's `time` was updated (in the content `.set`) but the local `slot.time` variable is stale (still the OLD time). Introduce `const effectiveTime = movingTime ? dto.newTime! : slot.time;` and use it at both points. Also reuse `campaign.schedule` instead of the second `await this.getOne(...)` at ~1420 (Task 1 captured `campaign`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/campaigns/campaigns.service.spec.ts` — the successful launched move (this is the case with no existing coverage):
+
+```ts
+it('active + scheduled + future newTime: cancels the old job and re-enqueues at the NEW time', async () => {
+  // campaign.status='active', slot.slotStatus='scheduled', slot.time='17:00',
+  // slot.jobId/postId set. dto.newTime='20:00' (future, target free).
+  // Mock cancelSlotJob + materializeAndEnqueue.
+  // Act: await service.updateEvent(...)
+  // Assert:
+  //   - cancelAndClearSlotPost path ran: cancelSlotJob called with the OLD jobId,
+  //     posts delete guarded by status='scheduled'.
+  //   - publishing.materializeAndEnqueue was called with time: '20:00' (the NEW time) —
+  //     NOT '17:00'. THIS is the stale-slot.time guard.
+  //   - the slot row is updated with the new postId/jobId/scheduledAt and slotStatus='scheduled'.
+  //   - computeSlotSchedule (if real) was evaluated against '20:00' so scheduledAt matches 20:00.
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- campaigns.service`
+Expected: FAIL — today `materializeAndEnqueue` would be called with `'17:00'` (stale) even if the guard were relaxed; assert on `'20:00'` fails.
+
+- [ ] **Step 3: Introduce `effectiveTime` and use it in the re-materialize block**
+
+In `updateEvent`, right after the content+time `.set(...)` (~line 1404, before the `if (campaignStatus === 'active' && slot.slotStatus === 'scheduled')` block), add:
+```ts
+    const effectiveTime = movingTime ? dto.newTime! : slot.time;
+```
+Then inside the re-materialize block:
+- Replace `(await this.getOne(workspaceId, id)).schedule` (~1420) with `campaign.schedule`.
+- Replace `[{ date: slot.date, time: slot.time }]` (~1421) with `[{ date: slot.date, time: effectiveTime }]`.
+- Replace `time: slot.time,` in the `materializeAndEnqueue({ ... })` call (~1447) with `time: effectiveTime,`.
+
+Leave everything else in the block unchanged (the `skipped` branch, the destination, the final `.set` storing new ids).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- campaigns.service`
+Expected: PASS — `materializeAndEnqueue` now called with `'20:00'`. All Task-1 cases stay green.
+
+- [ ] **Step 5: Verify the backend compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "fix(campaigns): re-enqueue launched slot move at the NEW time (stale slot.time)"
+```
+
+---
+
+### Task 3: Frontend — "reschedules this post" note in the time-edit popover
+
+**Files:**
+- Modify: `src/features/campaigns/components/builder/bonzo/channels-column.tsx` (`SlotActionsMenu` + its call site)
+
+**Interfaces:**
+- Consumes: `campaign.status`; the row's `content.runtime?.slotStatus`.
+- Produces: the time-edit `PopoverContent` shows "Saving reschedules this post." only when the campaign is active AND the slot is `scheduled`.
+
+**Design note:** `SlotActionsMenu` currently receives `accountName`, `time`, `canEditTime`, `onEditTime`, `isSavingTime`, `onDelete`. Add a `rescheduleOnSave: boolean` prop. Compute it at the call site (inside the row `.map`) as `campaign.status === 'active' && content.runtime?.slotStatus === 'scheduled'`. Render the note inside `PopoverContent`, under the picker (before or after the Cancel/Save row — put it under the header, above the buttons).
+
+- [ ] **Step 1: Add the `rescheduleOnSave` prop to `SlotActionsMenu`**
+
+In `SlotActionsMenuProps` (interface), add:
+```ts
+  /** True when saving will cancel + re-enqueue a live job (active campaign,
+   *  still-scheduled slot) — surfaces a heads-up in the popover. */
+  rescheduleOnSave: boolean
+```
+Accept it in the destructured params of `SlotActionsMenu`.
+
+- [ ] **Step 2: Render the note in `PopoverContent`**
+
+Inside the `<PopoverContent ...>`, after the `<p>Edit post time</p>` header and before the `<div className="flex justify-end gap-2">` button row, add:
+```tsx
+        {rescheduleOnSave && (
+          <p className="text-[11px] text-muted-foreground">
+            Saving reschedules this post.
+          </p>
+        )}
+```
+
+- [ ] **Step 3: Pass `rescheduleOnSave` at the call site**
+
+At the `<SlotActionsMenu ... />` call (inside the row `.map`, where `content` is in scope), add the prop:
+```tsx
+                      rescheduleOnSave={
+                        campaign.status === 'active' &&
+                        content.runtime?.slotStatus === 'scheduled'
+                      }
+```
+
+- [ ] **Step 4: Verify the frontend compiles**
+
+Run: `npm run build`
+Expected: PASS (`tsc -b && vite build`).
+
+- [ ] **Step 5: Lint the touched file**
+
+Run: `npx eslint src/features/campaigns/components/builder/bonzo/channels-column.tsx`
+Expected: no errors (no unused props/vars).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/campaigns/components/builder/bonzo/channels-column.tsx
+git commit -m "feat(campaigns): note that saving reschedules a launched scheduled slot"
+```
+
+---
+
+### Task 4: Full build + test gate (both repos)
+
+**Files:** none (verification task).
+
+- [ ] **Step 1: Backend build + campaigns tests**
+
+In `socialmedia-workspace`:
+Run: `npm run build` → Expected: PASS.
+Run: `npm run test -- campaigns` → Expected: PASS (all campaigns specs, including the new launched-move + past-time cases).
+
+- [ ] **Step 2: Frontend build**
+
+In `socialmedia-frontend`:
+Run: `npm run build` → Expected: PASS.
+Run: `npm run test -- --run` → Expected: PASS (existing suite green; no new FE tests required, but nothing regresses).
+
+- [ ] **Step 3: Ledger the result**
+
+Record both outcomes in the SDD ledger. No commit.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec §2 "Launched + scheduled → time editable, cancel + re-enqueue at NEW time" → Task 1 (guard relax) + Task 2 (re-enqueue + stale fix). ✅
+- Spec §2 "Past-time moves BLOCKED (draft & launched)" → Task 1 Step 4 (past-time check via `computeSlotSchedule`). ✅
+- Spec §2 "collision / race / read-only guards unchanged" → Task 1 keeps the collision check verbatim; `cancelAndClearSlotPost` false-return 409 and `assertLaunchedSlotEditable` are untouched. ✅
+- Spec §2/§4.2 "FE reschedule note" → Task 3. ✅
+- Spec §7 testing (replace launched-409, past-time draft+launched, successful launched move asserting NEW time, collision, race) → Task 1 + Task 2 tests. ✅
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Test-case bodies describe exact arrange/assert; the implementer is told to reuse the existing mock harness and read it first (the one thing that can't be transcribed blind is the fixture-builder shape, which the plan points at explicitly).
+
+**3. Type consistency:**
+- `effectiveTime` defined in Task 2, used at the two re-materialize points in Task 2. ✅
+- `campaign` captured in Task 1 Step 3, reused in Task 1 (past-time check) and Task 2 (re-materialize schedule). Both tasks touch the same method — Task 2 depends on Task 1's `campaign` capture; noted in Task 2's design note. ✅
+- `rescheduleOnSave: boolean` added to props + call site within Task 3. ✅
+- `computeSlotSchedule(schedule, [{date, time}], now)` signature identical to its existing use in the re-materialize block. ✅
+
+Plan is internally consistent and covers the spec.

--- a/docs/superpowers/specs/2026-08-16-launched-slot-time-edit-design.md
+++ b/docs/superpowers/specs/2026-08-16-launched-slot-time-edit-design.md
@@ -1,0 +1,170 @@
+# Launched-Campaign Slot Time Edit — Design Spec
+
+**Date:** 2026-08-16
+**Branches:** `feat/launched-slot-time-edit` (both `socialmedia-workspace` and `socialmedia-frontend`, each off `main`)
+**Type:** Architectural (relax the launched-campaign time-move guard + re-enqueue at the new time + block past-time moves; small FE messaging add)
+
+---
+
+## 1. Problem
+
+A campaign/drip slot's time can be changed before launch (the `updateEvent` `newTime` move). But once the campaign is **launched** (`status === 'active'`), a still-`scheduled` slot's time **cannot** be changed: `updateEvent` throws a hard 409 ("Change this post's time before launching the campaign.") the moment `newTime` is set on an active campaign — even though:
+
+- The per-slot **⋮ menu with "Edit time" already renders** for `scheduled` slots on a launched campaign (frontend `isSlotEditable` returns true for `pending`/`scheduled`), so the user is offered an action the backend then rejects — a confusing dead end.
+- The exact mechanism needed (cancel the enqueued BullMQ job + re-materialize) **already exists** for launched **content** edits in the same method's re-materialize block — it just re-enqueues at the slot's *old* time.
+
+Two more gaps this surfaces:
+
+- **🐞 Stale `slot.time` in re-enqueue.** In the re-materialize block, `computeSlotSchedule(...)` and `materializeAndEnqueue({ time: slot.time })` both read the local `slot.time` variable. After a `newTime` move the DB row's `time` is updated, but the local `slot.time` is **not** reassigned — so if the launched move were simply allowed today, the job would silently re-enqueue at the OLD time while the DB/UI show the new time. This is unreachable today (the 409 guards it), but becomes a live, worst-case bug the moment the guard is relaxed.
+- **Past-time moves are not blocked.** Today a user can move a slot to a time that's already passed; at launch it's silently marked `skipped`. Per product decision, a past-time move should be **blocked outright** (draft and launched alike), not silently skipped.
+
+## 2. Scope (approved with user)
+
+- **Launched + `scheduled` slot → time is editable.** Changing it cancels the enqueued job and re-enqueues at the NEW time (content preserved). Only `scheduled` (and `pending`) slots; `published`/`publishing`/`failed`/`skipped` stay read-only (already enforced by `assertLaunchedSlotEditable` + the FE menu gate).
+- **Past-time moves are BLOCKED** (both draft and launched, for consistency): if `newTime` on the slot's date is already in the past (in the campaign's timezone), reject with a 409 "This time has already passed — pick a future time." The slot keeps its old time; nothing is lost. This replaces the prior "move-then-skip" behaviour for the *move* action. (Slots whose time passes *after* being set still show the existing "Past due" warning — that path is unchanged.)
+- **Fix the stale `slot.time`** so the re-enqueued job fires at the new time.
+- **Collision, race, and read-only guards unchanged:** target time already occupied → 409 (existing); post already publishing when the move lands → 409 "reload" (existing `cancelAndClearSlotPost` false-return); fired/read-only slot → 409 + no FE menu (existing).
+- **Frontend:** add a "Saving reschedules this post." note inside the time-edit popover when the campaign is active and the slot is scheduled (mirrors the content-edit composer's existing note). No functional FE change — the mutation already wires `newTime` through regardless of launch state; the backend 409-relax is what enables it.
+- Out of scope (unchanged): past-launch content-edit re-materialize (already shipped); the "Past due" badge/preflight/days-marker feature (unchanged); bulk vs drip distinction (both use the same slot `time` column).
+
+## 3. Key facts (verified in code)
+
+**Backend (`socialmedia-workspace`):**
+- `updateEvent` (`campaigns.service.ts` ~1334-1460): find slot → `await this.getOne(workspaceId, id)` (result currently discarded, ~1340) → load raw `campaignStatus` → `assertLaunchedSlotEditable(campaignStatus, slot.slotStatus)` (1365) → `movingTime` block (1367-1393, currently 409s on `active`) → content+time `.set` (1395-1404) → re-materialize block (1406-1454, gated `active && slotStatus==='scheduled'`).
+- `assertLaunchedSlotEditable` (~985-994): `campaignStatus !== 'active'` → return (unguarded); on active, `['publishing','published','failed','skipped']` → 409; `pending`/`scheduled` pass. **So the ONLY thing blocking a launched move today is the explicit `if (campaignStatus === 'active') throw` at ~1372, layered on top.**
+- `cancelAndClearSlotPost({ jobId, postId })` (~1004-1015): cancels the BullMQ job, deletes the `posts` row only if still `status='scheduled'` (race-safe), returns `false` (→ caller 409s) if the post already flipped to publishing. Reusable as-is.
+- Re-materialize block reads **`slot.time`** at line ~1421 (`computeSlotSchedule([{ date: slot.date, time: slot.time }], now)`) and ~1447 (`materializeAndEnqueue({ time: slot.time })`) — both STALE after a move (see §1).
+- `computeSlotSchedule(schedule, slots, now)` (exported, `campaign-schedule.util.ts:71`): for each `(date, time)`, converts wall-clock→UTC in `schedule.timezone` (`wallClockToUtc`, internal/not exported, `:47`), and splits `due` (`at >= now`, with `scheduledAt`) vs `pastDue` (`at < now`). **Reusing this for the past-time check keeps the block/skip boundary identical to launch.**
+- `UpdateEventDto.newTime?` exists in BOTH the class-validator DTO (`dto/campaigns.dto.ts:204-205`, `@Matches(/^\d{2}:\d{2}$/)`) and the local interface (`campaigns.service.ts:144`, comment says "pre-launch only" — now stale).
+- Existing tests (`campaigns.service.spec.ts`): `describe('updateEvent — newTime move')` at ~1986 has a draft-move-succeeds test (~1991), a collision-409 (~2021), **a launched-409 (~2062) that this feature INVERTS**, and a no-newTime-unchanged (~2094). `describe('updateEvent')` at ~1722 has content-edit re-materialize tests (~1785, ~1838, ~1873) — the pattern to mirror.
+
+**Frontend (`socialmedia-frontend`):**
+- `SlotActionsMenu` in `channels-column.tsx` (~561+): gated `{canDelete && ...}` where `canDelete = isSlotEditable(content, isLaunched)`. `isSlotEditable` (`utils/slot-editability.ts:8-11`): `!isLaunched` → true; else `slotStatus ∈ {pending, scheduled}`. **So the ⋮ + "Edit time" already renders on a launched drip's scheduled slots.**
+- `SlotActionsMenu`'s "Edit time" → `onEditTime(newTime)` → parent runs `updateEvent.mutate({ date, channelId, time, newTime, patch: content })` regardless of launch. `onError` toasts the server message. **The only blocker is the backend 409.**
+- The time-edit `PopoverContent` (~653+) shows a static "Edit post time" header — no reschedule note. The content-edit composer (`event-composer.tsx:359-363`) DOES show "Saving reschedules this post." when `campaign.status === 'active'` — the pattern to mirror.
+- FE `SlotActionsMenu` currently only knows `time`/`accountName`/`canEditTime`/handlers — it does NOT receive campaign status or the slot's runtime status, so the note needs those threaded in (or a precomputed boolean).
+
+## 4. Design — backend-first
+
+### Layer 1 — Backend (`campaigns.service.ts`)
+
+**1a. Capture the schedule once.** Change `await this.getOne(workspaceId, id);` (~1340) to `const campaign = await this.getOne(workspaceId, id);` so `campaign.schedule` is available for the past-time check (and reused later instead of the second `getOne` at ~1420).
+
+**1b. Relax the launched 409 + add the past-time block** in the `movingTime` block (~1371-1393). Replace the current `if (campaignStatus === 'active') throw ...` with a past-time guard that applies to BOTH draft and launched:
+
+```ts
+const movingTime = !!dto.newTime && dto.newTime !== slot.time;
+if (movingTime) {
+  // Block moving to a time that has already passed (draft & launched alike) —
+  // reuse the launch-time due/past-due split so the boundary is identical.
+  const { pastDue } = computeSlotSchedule(
+    campaign.schedule,
+    [{ date: dto.date, time: dto.newTime! }],
+    new Date(),
+  );
+  if (pastDue.length > 0) {
+    throw new ConflictException(
+      'This time has already passed — pick a future time.',
+    );
+  }
+  // Collision: another slot already occupies the target time (existing check).
+  const [clash] = await db
+    .select({ id: campaignSlotContent.id })
+    .from(campaignSlotContent)
+    .where(and(
+      eq(campaignSlotContent.campaignId, id),
+      eq(campaignSlotContent.date, dto.date),
+      eq(campaignSlotContent.channelId, dto.channelId),
+      eq(campaignSlotContent.time, dto.newTime!),
+    ));
+  if (clash) {
+    throw new ConflictException(
+      'A post already exists for this channel at that time on this day.',
+    );
+  }
+}
+```
+
+Note: `assertLaunchedSlotEditable` (already called at ~1365) still 409s a launched `published`/`fired`/`skipped` slot before this block, so only `scheduled`/`pending` reach here on a launched campaign — no extra status guard needed.
+
+**1c. Fix the stale `slot.time`.** After the content+time `.set`, compute the effective time once and use it in the re-materialize block instead of `slot.time`:
+
+```ts
+const effectiveTime = movingTime ? dto.newTime! : slot.time;
+```
+- Line ~1421: `[{ date: slot.date, time: effectiveTime }]`
+- Line ~1447: `time: effectiveTime`
+- Reuse `campaign.schedule` (from 1a) instead of the second `await this.getOne(...)` at ~1420.
+
+The re-materialize block's own gate (`campaignStatus === 'active' && slot.slotStatus === 'scheduled'`) is already correct — it now runs for a launched move because 1b no longer 409s it. `computeSlotSchedule` with `effectiveTime` yields the correct `scheduledAt` (or, since 1b already blocked past times, `pastDue` will be empty here — the `isPastDue → skipped` branch is now effectively dead for a *move* but stays as a safety net for the content-only re-materialize path, which is fine).
+
+**1d. Comment.** Update `campaigns.service.ts:144` local-interface comment: `newTime?: string; // HH:mm — content-preserving time move (blocked if past; re-enqueues on a launched scheduled slot)`.
+
+### Layer 2 — Frontend (`channels-column.tsx`)
+
+**2a. Reschedule note in the time-edit popover.** Thread a boolean into `SlotActionsMenu` — `rescheduleOnSave` — true when the campaign is active AND this slot is still `scheduled` (i.e., saving will cancel + re-enqueue a live job). Compute it at the call site from `campaign.status` + `content.runtime?.slotStatus`, pass it in, and render a muted note inside `PopoverContent` under the picker:
+
+```tsx
+{rescheduleOnSave && (
+  <p className="text-[11px] text-muted-foreground">
+    Saving reschedules this post.
+  </p>
+)}
+```
+
+Use theme tokens only. No other FE change — the past-time 409 and collision 409 already surface via the existing `onError` toast.
+
+## 5. Data flow (move a launched scheduled slot)
+
+```
+Launched drip, scheduled slot @ 18:00 → ⋮ → Edit time → 20:00 → Save time
+  → updateEvent.mutate({ date, channelId, time:'18:00', newTime:'20:00', patch: content })
+Backend updateEvent:
+  getOne → campaign (schedule)
+  assertLaunchedSlotEditable(active, 'scheduled') → OK
+  movingTime=true → computeSlotSchedule(schedule, [{date,'20:00'}], now)
+    → pastDue empty? ok : 409 "time has already passed"
+    → collision @ 20:00? 409 : ok
+  .set({ content: merged, time:'20:00' })
+  active && scheduled → cancelAndClearSlotPost(old job/post)
+    → false (already publishing)? 409 "reload"
+    → computeSlotSchedule(schedule, [{date, effectiveTime:'20:00'}], now) → scheduledAt
+    → materializeAndEnqueue({ time:'20:00', content: merged, scheduledAt, ... }) → new postId/jobId
+    → slot { postId, jobId, scheduledAt, slotStatus:'scheduled' }
+  → CampaignDto (fresh)
+Frontend: popover closes; card shows 20:00; the live job now fires at 20:00.
+```
+
+## 6. Error handling
+
+- Past `newTime` (draft or launched) → 409 "This time has already passed — pick a future time."; slot keeps old time; toast.
+- Target time occupied → 409 (existing message); toast; slot unchanged.
+- Launched published/fired/skipped slot → 409 (existing, via `assertLaunchedSlotEditable`); also the FE menu isn't shown, so unreachable via UI.
+- Post already publishing when the move lands → 409 "reload" (existing `cancelAndClearSlotPost` false-return); nothing half-applied beyond the content/time row write, which self-heals on reload.
+- `newTime === slot.time` → no-op (existing `movingTime` false).
+
+## 7. Testing
+
+**Backend (`campaigns.service.spec.ts`):**
+- **Replace** the existing `it('throws ConflictException when the campaign is launched (active) and newTime is set')` (~2062) — it now asserts the *opposite*. New positive test: active + `scheduled` slot + future `newTime` (target free) → cancels old job (`cancelSlotJob` called with old jobId), deletes guarded post, `materializeAndEnqueue` called with **`time: newTime`** (assert the NEW time, guarding the stale-`slot.time` fix), stores new postId/jobId, `slotStatus:'scheduled'`.
+- New: active + scheduled + **past** `newTime` → 409 "already passed", no cancel/re-enqueue, slot untouched.
+- New: draft + **past** `newTime` → 409 "already passed" (consistency).
+- New: active + scheduled + future `newTime` but target **occupied** → 409 collision, no re-enqueue.
+- New: active + scheduled + future `newTime` but `cancelAndClearSlotPost` returns false (post publishing) → 409 "reload".
+- Keep green: draft future-move succeeds (~1991), draft collision (~2021), no-newTime content-only (~2094), content-edit re-materialize tests (~1785/1838/1873).
+
+**Frontend:** `channels-column.tsx` builds; the `rescheduleOnSave` note renders only when active + scheduled. (No component-test harness under builder/ — cover the boolean via inspection / a small pure helper if one is introduced, per the existing convention.)
+
+**Build:** `npm run build` green both repos (`nest build`; `tsc -b && vite build`).
+
+## 8. Global constraints
+
+- **NO DB migration** — logic + existing columns only.
+- **shadcn-only** UI, theme tokens only (the note uses `text-muted-foreground`; no hex/arbitrary colors).
+- **Never** `git add .`/`-A` — surgical `git add <path>` only (FE `.env` git-TRACKED with secrets; BE `.env` gitignored with secrets).
+- Commit/push only when the user explicitly asks.
+- Assistant runs **no** `db:*`/`psql`/migration commands.
+- Backend-first (Layer 1 before Layer 2).
+- Reuse `computeSlotSchedule` for the past-time check so the block/skip boundary matches launch exactly (never a hand-rolled naive local-time compare).
+- Draft-campaign behaviour unchanged **except** past-time moves are now blocked (was: allowed-then-skipped-at-launch).
+- Off `main` (which has the per-slot ⋮ menu + earlier slot-time-edit merged); independent branch/PR both repos.

--- a/src/campaigns/campaigns.service.spec.ts
+++ b/src/campaigns/campaigns.service.spec.ts
@@ -1245,7 +1245,13 @@ describe('CampaignsService write methods (mocked db)', () => {
                     ? (r as { time?: string }).time === wantedTime
                     : true,
                 );
-              return Promise.resolve(filtered);
+              // Return shallow CLONES, matching a real DB: the object a SELECT
+              // hands back is a snapshot, not the same reference a later UPDATE
+              // mutates. (The update path still write-throughs to the fixture
+              // rows, so a subsequent re-select sees the new state.) Without
+              // this, Object.assign in the update would retroactively mutate a
+              // slot the service is still holding — masking stale-read bugs.
+              return Promise.resolve(filtered.map((r) => ({ ...r })));
             }
             if (name === 'social_media_channels') {
               return Promise.resolve(fixture.channelRows ?? []);
@@ -2157,6 +2163,59 @@ describe('CampaignsService write methods (mocked db)', () => {
 
       expect(publishing.cancelSlotJob).not.toHaveBeenCalled();
       expect(publishing.materializeAndEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('active + scheduled + future newTime: cancels the old job and re-enqueues at the NEW time', async () => {
+      const publishing = makePublishingMock();
+      publishing.materializeAndEnqueue.mockResolvedValue({ postId: 'p2', jobId: 'j2' });
+      const slot = makeSlotRow({
+        date: futureDate,
+        channelId: '1',
+        time: '17:00',
+        slotStatus: 'scheduled',
+        postId: 'post-old',
+        jobId: 'job-old',
+        content: content({ caption: 'hi' }),
+      });
+      const { db, updates, deletes } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'active' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+        postRows: [{ id: 'post-old', status: 'scheduled' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+        date: futureDate,
+        channelId: '1',
+        patch: { caption: 'bye' },
+        time: '17:00',
+        newTime: '20:00',
+      });
+
+      // Old job cancelled + guarded post delete ran.
+      expect(publishing.cancelSlotJob).toHaveBeenCalledWith('job-old');
+      expect(deletes.postIds).toEqual(['post-old']);
+      // Re-enqueued at the NEW time (not the stale '17:00') with the merged content.
+      expect(publishing.materializeAndEnqueue).toHaveBeenCalledTimes(1);
+      expect(publishing.materializeAndEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          date: futureDate,
+          channelId: '1',
+          time: '20:00',
+          content: expect.objectContaining({ caption: 'bye' }),
+        }),
+      );
+      // Slot re-linked to the new post/job.
+      const reLink = updates.slotUpdates.find(
+        (u) => u.id === 'slot-1' && u.set.postId === 'p2',
+      );
+      expect(reLink?.set).toMatchObject({
+        postId: 'p2',
+        jobId: 'j2',
+        slotStatus: 'scheduled',
+      });
     });
 
     it('leaves content-only behaviour unchanged when newTime is absent', async () => {

--- a/src/campaigns/campaigns.service.spec.ts
+++ b/src/campaigns/campaigns.service.spec.ts
@@ -1987,6 +1987,7 @@ describe('CampaignsService write methods (mocked db)', () => {
     const WORKSPACE_ID = 'ws-1';
     const CAMPAIGN_ID = 'c-1';
     const futureDate = '2099-06-15'; // far future -> always "due", never past-due
+    const pastDate = '2020-01-02'; // within nothing special -> any time on it is past-due
 
     it('moves the slot to newTime and preserves merged content when the target time is free', async () => {
       const publishing = makePublishingMock();
@@ -2059,20 +2060,27 @@ describe('CampaignsService write methods (mocked db)', () => {
       ).toBeUndefined();
     });
 
-    it('throws ConflictException when the campaign is launched (active) and newTime is set', async () => {
+    it('does NOT throw the old launched-409 for a future newTime move on an active scheduled slot', async () => {
+      // The launched campaign + newTime path used to hard-409; now a future move
+      // on a still-scheduled slot is allowed (it re-enqueues — see the re-enqueue
+      // test below). Here just prove it no longer throws the old message.
       const publishing = makePublishingMock();
+      publishing.materializeAndEnqueue.mockResolvedValue({ postId: 'p2', jobId: 'j2' });
       const slot = makeSlotRow({
         date: futureDate,
         channelId: '1',
         time: '17:00',
         slotStatus: 'scheduled',
+        postId: 'post-old',
+        jobId: 'job-old',
         content: content({ caption: 'hi' }),
       });
-      const { db, updates } = buildFakeDb({
+      const { db } = buildFakeDb({
         campaignRow: makeCampaignRow({ status: 'active' }),
         dayRows: [],
         slotRows: [slot],
         channelRows: [{ id: 1, platform: 'twitter' }],
+        postRows: [{ id: 'post-old', status: 'scheduled' }],
       });
       const service = loadServiceWithFakeDb(db, publishing);
 
@@ -2084,11 +2092,71 @@ describe('CampaignsService write methods (mocked db)', () => {
           time: '17:00',
           newTime: '18:00',
         }),
-      ).rejects.toThrow(/before launching the campaign/i);
+      ).resolves.toBeDefined();
+    });
 
-      expect(
-        updates.slotUpdates.find((u) => u.id === 'slot-1' && u.set.time === '18:00'),
-      ).toBeUndefined();
+    it('throws ConflictException when newTime is in the past (draft campaign)', async () => {
+      const publishing = makePublishingMock();
+      const slot = makeSlotRow({
+        date: pastDate,
+        channelId: '1',
+        time: '08:00',
+        slotStatus: 'pending',
+        content: content({ caption: 'hi' }),
+      });
+      const { db, updates } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'draft' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await expect(
+        service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+          date: pastDate,
+          channelId: '1',
+          patch: { caption: 'bye' },
+          time: '08:00',
+          newTime: '09:00',
+        }),
+      ).rejects.toThrow(/already passed/i);
+
+      expect(updates.slotUpdates.find((u) => u.set.time === '09:00')).toBeUndefined();
+    });
+
+    it('throws ConflictException when newTime is in the past (launched/active campaign)', async () => {
+      const publishing = makePublishingMock();
+      const slot = makeSlotRow({
+        date: pastDate,
+        channelId: '1',
+        time: '08:00',
+        slotStatus: 'scheduled',
+        postId: 'post-old',
+        jobId: 'job-old',
+        content: content({ caption: 'hi' }),
+      });
+      const { db } = buildFakeDb({
+        campaignRow: makeCampaignRow({ status: 'active' }),
+        dayRows: [],
+        slotRows: [slot],
+        channelRows: [{ id: 1, platform: 'twitter' }],
+        postRows: [{ id: 'post-old', status: 'scheduled' }],
+      });
+      const service = loadServiceWithFakeDb(db, publishing);
+
+      await expect(
+        service.updateEvent(WORKSPACE_ID, CAMPAIGN_ID, {
+          date: pastDate,
+          channelId: '1',
+          patch: { caption: 'bye' },
+          time: '08:00',
+          newTime: '09:00',
+        }),
+      ).rejects.toThrow(/already passed/i);
+
+      expect(publishing.cancelSlotJob).not.toHaveBeenCalled();
+      expect(publishing.materializeAndEnqueue).not.toHaveBeenCalled();
     });
 
     it('leaves content-only behaviour unchanged when newTime is absent', async () => {

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -141,7 +141,7 @@ export interface UpdateEventDto {
   channelId: string;
   patch: Partial<ChannelDayContentJson>;
   time?: string; // HH:mm — disambiguates a multi-time slot when provided
-  newTime?: string; // HH:mm — content-preserving move to this time (pre-launch only)
+  newTime?: string; // HH:mm — content-preserving time move (blocked if past; re-enqueues a launched scheduled slot)
 }
 
 export interface RemoveEventDto {
@@ -1337,7 +1337,7 @@ export class CampaignsService {
     id: string,
     dto: UpdateEventDto,
   ): Promise<CampaignDto> {
-    await this.getOne(workspaceId, id);
+    const campaign = await this.getOne(workspaceId, id);
 
     const [slot] = await db
       .select()
@@ -1364,14 +1364,23 @@ export class CampaignsService {
 
     this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);
 
-    // Content-preserving time move. Pre-launch only: moving a launched slot
-    // would need a re-materialize at the new fire time (out of scope here), so
-    // reject it with a clear 409 — the picker is disabled there anyway.
+    // Content-preserving time move. Allowed on draft AND launched campaigns —
+    // on a launched, still-scheduled slot the re-materialize block below cancels
+    // the enqueued job and re-enqueues at the new time. assertLaunchedSlotEditable
+    // (above) has already 409'd a launched published/fired slot, so only
+    // scheduled/pending reach here.
     const movingTime = !!dto.newTime && dto.newTime !== slot.time;
     if (movingTime) {
-      if (campaignStatus === 'active') {
+      // Block moving to a time that has already passed — draft & launched alike.
+      // Reuse the launch due/past-due split so the boundary is identical.
+      const { pastDue } = computeSlotSchedule(
+        campaign.schedule,
+        [{ date: dto.date, time: dto.newTime! }],
+        new Date(),
+      );
+      if (pastDue.length > 0) {
         throw new ConflictException(
-          'Change this post’s time before launching the campaign.',
+          'This time has already passed — pick a future time.',
         );
       }
       const [clash] = await db

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -1403,6 +1403,12 @@ export class CampaignsService {
 
     const mergedContent: ChannelDayContentJson = { ...slot.content, ...dto.patch };
 
+    // The effective fire time after this update: the new time when moving,
+    // otherwise the slot's existing time. Capture it BEFORE the write — the
+    // re-materialize block below must re-enqueue at the NEW time, not the old
+    // `slot.time` (which, post-write, would otherwise be stale).
+    const effectiveTime = movingTime ? dto.newTime! : slot.time;
+
     await db
       .update(campaignSlotContent)
       .set({
@@ -1413,7 +1419,7 @@ export class CampaignsService {
       .where(eq(campaignSlotContent.id, slot.id));
 
     // Launched + still-scheduled: the enqueued post is stale — cancel & re-enqueue
-    // from the merged content so the NEW content actually fires.
+    // from the merged content (at the effective time) so the NEW content/time fires.
     if (campaignStatus === 'active' && slot.slotStatus === 'scheduled') {
       const safe = await this.cancelAndClearSlotPost({ jobId: slot.jobId, postId: slot.postId });
       if (!safe) {
@@ -1425,9 +1431,8 @@ export class CampaignsService {
       const channelMap = await this.resolveSlotChannels([slot.channelId]);
       const platform = channelMap.get(slot.channelId);
       const { due, pastDue } = computeSlotSchedule(
-        // reload the campaign schedule for computeSlotSchedule
-        (await this.getOne(workspaceId, id)).schedule,
-        [{ date: slot.date, time: slot.time }],
+        campaign.schedule,
+        [{ date: slot.date, time: effectiveTime }],
         new Date(),
       );
       const scheduledAt = due[0]?.scheduledAt;
@@ -1450,7 +1455,7 @@ export class CampaignsService {
           campaignId: id,
           date: slot.date,
           channelId: slot.channelId,
-          time: slot.time,
+          time: effectiveTime,
           content: mergedContent,
           platform,
           scheduledAt,


### PR DESCRIPTION
﻿## Launched-campaign slot time edit

Lets a user change the time of a still-`scheduled` slot on a **launched** (active) campaign/drip — the enqueued BullMQ job is cancelled and re-enqueued at the new time (content preserved). Also blocks moving a slot to an already-past time.

### Changes (`campaigns.service.ts` `updateEvent`)
- **Relaxed the launched 409**: a `newTime` move is now allowed on an active campaign's scheduled/pending slot (published/fired slots are still 409'd by `assertLaunchedSlotEditable`).
- **Past-time block** (draft AND launched): if `newTime` on the slot's date is already in the past (via `computeSlotSchedule` — same boundary as launch), reject with 409 "This time has already passed — pick a future time." The slot keeps its old time.
- **🐞 Stale `slot.time` fix**: the re-materialize block re-read `slot.time`, which is stale after a move (DB row updated, local var not) — so the job would have silently re-enqueued at the OLD time. Now captures `effectiveTime` before the write and uses it for `computeSlotSchedule` + `materializeAndEnqueue`.
- Collision / race / read-only guards unchanged.
- **NO DB migration** — logic only.

### Test-harness fix
The test's fake DB did `Object.assign(row, set)` on UPDATE, mutating a slot the service still held — which **masked** the stale-`slot.time` bug (a buggy test falsely passed). Fixed the SELECT to return row clones like a real DB; verified the re-enqueue test now genuinely fails on the stale read and passes on the fix.

### Quality
- 119/119 campaigns tests; `nest build` clean.
- Pairs with the frontend PR on `asad00712/schedura-frontend` (reschedule note + add-channel ordering polish).

Spec/plan: `docs/superpowers/{specs,plans}/2026-08-16-launched-slot-time-edit*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
