### PR TITLE
feat(evergreen): Evergreen Recycling — category-based auto-rotating campaign type

### DIFF
--- a/docs/superpowers/plans/2026-08-17-evergreen-recycling.md
+++ b/docs/superpowers/plans/2026-08-17-evergreen-recycling.md
@@ -514,13 +514,15 @@ git commit -m "feat(evergreen): rotation engine — fire + per-fire re-enqueue +
 
 ---
 
-## Task 7: Lifecycle branches (launch / pause / resume) + reconcile cron
+## Task 7: Lifecycle branches (launch / pause / resume) + reconcile cron + multi-channel fan-out
 
 **Files:**
 - Modify: `src/campaigns/campaigns.service.ts` (branch `launch/pause/resume/assembleCampaign/duplicate` to `EvergreenService` when `type==='evergreen'`)
-- Modify: `src/campaigns/evergreen.service.ts` (`launch`, `pause`, `resume`, `reconcile`)
+- Modify: `src/campaigns/evergreen.service.ts` (`launch`, `pause`, `resume`, `reconcile`, **+ multi-channel fan-out in `armCategory`**)
 - Create: `src/campaigns/evergreen-reconcile.cron.ts` (one daily `@Cron` that re-arms active categories with no future scheduled occurrence)
 - Test: `src/campaigns/evergreen-lifecycle.spec.ts`
+
+**FOLDED-IN FROM TASK 6 REVIEW (multi-channel fan-out):** Task 6 shipped `armCategory` using `category.channelIds[0]` only — a category with N channels silently posts to just the first. Fix here (this is where arm/fire/reconcile design lives together): when a category's fire is due, `armCategory` must insert **one `evergreenOccurrences` row per channelId** in `category.channelIds` (each its own occurrence → own post → own BullMQ job), NOT just the first. `fireOccurrence` already fires a single occurrence's `channelId`, so it needs no change — only `armCategory` fans out, and the reconcile must re-arm ALL channels of a category, not one. Add a test: a category with 2 channelIds arms 2 occurrences (one per channel) at the same fire instant. Keep the single-channel path working. The occurrence's `postIdRef` pick is per-fire-instant (all channels of one fire may share the same picked post, or re-pick per channel — pick shared-per-instant for simplicity + document it).
 
 **Interfaces:**
 - Consumes: Task 6 `armCategory`; `cancelSlotJob`.

--- a/docs/superpowers/plans/2026-08-17-evergreen-recycling.md
+++ b/docs/superpowers/plans/2026-08-17-evergreen-recycling.md
@@ -1,0 +1,695 @@
+# Evergreen Recycling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Evergreen Recycling campaign type that auto-rotates a pool of categorized posts on a repeating schedule forever, with AI variations, performance-aware recycling, freshness guard, and messaging channels.
+
+**Architecture:** Extend the existing NestJS campaigns module. Three new Drizzle tables (categories, pool posts, occurrence log) + a per-fire re-enqueue rotation engine that reuses the existing `post-publishing` BullMQ queue and `materializeAndEnqueue` publish path. Frontend adds a category-first builder view (rail + Up-Next strip + post grid) reusing the composer building blocks. Bulk/Drip untouched.
+
+**Tech Stack:** NestJS, Drizzle ORM (Postgres), BullMQ, class-validator, Jest (BE). Vite/React 19, TypeScript, Tailwind 3, shadcn/ui, TanStack Query v5, Vitest (FE).
+
+**Spec:** `socialmedia-workspace/docs/superpowers/specs/2026-08-17-evergreen-recycling-design.md`
+
+## Global Constraints
+
+- **Bulk/Drip byte-for-byte unchanged.** Evergreen logic is additive; branch on `type==='evergreen'`. Never alter a shared code path in a way that changes bulk/drip behavior. `campaign_days` / `campaign_slot_content` are NOT used by evergreen.
+- **Assistant never runs `db:*` / `psql` / migrations.** Generate migration SQL via `npm run db:generate`; the USER applies it. A task that needs a table present tests against the schema/service with a fake DB, not a live one.
+- **Never `git add .` / `-A`.** Frontend `.env` is git-TRACKED with secrets; backend `.env` is gitignored with live secrets. Surgical `git add <path>` only. Commit only; never push/PR/merge unless the user explicitly asks.
+- **shadcn-only UI + theme tokens only** (no hex, no arbitrary Tailwind colors like `bg-blue-500`). Category colors come from a fixed token set reusing the `ACCENT_CLASSES` pattern.
+- **Every async surface** gets loading / disabled / empty / error states (CLAUDE.md Rule 4). Pages stay thin; feature components carry concerns (Rule 1). `kebab-case.tsx` files, `PascalCase` components.
+- **Graceful degradation is mandatory:** AI down → publish base caption; no metrics → neutral score; freshness error → don't flag, don't block. The rotation core never depends on a differentiator succeeding.
+- **git autocrlf note (BE repo):** working tree is CRLF; committed blobs LF. `npx eslint` shows prettier `␍⏎` noise — do NOT run `--fix`. `nest build` is the gate.
+- **Reused exact signatures** (cite verbatim; do not invent):
+  - `computeSlotSchedule(schedule: CampaignScheduleJson, slots: {date;time}[], now: Date): { due: {date;time;scheduledAt:Date}[]; pastDue: {date;time}[] }` — `src/campaigns/campaign-schedule.util.ts`
+  - `CampaignPublishingService.materializeAndEnqueue(input: { workspaceId; createdById; campaignId; date; channelId; time; content: ChannelDayContentJson; platform: string; scheduledAt: Date; destination?: {id;name?} }): Promise<{ postId: string; jobId: string }>` — `src/campaigns/campaign-publishing.service.ts`
+  - `CampaignPublishingService.cancelSlotJob(jobId: string): Promise<void>`
+  - `GroqService.generateVariations(content: string, platform: Platform, count?: number): Promise<string[]>` — `src/ai/groq.service.ts`
+  - Schema enums `CAMPAIGN_SLOT_STATUSES` / `CampaignSlotStatus`, JSON types `ChannelDayContentJson`, `CampaignScheduleEvergreenJson` — `src/drizzle/schema/campaigns.schema.ts`
+
+---
+
+## File Structure
+
+**Backend (`socialmedia-workspace/`):**
+- `src/drizzle/schema/evergreen.schema.ts` — NEW: 3 tables + enums + JSON types + relations + type exports. Re-exported from `src/drizzle/schema/index.ts`.
+- `src/campaigns/evergreen-rotation.util.ts` — NEW: pure rotation helpers (`computeNextCategoryFire`, `pickNextPost`, eligibility, variation selection). No DB, fully unit-testable.
+- `src/campaigns/evergreen.service.ts` — NEW: `EvergreenService` — category/pool/variation CRUD, launch/pause/resume branches, `fireOccurrence`, reconcile.
+- `src/campaigns/evergreen.controller.ts` — NEW: REST routes under `campaigns/workspaces/:ws/...`.
+- `src/campaigns/dto/evergreen.dto.ts` — NEW: class-validator DTOs.
+- `src/campaigns/processors/evergreen-fire.processor.ts` — NEW: BullMQ processor for the per-fire rotation job.
+- `src/campaigns/campaigns.module.ts` — MODIFY: register new providers + the fire queue + reconcile cron.
+- `src/campaigns/campaigns.service.ts` — MODIFY (surgical): `launch/pause/resume/assembleCampaign/duplicate` branch to `EvergreenService` when `type==='evergreen'`.
+
+**Frontend (`socialmedia-frontend/`):**
+- `src/features/campaigns/types/evergreen.ts` — NEW: types.
+- `src/features/campaigns/api/evergreen.api.ts` — NEW: typed API wrappers.
+- `src/features/campaigns/hooks/use-evergreen.ts` + `use-evergreen-mutations.ts` — NEW.
+- `src/features/campaigns/utils/evergreen-colors.ts` — NEW: category color token map + tests.
+- `src/features/campaigns/components/evergreen/` — NEW: `evergreen-builder-view.tsx`, `category-rail.tsx`, `up-next-strip.tsx`, `post-grid.tsx`, `evergreen-post-card.tsx`, `evergreen-post-editor.tsx`, `variations-panel.tsx`, `recycle-policy-control.tsx`, `new-category-dialog.tsx`.
+- `src/features/campaigns/constants/type-config.tsx` — MODIFY: nothing (card exists).
+- `src/features/campaigns/components/create/new-campaign-type-chooser.tsx` — MODIFY (last task): add `'evergreen'` to `ACTIVE_TYPES`.
+- Router / builder routing — MODIFY: route an evergreen campaign to `EvergreenBuilderView` instead of the bonzo builder.
+
+---
+
+## Task 1: Evergreen schema (tables + enums + types)
+
+**Files:**
+- Create: `src/drizzle/schema/evergreen.schema.ts`
+- Modify: `src/drizzle/schema/index.ts` (add `export * from './evergreen.schema';` after the campaigns line at :27)
+- Test: `src/drizzle/schema/evergreen.schema.spec.ts`
+
+**Interfaces:**
+- Produces: tables `evergreenCategories`, `evergreenPosts`, `evergreenOccurrences`; enums `EVERGREEN_POST_STATUSES`/`EvergreenPostStatus`; JSON types `EvergreenCategoryScheduleJson`, `EvergreenVariationJson`, `RecyclePolicyJson`, `EvergreenSeasonalJson`; type exports `EvergreenCategory`/`NewEvergreenCategory`/`EvergreenPost`/`NewEvergreenPost`/`EvergreenOccurrence`/`NewEvergreenOccurrence`. Consumed by every later BE task.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/drizzle/schema/evergreen.schema.spec.ts
+import {
+  evergreenCategories,
+  evergreenPosts,
+  evergreenOccurrences,
+  EVERGREEN_POST_STATUSES,
+} from './evergreen.schema';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+
+describe('evergreen schema', () => {
+  it('defines the three evergreen tables with correct names', () => {
+    expect(getTableConfig(evergreenCategories).name).toBe('campaign_evergreen_categories');
+    expect(getTableConfig(evergreenPosts).name).toBe('campaign_evergreen_posts');
+    expect(getTableConfig(evergreenOccurrences).name).toBe('campaign_evergreen_occurrences');
+  });
+
+  it('categories table has a unique (campaign_id, name) index', () => {
+    const idx = getTableConfig(evergreenCategories).indexes.map((i) => i.config.name);
+    expect(idx).toContain('evergreen_categories_campaign_name_uq');
+  });
+
+  it('exports the post status enum', () => {
+    expect(EVERGREEN_POST_STATUSES).toEqual(['active', 'paused', 'retired']);
+  });
+
+  it('posts table has category_id and campaign_id columns', () => {
+    const cols = getTableConfig(evergreenPosts).columns.map((c) => c.name);
+    expect(cols).toEqual(
+      expect.arrayContaining(['category_id', 'campaign_id', 'content', 'variations', 'recycle_policy', 'performance_score', 'is_stale', 'status']),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/drizzle/schema/evergreen.schema.spec.ts`
+Expected: FAIL — cannot find module `./evergreen.schema`.
+
+- [ ] **Step 3: Write the schema**
+
+Follow `campaigns.schema.ts` style exactly (pgTable, column helpers, `uniqueIndex`, `.$type<>()`, relations, `$inferSelect`/`$inferInsert` exports). Import `campaigns` from `./campaigns.schema` for FK references, `CampaignSlotStatus`/`ChannelDayContentJson` too.
+
+```ts
+// src/drizzle/schema/evergreen.schema.ts
+import {
+  pgTable, uuid, text, timestamp, varchar, boolean, jsonb, integer, real, uniqueIndex, index,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { campaigns, CampaignSlotStatus, ChannelDayContentJson } from './campaigns.schema';
+
+export const EVERGREEN_POST_STATUSES = ['active', 'paused', 'retired'] as const;
+export type EvergreenPostStatus = (typeof EVERGREEN_POST_STATUSES)[number];
+
+export interface EvergreenCategoryScheduleJson {
+  weekdays: number[]; // 0=Sun..6=Sat
+  times: string[];    // HH:mm
+}
+export interface EvergreenSeasonalJson {
+  startDate: string; // yyyy-MM-dd
+  endDate: string;
+}
+export interface EvergreenVariationJson {
+  id: string;
+  caption: string;
+  media?: { id: string; filename: string; kind: 'image' | 'video'; url?: string }[];
+  source: 'ai' | 'manual';
+}
+export interface RecyclePolicyJson {
+  mode: 'forever' | 'maxCount' | 'expiry';
+  maxCount?: number;
+  expiryDate?: string; // yyyy-MM-dd
+}
+
+export const evergreenCategories = pgTable(
+  'campaign_evergreen_categories',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 120 }).notNull(),
+    color: varchar('color', { length: 20 }).notNull(),
+    schedule: jsonb('schedule').$type<EvergreenCategoryScheduleJson>().notNull(),
+    channelIds: jsonb('channel_ids').$type<string[]>().default([]).notNull(),
+    seasonal: jsonb('seasonal').$type<EvergreenSeasonalJson | null>(),
+    isActive: boolean('is_active').default(true).notNull(),
+    rotationCursor: integer('rotation_cursor').default(0).notNull(),
+    sortOrder: integer('sort_order').default(0).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    uqCampaignName: uniqueIndex('evergreen_categories_campaign_name_uq').on(t.campaignId, t.name),
+  }),
+);
+
+export const evergreenPosts = pgTable(
+  'campaign_evergreen_posts',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    categoryId: uuid('category_id').notNull().references(() => evergreenCategories.id, { onDelete: 'cascade' }),
+    content: jsonb('content').$type<ChannelDayContentJson>().notNull(),
+    variations: jsonb('variations').$type<EvergreenVariationJson[]>().default([]).notNull(),
+    recyclePolicy: jsonb('recycle_policy').$type<RecyclePolicyJson>().notNull(),
+    minGapHours: integer('min_gap_hours').default(0).notNull(),
+    recycledCount: integer('recycled_count').default(0).notNull(),
+    lastPublishedAt: timestamp('last_published_at', { withTimezone: true }),
+    performanceScore: real('performance_score'),
+    isStale: boolean('is_stale').default(false).notNull(),
+    staleReason: text('stale_reason'),
+    status: varchar('status', { length: 20 }).$type<EvergreenPostStatus>().default('active').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    idxCategoryStatus: index('evergreen_posts_category_status_idx').on(t.categoryId, t.status),
+    idxCampaign: index('evergreen_posts_campaign_idx').on(t.campaignId),
+  }),
+);
+
+export const evergreenOccurrences = pgTable(
+  'campaign_evergreen_occurrences',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    categoryId: uuid('category_id').notNull().references(() => evergreenCategories.id, { onDelete: 'cascade' }),
+    postIdRef: uuid('post_id_ref').notNull().references(() => evergreenPosts.id, { onDelete: 'cascade' }),
+    variationId: varchar('variation_id', { length: 64 }),
+    channelId: varchar('channel_id', { length: 255 }).notNull(),
+    scheduledAt: timestamp('scheduled_at', { withTimezone: true }).notNull(),
+    slotStatus: varchar('slot_status', { length: 20 }).$type<CampaignSlotStatus>().default('scheduled').notNull(),
+    postsRowId: uuid('posts_row_id'),
+    jobId: varchar('job_id', { length: 160 }),
+    publishedAt: timestamp('published_at', { withTimezone: true }),
+    lastError: text('last_error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    idxCampaignScheduled: index('evergreen_occurrences_campaign_scheduled_idx').on(t.campaignId, t.scheduledAt),
+    idxPostRef: index('evergreen_occurrences_post_ref_idx').on(t.postIdRef),
+    idxJob: index('evergreen_occurrences_job_idx').on(t.jobId),
+  }),
+);
+
+export const evergreenCategoriesRelations = relations(evergreenCategories, ({ one, many }) => ({
+  campaign: one(campaigns, { fields: [evergreenCategories.campaignId], references: [campaigns.id] }),
+  posts: many(evergreenPosts),
+}));
+export const evergreenPostsRelations = relations(evergreenPosts, ({ one }) => ({
+  category: one(evergreenCategories, { fields: [evergreenPosts.categoryId], references: [evergreenCategories.id] }),
+}));
+
+export type EvergreenCategory = typeof evergreenCategories.$inferSelect;
+export type NewEvergreenCategory = typeof evergreenCategories.$inferInsert;
+export type EvergreenPost = typeof evergreenPosts.$inferSelect;
+export type NewEvergreenPost = typeof evergreenPosts.$inferInsert;
+export type EvergreenOccurrence = typeof evergreenOccurrences.$inferSelect;
+export type NewEvergreenOccurrence = typeof evergreenOccurrences.$inferInsert;
+```
+
+Then add to `src/drizzle/schema/index.ts` after line 27: `export * from './evergreen.schema';`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/drizzle/schema/evergreen.schema.spec.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Generate migration (do NOT apply)**
+
+Run: `npm run db:generate`
+Expected: a new migration file under `drizzle/migrations/` creating the 3 tables + indexes. Do NOT run `db:migrate`/`db:push`. Note the file path in the commit; the user applies it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/drizzle/schema/evergreen.schema.ts src/drizzle/schema/index.ts src/drizzle/schema/evergreen.schema.spec.ts drizzle/migrations/
+git commit -m "feat(evergreen): schema — categories, pool posts, occurrences"
+```
+
+---
+
+## Task 2: Rotation utility (pure, no DB)
+
+**Files:**
+- Create: `src/campaigns/evergreen-rotation.util.ts`
+- Test: `src/campaigns/evergreen-rotation.util.spec.ts`
+
+**Interfaces:**
+- Consumes: `EvergreenCategoryScheduleJson`, `EvergreenPost`, `RecyclePolicyJson` (Task 1); `wallClockToUtc` logic pattern from `campaign-schedule.util.ts` (reuse by importing its exported helper if available, else replicate the tz conversion — check the util's exports first).
+- Produces:
+  - `computeNextCategoryFire(schedule: EvergreenCategoryScheduleJson, timezone: string, blackoutDates: string[], after: Date): Date | null` — next matching weekday+time strictly after `after`, in tz; null if none within a safety scan (e.g. 366 days).
+  - `isPostEligible(post: EvergreenPost, category: { isActive: boolean; seasonal: EvergreenSeasonalJson | null }, now: Date): boolean` — status active + category active + within seasonal window + not expired by policy + min-gap satisfied.
+  - `pickNextPost(posts: EvergreenPost[], category, now: Date): EvergreenPost | null` — filter eligible, rank least-recently-published-first with D2 weighting `(0.5 + performanceScore)` when non-null, return top or null.
+  - `selectVariation(post: EvergreenPost): { variationId: string | null; caption: string }` — cycle base→var1→var2 by `recycledCount % (variations.length + 1)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/campaigns/evergreen-rotation.util.spec.ts
+import { computeNextCategoryFire, isPostEligible, pickNextPost, selectVariation } from './evergreen-rotation.util';
+
+const NOW = new Date('2026-08-17T12:00:00Z'); // Monday
+
+function post(overrides: any = {}): any {
+  return {
+    id: 'p1', status: 'active', recyclePolicy: { mode: 'forever' }, minGapHours: 0,
+    recycledCount: 0, lastPublishedAt: null, performanceScore: null, variations: [], ...overrides,
+  };
+}
+const liveCat = { isActive: true, seasonal: null };
+
+describe('computeNextCategoryFire', () => {
+  it('returns the next matching weekday+time after `after`', () => {
+    // Wednesday(3) 09:00 UTC, from Monday noon → 2026-08-19T09:00Z
+    const next = computeNextCategoryFire({ weekdays: [3], times: ['09:00'] }, 'UTC', [], NOW);
+    expect(next?.toISOString()).toBe('2026-08-19T09:00:00.000Z');
+  });
+  it('skips blackout dates', () => {
+    const next = computeNextCategoryFire({ weekdays: [1,2,3], times: ['09:00'] }, 'UTC', ['2026-08-18'], NOW);
+    // Mon noon → Tue 18th is blackout → Wed 19th 09:00
+    expect(next?.toISOString()).toBe('2026-08-19T09:00:00.000Z');
+  });
+  it('returns null when no weekday configured', () => {
+    expect(computeNextCategoryFire({ weekdays: [], times: ['09:00'] }, 'UTC', [], NOW)).toBeNull();
+  });
+});
+
+describe('isPostEligible', () => {
+  it('true for an active post in an active category', () => {
+    expect(isPostEligible(post(), liveCat, NOW)).toBe(true);
+  });
+  it('false for a paused/retired post', () => {
+    expect(isPostEligible(post({ status: 'paused' }), liveCat, NOW)).toBe(false);
+    expect(isPostEligible(post({ status: 'retired' }), liveCat, NOW)).toBe(false);
+  });
+  it('false when category is inactive', () => {
+    expect(isPostEligible(post(), { isActive: false, seasonal: null }, NOW)).toBe(false);
+  });
+  it('false outside a seasonal window', () => {
+    expect(isPostEligible(post(), { isActive: true, seasonal: { startDate: '2026-12-01', endDate: '2026-12-31' } }, NOW)).toBe(false);
+  });
+  it('false when maxCount reached', () => {
+    expect(isPostEligible(post({ recyclePolicy: { mode: 'maxCount', maxCount: 3 }, recycledCount: 3 }), liveCat, NOW)).toBe(false);
+  });
+  it('false when past expiry', () => {
+    expect(isPostEligible(post({ recyclePolicy: { mode: 'expiry', expiryDate: '2026-08-01' } }), liveCat, NOW)).toBe(false);
+  });
+  it('false when min-gap not satisfied', () => {
+    expect(isPostEligible(post({ minGapHours: 48, lastPublishedAt: new Date('2026-08-17T00:00:00Z') }), liveCat, NOW)).toBe(false);
+  });
+});
+
+describe('pickNextPost', () => {
+  it('returns null when nothing eligible', () => {
+    expect(pickNextPost([post({ status: 'retired' })], liveCat, NOW)).toBeNull();
+  });
+  it('prefers the least-recently-published post', () => {
+    const a = post({ id: 'a', lastPublishedAt: new Date('2026-08-16T00:00:00Z') });
+    const b = post({ id: 'b', lastPublishedAt: new Date('2026-08-10T00:00:00Z') }); // older
+    expect(pickNextPost([a, b], liveCat, NOW)?.id).toBe('b');
+  });
+  it('weights a strong performer ahead of a slightly-older weak one', () => {
+    const weakOld = post({ id: 'weakOld', lastPublishedAt: new Date('2026-08-10T00:00:00Z'), performanceScore: 0.0 });
+    const strongNewer = post({ id: 'strongNewer', lastPublishedAt: new Date('2026-08-11T00:00:00Z'), performanceScore: 1.0 });
+    expect(pickNextPost([weakOld, strongNewer], liveCat, NOW)?.id).toBe('strongNewer');
+  });
+  it('treats null performanceScore as neutral (never excludes on score)', () => {
+    const only = post({ id: 'only', performanceScore: null });
+    expect(pickNextPost([only], liveCat, NOW)?.id).toBe('only');
+  });
+});
+
+describe('selectVariation', () => {
+  it('uses base caption on the first fire', () => {
+    const p = post({ content: { caption: 'BASE' } as any, variations: [{ id: 'v1', caption: 'V1', source: 'ai' }], recycledCount: 0 });
+    expect(selectVariation({ ...p, content: { caption: 'BASE' } } as any)).toEqual({ variationId: null, caption: 'BASE' });
+  });
+  it('cycles to variation 1 on the second fire', () => {
+    const p = { content: { caption: 'BASE' }, variations: [{ id: 'v1', caption: 'V1', source: 'ai' }], recycledCount: 1 } as any;
+    expect(selectVariation(p)).toEqual({ variationId: 'v1', caption: 'V1' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx jest src/campaigns/evergreen-rotation.util.spec.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the util**
+
+Implement the four functions. For `computeNextCategoryFire`, first check `campaign-schedule.util.ts` for an exported `wallClockToUtc`/`zoneOffsetMinutes`; if exported, import and reuse; if not, replicate the exact tz conversion (Intl.DateTimeFormat offset). Scan day-by-day up to 366 days from `after`, for each matching weekday try each time (ascending), skip blackout dates, return the first instant strictly `> after`. Weighting in `pickNextPost`: sort ascending by `lastPublishedAt` (nulls first = highest priority), then compute a priority number = `agePriority × (0.5 + (performanceScore ?? 0.5))` and pick the max; keep it simple and deterministic. Provide clear inline comments.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest src/campaigns/evergreen-rotation.util.spec.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/evergreen-rotation.util.ts src/campaigns/evergreen-rotation.util.spec.ts
+git commit -m "feat(evergreen): pure rotation util — next-fire, eligibility, picker, variation"
+```
+
+---
+
+## Task 3: Evergreen DTOs
+
+**Files:**
+- Create: `src/campaigns/dto/evergreen.dto.ts`
+- Test: `src/campaigns/dto/evergreen.dto.spec.ts`
+
+**Interfaces:**
+- Produces: `CreateEvergreenCampaignDto`, `CreateEvergreenCategoryDto`, `UpdateEvergreenCategoryDto`, `SetCategoryActiveDto`, `CreateEvergreenPostDto`, `UpdateEvergreenPostDto`, `AddVariationDto`, `RecyclePolicyDto`, `CategoryScheduleDto`. Consumed by Task 5 (controller).
+
+- [ ] **Step 1: Write the failing test** (validation behavior)
+
+```ts
+// src/campaigns/dto/evergreen.dto.spec.ts
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateEvergreenCategoryDto, CreateEvergreenCampaignDto } from './evergreen.dto';
+
+describe('CreateEvergreenCategoryDto', () => {
+  it('accepts a valid category', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: 'Tips', color: 'emerald', schedule: { weekdays: [1, 3], times: ['09:00'] }, channelIds: ['12'],
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+  it('rejects an empty name', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: '', color: 'emerald', schedule: { weekdays: [1], times: ['09:00'] }, channelIds: [],
+    });
+    expect((await validate(dto)).length).toBeGreaterThan(0);
+  });
+});
+
+describe('CreateEvergreenCampaignDto', () => {
+  it('requires name, startDate, timezone', async () => {
+    const dto = plainToInstance(CreateEvergreenCampaignDto, { name: 'X', startDate: '2026-08-20', timezone: 'UTC', channelIds: ['1'] });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — `npx jest src/campaigns/dto/evergreen.dto.spec.ts` → FAIL (module not found).
+
+- [ ] **Step 3: Implement DTOs** using `class-validator` decorators (`@IsString`, `@IsNotEmpty`, `@IsDateString`, `@IsArray`, `@ValidateNested`, `@Type`, `@IsIn`, `@IsOptional`, `@IsInt`, `@Min`), mirroring the existing `dto/campaigns.dto.ts` style. `CategoryScheduleDto` = `{ weekdays: number[]; times: string[] }`. `RecyclePolicyDto` = `{ mode: 'forever'|'maxCount'|'expiry'; maxCount?; expiryDate? }`. `color` `@IsIn(['emerald','violet','sky','amber','rose','cyan'])`.
+
+- [ ] **Step 4: Run to verify pass** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/dto/evergreen.dto.ts src/campaigns/dto/evergreen.dto.spec.ts
+git commit -m "feat(evergreen): request DTOs"
+```
+
+---
+
+## Task 4: EvergreenService — category + pool CRUD (no rotation yet)
+
+**Files:**
+- Create: `src/campaigns/evergreen.service.ts`
+- Test: `src/campaigns/evergreen.service.spec.ts`
+
+**Interfaces:**
+- Consumes: schema (Task 1), DTOs (Task 3), Drizzle `DRIZZLE` provider (inject like `CampaignsService` does — check its constructor for the token), `CampaignsService.assembleCampaign` pattern.
+- Produces methods: `createCampaign(workspaceId, userId, dto): Promise<CampaignDto>`; `addCategory / updateCategory / removeCategory / setCategoryActive`; `addPost / updatePost / removePost`; `assembleEvergreen(campaignId)` returning the campaign + `categories[]` (each with `posts[]` + computed `nextRunAt` via Task 2 `computeNextCategoryFire`) + `upNext[]` (next N occurrences, from occurrences table once rotation exists — for now empty array). Return shape must extend the existing `CampaignDto`.
+
+- [ ] **Step 1: Write failing tests** with a fake DB (follow the `buildFakeDb` pattern in `campaigns.service.spec.ts` — a hand-rolled object matching the drizzle query chain used; **the fake's SELECT must return CLONES** `rows.map(r => ({...r}))` to avoid the in-place-mutation trap that masks stale-read bugs). Test: create campaign sets `type='evergreen'`; addCategory persists + returns assembled; addPost defaults `recyclePolicy` to `{mode:'forever'}` when omitted; removeCategory cascades (fake asserts posts deleted); `assembleEvergreen` computes each category's `nextRunAt`.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement `EvergreenService`.** Inject the Drizzle client and (for later) `CampaignPublishingService` + the fire queue (leave rotation methods as stubs marked for Task 6 — do NOT implement fire yet). CRUD writes to the three tables; `assembleEvergreen` reads categories+posts, computes `nextRunAt` per category via `computeNextCategoryFire`, returns `upNext: []` for now.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/evergreen.service.ts src/campaigns/evergreen.service.spec.ts
+git commit -m "feat(evergreen): service — category + pool CRUD + assemble"
+```
+
+---
+
+## Task 5: EvergreenController + module wiring (CRUD reachable)
+
+**Files:**
+- Create: `src/campaigns/evergreen.controller.ts`
+- Modify: `src/campaigns/campaigns.module.ts` (add `EvergreenService`, `EvergreenController`; controller list + providers)
+- Test: `src/campaigns/evergreen.controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `EvergreenService` (Task 4), DTOs (Task 3), `JwtAuthGuard`, the workspace-scoped route base `campaigns/workspaces/:workspaceId`.
+- Produces: routes from spec §5 (create, categories CRUD + active, posts CRUD). Variation/freshness routes are added in their own tasks (8, 9) — leave them out here.
+
+- [ ] **Step 1: Write failing controller test** — mock `EvergreenService`, assert each route delegates with the right args (e.g. `POST /:id/evergreen/categories` calls `service.addCategory(ws, id, dto)`).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement controller** mirroring `campaigns.controller.ts` (`@Controller('campaigns')`, `@UseGuards(JwtAuthGuard)`, `@Param`, `@Body`, workspace-scoped paths). Register in `campaigns.module.ts` providers + controllers.
+
+- [ ] **Step 4: Run to verify pass** + `nest build` to confirm module wiring compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/evergreen.controller.ts src/campaigns/evergreen.controller.spec.ts src/campaigns/campaigns.module.ts
+git commit -m "feat(evergreen): controller + module wiring (CRUD reachable)"
+```
+
+---
+
+## Task 6: Rotation engine — fire + per-fire re-enqueue + processor
+
+**Files:**
+- Create: `src/campaigns/processors/evergreen-fire.processor.ts`
+- Modify: `src/campaigns/evergreen.service.ts` (implement `fireOccurrence`, `enqueueNextFire`, `armCategory`), `campaigns.module.ts` (register the fire queue + processor)
+- Modify: `src/queue/queue.module.ts` (add `EVERGREEN_ROTATION = 'evergreen-rotation'` to `QUEUES`)
+- Test: `src/campaigns/evergreen-fire.spec.ts`
+
+**Interfaces:**
+- Consumes: `materializeAndEnqueue`, `cancelSlotJob` (from `CampaignPublishingService`), `computeNextCategoryFire`, `pickNextPost`, `selectVariation` (Task 2).
+- Produces:
+  - `armCategory(category, now): Promise<void>` — compute next fire, insert an `evergreenOccurrences` row (`slot_status='scheduled'`), enqueue a delayed `evergreen-rotation` job `{ occurrenceId }` with deterministic `jobId = evg-<occurrenceId>` and `delay = max(0, nextFire - now)`.
+  - `fireOccurrence(occurrenceId): Promise<void>` — load occurrence+category+eligible posts; `pickNextPost`; if null → mark occurrence `skipped`, still `armCategory` next; else `selectVariation`, build `ChannelDayContentJson` with the variation caption, call `materializeAndEnqueue` (scheduledAt=now, carry `destination`), write `postsRowId`/`jobId`, bump post (`recycledCount+1`, `lastPublishedAt=now`), then `armCategory` next. Wrap in try/finally so the next fire is ALWAYS armed even if publish throws (graceful — the chain must not die).
+  - The processor's `process(job)` calls `service.fireOccurrence(job.data.occurrenceId)`.
+
+- [ ] **Step 1: Write failing tests** (fake DB + mocked `CampaignPublishingService` + mocked queue). Assert: fire with an eligible post calls `materializeAndEnqueue` with the selected variation caption + destination, bumps the post, and arms the next fire (queue.add called with the next delay). Fire with NO eligible post marks occurrence `skipped` and STILL arms next. Fire where `materializeAndEnqueue` throws still arms next (chain self-heals). `armCategory` with no configured weekday inserts nothing / logs (null next-fire).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** the processor + the three service methods. Add `EVERGREEN_ROTATION` queue name; register `BullModule.registerQueue({ name: QUEUES.EVERGREEN_ROTATION })` and the processor in the module. Use deterministic `jobId` for idempotency.
+
+- [ ] **Step 4: Run to verify pass** + `nest build`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/processors/evergreen-fire.processor.ts src/campaigns/evergreen.service.ts src/campaigns/evergreen-fire.spec.ts src/campaigns/campaigns.module.ts src/queue/queue.module.ts
+git commit -m "feat(evergreen): rotation engine — fire + per-fire re-enqueue + processor"
+```
+
+---
+
+## Task 7: Lifecycle branches (launch / pause / resume) + reconcile cron
+
+**Files:**
+- Modify: `src/campaigns/campaigns.service.ts` (branch `launch/pause/resume/assembleCampaign/duplicate` to `EvergreenService` when `type==='evergreen'`)
+- Modify: `src/campaigns/evergreen.service.ts` (`launch`, `pause`, `resume`, `reconcile`)
+- Create: `src/campaigns/evergreen-reconcile.cron.ts` (one daily `@Cron` that re-arms active categories with no future scheduled occurrence)
+- Test: `src/campaigns/evergreen-lifecycle.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 6 `armCategory`; `cancelSlotJob`.
+- Produces: `EvergreenService.launch/pause/resume(workspaceId, id)`; `reconcile()` (idempotent; deterministic jobIds prevent double-fire). `CampaignsService` delegates when evergreen; bulk/drip path untouched (assert this in tests).
+
+- [ ] **Step 1: Write failing tests** — launch arms exactly one fire per active category (≥1 eligible post) and sets status `active`; launch with a category that has 0 eligible posts still launches but that category arms nothing (or arms and later skips — pick one, test it); pause cancels every future scheduled occurrence's job + deletes unpublished posts + status `paused`; resume re-arms; reconcile re-arms a category whose only occurrence is already `published` (dead chain) and is a no-op when a future `scheduled` occurrence exists. Add one test asserting `CampaignsService.launch` for a **bulk** campaign does NOT touch `EvergreenService` (regression guard).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement.** In `campaigns.service.ts`, add minimal `if (campaign.type === 'evergreen') return this.evergreen.<method>(...)` at the top of each lifecycle method (inject `EvergreenService` — watch for a circular dep: if `EvergreenService` already injects `CampaignsService`, use `forwardRef` or move the shared assemble into a helper; prefer having `EvergreenService` NOT depend on `CampaignsService`). Reconcile cron uses `@Cron(CronExpression.EVERY_DAY_AT_3AM)` scanning active evergreen campaigns.
+
+- [ ] **Step 4: Run to verify pass** + `nest build` (watch the cold-boot circular-dep — a prior effort hit this; verify the app module resolves).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/evergreen.service.ts src/campaigns/evergreen-reconcile.cron.ts src/campaigns/evergreen-lifecycle.spec.ts src/campaigns/campaigns.module.ts
+git commit -m "feat(evergreen): lifecycle branches + reconcile cron"
+```
+
+---
+
+## Task 8: D1 — AI variation generation endpoint
+
+**Files:**
+- Modify: `src/campaigns/evergreen.service.ts` (`generateVariations`, `addVariation`, `removeVariation`), `src/campaigns/evergreen.controller.ts` (3 routes), `src/campaigns/campaigns.module.ts` (import `AiModule`/inject `GroqService` + `AiTokenService`)
+- Test: `src/campaigns/evergreen-variations.spec.ts`
+
+**Interfaces:**
+- Consumes: `GroqService.generateVariations(content, platform, count?)`, `AiTokenService.executeWithTokens(workspaceId, userId, operation, platform, description, fn)` (metering — mirror how `ai.controller.ts` wraps it).
+- Produces: `generateVariations(ws, userId, postId, count?)` → appends `{id, caption, source:'ai'}[]`; `addVariation`/`removeVariation`.
+
+- [ ] **Step 1: Write failing tests** — mock `GroqService.generateVariations` → returns `['V1','V2']`; assert service appends two `source:'ai'` variations with unique ids; assert **graceful**: when `generateVariations` throws, the service surfaces a clean error and does NOT corrupt the post (no partial write).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** wrapped in `executeWithTokens`; platform derived from the post's first channel platform. Add routes `POST /:id/evergreen/posts/:postId/variations/generate`, `POST .../variations`, `DELETE .../variations/:variationId`.
+
+- [ ] **Step 4: Run to verify pass** + `nest build`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/evergreen.service.ts src/campaigns/evergreen.controller.ts src/campaigns/campaigns.module.ts src/campaigns/evergreen-variations.spec.ts
+git commit -m "feat(evergreen): D1 AI variation generation"
+```
+
+---
+
+## Task 9: D2 performance scoring + D3 freshness guard
+
+**Files:**
+- Create: `src/campaigns/evergreen-scoring.service.ts` (performance score task + freshness check)
+- Modify: `src/campaigns/evergreen.controller.ts` (add `POST /:id/evergreen/posts/:postId/freshness-check`), `campaigns.module.ts`
+- Test: `src/campaigns/evergreen-scoring.spec.ts`
+
+**Interfaces:**
+- Consumes: `post_metric_snapshots` reads (mirror `analytics.service` query pattern), `GroqService` (a cheap staleness prompt), the evergreen occurrences→posts link.
+- Produces: `recomputeScores(campaignId)` — for each active post, average normalized engagement across its occurrences' snapshots → `performanceScore` in [0,1]; posts with no snapshots stay `null`. `checkFreshness(postId)` — Groq returns `{ isStale, reason }`; write `is_stale`/`stale_reason`; on Groq error return `{isStale:false}` and do NOT flag (graceful). A `@Cron` (weekly) that calls `recomputeScores` for active evergreen campaigns.
+
+- [ ] **Step 1: Write failing tests** — scoring maps snapshot engagement to [0,1] and leaves unsnapshotted posts null; freshness sets flag from a mocked Groq `{isStale:true, reason:'mentions 2025'}`; freshness on Groq throw → `{isStale:false}`, no write. Assert scoring never throws on an empty snapshot set.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement.** Keep scoring off the fire hot-path (separate service/cron). Freshness on-demand via the route + optional cron.
+
+- [ ] **Step 4: Run to verify pass** + `nest build`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/campaigns/evergreen-scoring.service.ts src/campaigns/evergreen.controller.ts src/campaigns/campaigns.module.ts src/campaigns/evergreen-scoring.spec.ts
+git commit -m "feat(evergreen): D2 performance scoring + D3 freshness guard"
+```
+
+---
+
+## Task 10: Frontend types + API + hooks
+
+**Files:**
+- Create: `src/features/campaigns/types/evergreen.ts`, `src/features/campaigns/api/evergreen.api.ts`, `src/features/campaigns/hooks/use-evergreen.ts`, `src/features/campaigns/hooks/use-evergreen-mutations.ts`, `src/features/campaigns/utils/evergreen-colors.ts`
+- Test: `src/features/campaigns/utils/evergreen-colors.spec.ts`
+
+**Interfaces:**
+- Consumes: the assembled evergreen `Campaign` shape (§5) — mirror BE JSON types in TS.
+- Produces: TS types (`EvergreenCategory`, `EvergreenPost`, `EvergreenVariation`, `RecyclePolicy`, `EvergreenOccurrence`, `EvergreenCampaignAssembled` with `categories[]`+`upNext[]`); `evergreenApi` wrappers (mirror `campaigns.api.ts`); React Query hooks (settle-then-invalidate pattern from `use-campaign-event-mutations.ts` — `qc.setQueryData` then `invalidateQueries`); `evergreen-colors.ts` maps a color token → `ACCENT_CLASSES`-style class fragments.
+
+- [ ] **Step 1: Write failing test** for `evergreen-colors.ts` — `colorClasses('emerald')` returns the emerald token fragments; unknown color falls back to emerald.
+
+- [ ] **Step 2: Run to verify fail** — `npx vitest run src/features/campaigns/utils/evergreen-colors.spec.ts`.
+
+- [ ] **Step 3: Implement** types, api, hooks, colors. Types only; no components yet.
+
+- [ ] **Step 4: Run to verify pass** + `tsc -b` (type-check the new API/hooks compile against the query client).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/campaigns/types/evergreen.ts src/features/campaigns/api/evergreen.api.ts src/features/campaigns/hooks/use-evergreen.ts src/features/campaigns/hooks/use-evergreen-mutations.ts src/features/campaigns/utils/evergreen-colors.ts src/features/campaigns/utils/evergreen-colors.spec.ts
+git commit -m "feat(evergreen): FE types, api, hooks, color tokens"
+```
+
+---
+
+## Task 11: Frontend builder view — rail + Up-Next + post grid
+
+**Files:**
+- Create: `src/features/campaigns/components/evergreen/evergreen-builder-view.tsx`, `category-rail.tsx`, `up-next-strip.tsx`, `post-grid.tsx`, `evergreen-post-card.tsx`, `new-category-dialog.tsx`
+- Modify: the campaign builder router/routing to render `EvergreenBuilderView` when `campaign.type === 'evergreen'` (find where the bonzo builder is chosen — likely `campaign-builder-view.tsx` or the route)
+- Test: `src/features/campaigns/components/evergreen/up-next-strip.spec.tsx` (+ a smoke render test for the builder)
+
+**Interfaces:**
+- Consumes: Task 10 types/hooks; shadcn components (Card, Badge, Button, Dialog, DropdownMenu, Popover, Tabs if needed) — **install via shadcn MCP, don't hand-roll**; `evergreen-colors.ts`.
+- Produces: the category-first builder. Thin view file composing rail + strip + grid (Rule 1 — no god-file).
+
+- [ ] **Step 1: Confirm shadcn components** — use the shadcn MCP (`search`/`view`/`get_add_command`) for any primitive not already in `components/ui/`. Do NOT assume names.
+
+- [ ] **Step 2: Write failing test** — `up-next-strip.tsx` renders N upcoming occurrences with category color + time; empty `upNext` → "Add posts to start the rotation" empty state.
+
+- [ ] **Step 3: Run to verify fail.**
+
+- [ ] **Step 4: Implement** the components + wire routing. Each async surface: loading skeleton, empty CTA, error. Card badges: `✎ N variations`, `⚠ stale`, `📈`, `♻︎ N×`. Spacing per CLAUDE.md Rule 3.
+
+- [ ] **Step 5: Run to verify pass** + `tsc -b && vite build`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/campaigns/components/evergreen/ src/features/campaigns/components/builder/campaign-builder-view.tsx
+git commit -m "feat(evergreen): FE builder view — category rail + up-next + post grid"
+```
+
+---
+
+## Task 12: Frontend post editor + activate type-chooser
+
+**Files:**
+- Create: `src/features/campaigns/components/evergreen/evergreen-post-editor.tsx`, `variations-panel.tsx`, `recycle-policy-control.tsx`
+- Modify: `src/features/campaigns/components/create/new-campaign-type-chooser.tsx` (add `'evergreen'` to `ACTIVE_TYPES`), the create flow to POST `/evergreen` and open the evergreen builder
+- Test: `src/features/campaigns/components/evergreen/recycle-policy-control.spec.tsx`
+
+**Interfaces:**
+- Consumes: Task 10 hooks (add-post, generate-variations, freshness-check), the existing composer building blocks where the content shape matches.
+- Produces: post editor with Variations panel (list + "✨ Generate with AI" spinner-in-button + manual add + remove), Recycle policy control (forever / max N / until date + min-gap), Freshness row ("Check now" → flag + suggestion). Activates the type card.
+
+- [ ] **Step 1: Write failing test** — `recycle-policy-control.tsx`: selecting "max N" reveals a count input and emits `{mode:'maxCount', maxCount}`; "until date" reveals a date input.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** editor + panels; wire create flow; flip `ACTIVE_TYPES`. AI/freshness buttons show in-button spinners and never block on failure (toast on error).
+
+- [ ] **Step 4: Run to verify pass** + `tsc -b && vite build` + full `npx vitest run` (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/campaigns/components/evergreen/ src/features/campaigns/components/create/new-campaign-type-chooser.tsx
+git commit -m "feat(evergreen): FE post editor (variations, policy, freshness) + activate type card"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §3 data model → Task 1. §4 rotation → Tasks 2, 6, 7. §5 API → Tasks 3, 5, 8, 9. §6 FE/UX → Tasks 10, 11, 12. §7 reuse → enforced by Global Constraints + Task 6/7/8 reuse. §8 migrations → Task 1 Step 5 (generate, user applies). §9 testing → every task is TDD. §10 sequencing → task order matches. All covered.
+
+**2. Placeholder scan:** No TBD/TODO. Each code step has real code or a precise, testable description. The one deliberately-deferred item — `upNext: []` in Task 4 — is explicitly called out as filled by Task 6/rotation, not a placeholder.
+
+**3. Type consistency:** `ChannelDayContentJson`, `CampaignSlotStatus`, `CampaignScheduleEvergreenJson` used verbatim from the schema. `computeNextCategoryFire`/`pickNextPost`/`selectVariation` signatures defined in Task 2 and consumed unchanged in Tasks 6/7. `materializeAndEnqueue` input matches the Global Constraints signature. `EvergreenService` method names consistent across Tasks 4→12.
+
+**Known risks flagged for executors:** (a) circular dep between `CampaignsService` and `EvergreenService` (Task 7) — prefer one-directional dependency; a prior effort hit a cold-boot cycle. (b) fake-DB SELECT must clone rows (Task 4) — the in-place-mutation trap masked a real stale-read bug in a prior effort. (c) evergreen fires at `scheduledAt=now`, so the delayed job is effectively immediate — ensure `delay` clamps to `>=0`.

--- a/docs/superpowers/specs/2026-08-17-evergreen-recycling-design.md
+++ b/docs/superpowers/specs/2026-08-17-evergreen-recycling-design.md
@@ -1,0 +1,340 @@
+# Evergreen Recycling — Design Spec
+
+**Date:** 2026-08-17
+**Status:** Draft for review
+**Author:** brainstorming session (Claude + user)
+**Repos:** `socialmedia-workspace` (NestJS backend), `socialmedia-frontend` (Vite/React frontend)
+
+---
+
+## 1. Summary
+
+Evergreen Recycling is a new campaign **type** that auto-rotates a pool of timeless
+posts on a repeating schedule, **forever, until paused** — unlike Bulk (finite date
+range) and Drip (finite, bounded by `endDate`). Content is organized into
+**categories** (buckets), each with its own posting schedule and its own rotating
+queue. When a category's time-slot fires, the engine picks the next-due post from
+that category, publishes it (with a fresh AI-generated variation), and returns it to
+the back of the queue to be recycled again later.
+
+It is delivered as a **fourth mental model** in the campaigns module, reusing the
+existing publish path (BullMQ `post-publishing` queue, `materializeAndEnqueue`,
+`PostTarget.destination` for Slack/Discord) but introducing **new persistence and a
+new recurring-rotation engine** — because no existing engine re-fires after publish,
+and the date-keyed slot model does not fit a dateless rotating pool.
+
+### Four differentiators (all in v1)
+
+| # | Differentiator | Reuse | New work |
+|---|----------------|-------|----------|
+| D1 | **AI variations** — each recycle publishes a fresh text variation | `GroqService.generateVariations()` already exists | variation storage + rotation-time selection |
+| D2 | **Performance-aware recycling** — strong posts recycle more, weak auto-retire | `post_metric_snapshots` + `analytics.service` | a per-post performance score + weighting in the picker |
+| D3 | **Freshness / staleness guard** — flag stale posts ("2025…") before recycle | Groq LLM | a staleness check + a `stale` flag on the post |
+| D4 | **Messaging channels** — Slack/Discord in the rotation too | `PostTarget.destination` already carries chat destinations | none beyond wiring |
+
+Each differentiator **degrades gracefully**: AI down → publish the base post; no
+metrics yet → neutral weighting; staleness check fails → don't block, just don't
+flag. The rotation core never depends on any of them succeeding.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+- A category-based evergreen engine that recycles a post pool indefinitely.
+- Distinct, library+queue UX (not the calendar/day-slot builder).
+- All four differentiators, each graceful.
+- Reuse the campaigns publish path; keep Bulk/Drip byte-for-byte unchanged.
+- Messaging (Slack/Discord) channels supported alongside social platforms.
+
+### Non-goals (v1)
+- Cross-category rotation balancing / global smart-scheduler beyond per-category schedules.
+- A/B testing of variations with automated winner selection (D2 informs, doesn't auto-optimize copy).
+- Best-time-to-post AI slot suggestions.
+- Two-way sync of edits back into a shared media library (evergreen posts are their own pool; can reference library media but are authored in-place).
+- Importing an existing campaign's posts into an evergreen pool (manual add / library pick only).
+
+---
+
+## 3. Core concepts & data model
+
+Evergreen introduces **its own tables** rather than reusing `campaign_days` /
+`campaign_slot_content`, because those are keyed on a concrete `date` — evergreen
+posts are **dateless** pool members that fire on a repeating schedule. The parent
+`campaigns` row is still used (type `'evergreen'`, `status`, `channel_ids`,
+`platforms`, `schedule` jsonb) so evergreen shows up in the same list, status
+counts, and lifecycle actions.
+
+### 3.1 `campaign_evergreen_categories`
+
+A bucket with its own schedule and rotation cursor.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid PK | |
+| `campaign_id` | uuid NOT NULL → `campaigns.id` cascade | |
+| `name` | varchar(120) NOT NULL | "Tips", "Quotes" |
+| `color` | varchar(20) NOT NULL | one of a fixed token set (see §6.4) |
+| `schedule` | jsonb NOT NULL `$type<EvergreenCategoryScheduleJson>()` | `{ weekdays: number[]; times: string[] }` — per-category rhythm |
+| `channel_ids` | jsonb `$type<string[]>()` NOT NULL default `[]` | which of the campaign's channels this category posts to |
+| `seasonal` | jsonb `$type<{ startDate: string; endDate: string } \| null>()` default null | auto activate/deactivate window (D-seasonal) |
+| `is_active` | boolean NOT NULL default true | manual on/off, independent of seasonal |
+| `rotation_cursor` | integer NOT NULL default 0 | monotonic counter; picker uses it for round-robin fallback |
+| `sort_order` | integer NOT NULL default 0 | rail ordering |
+| `created_at` / `updated_at` | timestamptz | |
+
+Unique index: `(campaign_id, name)`.
+
+### 3.2 `campaign_evergreen_posts`
+
+A pool member. Belongs to exactly one category.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid PK | |
+| `campaign_id` | uuid NOT NULL → `campaigns.id` cascade | denormalized for scoping/queries |
+| `category_id` | uuid NOT NULL → `campaign_evergreen_categories.id` cascade | |
+| `content` | jsonb NOT NULL `$type<ChannelDayContentJson>()` | **reuses the existing slot content shape** — caption, media, poll, threadParts, templateIds, destination, platformSpecific. This is deliberate: the publish path already speaks this shape. |
+| `variations` | jsonb NOT NULL `$type<EvergreenVariationJson[]>()` default `[]` | D1 — `{ id; caption; media?: MediaJson[]; source: 'ai' \| 'manual' }[]` |
+| `recycle_policy` | jsonb NOT NULL `$type<RecyclePolicyJson>()` | `{ mode: 'forever' \| 'maxCount' \| 'expiry'; maxCount?: number; expiryDate?: string }` (SmarterQueue parity) |
+| `min_gap_hours` | integer NOT NULL default 0 | D — "minimum time to recycle": don't re-fire within N hours |
+| `recycled_count` | integer NOT NULL default 0 | how many times published |
+| `last_published_at` | timestamptz | for min-gap + rotation ordering |
+| `performance_score` | real | D2 — nullable; 0–1 computed from snapshots; null = unscored (neutral) |
+| `is_stale` | boolean NOT NULL default false | D3 — set by freshness guard |
+| `stale_reason` | text | e.g. `mentions "2025"` |
+| `status` | varchar(20) NOT NULL default `'active'` `$type<EvergreenPostStatus>()` | `'active' \| 'paused' \| 'retired'` — retired = removed from rotation, kept for history |
+| `created_at` / `updated_at` | timestamptz | |
+
+Indexes: `(category_id, status)`, `(campaign_id)`.
+
+`EvergreenPostStatus = ['active','paused','retired']`. A post is **eligible** for a
+fire when: `status='active'` AND category `is_active` (and within seasonal window) AND
+not expired by `recycle_policy` AND `min_gap_hours` satisfied.
+
+### 3.3 `campaign_evergreen_occurrences`
+
+An append-only log of each fire — the bridge to a real `posts` row, and the record
+the rotation driver reads to know "what fired and when."
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid PK | |
+| `campaign_id` | uuid NOT NULL → `campaigns.id` cascade | |
+| `category_id` | uuid NOT NULL → `campaign_evergreen_categories.id` cascade | |
+| `post_id_ref` | uuid NOT NULL → `campaign_evergreen_posts.id` cascade | which pool post fired |
+| `variation_id` | varchar(64) | which variation was used (null = base) |
+| `channel_id` | varchar(255) NOT NULL | |
+| `scheduled_at` | timestamptz NOT NULL | the fire instant |
+| `slot_status` | varchar(20) NOT NULL default `'scheduled'` `$type<CampaignSlotStatus>()` | **reuses `CAMPAIGN_SLOT_STATUSES`** |
+| `posts_row_id` | uuid | link to materialized `posts` row (not FK) |
+| `job_id` | varchar(160) | BullMQ job id |
+| `published_at` | timestamptz | |
+| `last_error` | text | |
+| `created_at` | timestamptz | |
+
+Indexes: `(campaign_id, scheduled_at desc)`, `(post_id_ref)`, `(job_id)`.
+
+### 3.4 Reused / unchanged
+- `campaigns` row (type `'evergreen'`), `CampaignScheduleEvergreenJson` (already exists: `weekdays`, `times`, `timezone`, `blackoutDates`, `loop`, `startDate`). The **campaign-level** schedule is the default; per-category schedules override which weekdays/times each bucket uses.
+- `posts` + `PostTarget` (with `destination`) — the materialized publish artifact.
+- `post_metric_snapshots` — read by D2.
+- BullMQ `post-publishing` queue + `PostPublishProcessor` — unchanged.
+
+---
+
+## 4. Rotation engine (the genuinely new part)
+
+No existing engine re-fires after publish, so evergreen needs a **recurring driver**.
+
+### 4.1 Approach: per-fire re-enqueue (chosen) vs cron sweep
+
+**Chosen: per-fire re-enqueue.** When an occurrence publishes, the engine immediately
+computes the category's **next** fire instant (next matching weekday+time ≥ now, in
+tz) and enqueues the next occurrence as a one-shot delayed job — same mechanism the
+rest of the campaigns engine already uses (`materializeAndEnqueue` style, one delayed
+job per fire, deterministic `jobId`). This keeps evergreen on the **existing
+`post-publishing` infrastructure** with zero new queue and no cron service.
+
+- **Why not a cron sweep:** a periodic sweep ("every 5 min, find categories due now")
+  introduces a new scheduled worker, double-fire risk on overlap, and clock drift. The
+  per-fire chain reuses BullMQ's delay precision and the existing processor.
+- **Cost:** the chain must be *self-healing* — if a fire fails or a job is lost, the
+  next fire won't be scheduled. Mitigation: **launch enqueues the first fire per
+  category**, and a lightweight **reconcile on campaign read/resume** re-arms any
+  category whose next occurrence is missing (idempotent via deterministic job id). A
+  safety **daily reconcile cron** (one, cheap, workspace-agnostic) re-arms any active
+  evergreen category with no future `scheduled` occurrence — belt-and-suspenders
+  against a broken chain. This is the one new scheduled job.
+
+### 4.2 The picker (what fires next)
+
+When a category's slot fires, `pickNextPost(categoryId, now)`:
+1. Load **eligible** posts (§3.2 eligibility).
+2. If none eligible → **skip** this fire (log occurrence `slot_status='skipped'`,
+   reason "no eligible posts"), still enqueue the next fire. Never crash, never leave
+   the chain dead.
+3. Rank eligible posts by a **recycle-priority score**:
+   - base: **least-recently-published first** (oldest `last_published_at`, nulls first) — the round-robin heart.
+   - D2 weighting: multiply priority by `(0.5 + performance_score)` when `performance_score` is non-null (strong posts surface sooner; weak ones sink). Null score = neutral (`× 1.0`). **Never** excludes a post solely on score — only `recycle_policy`/`status` retire.
+4. Pick the top post. Increment `rotation_cursor`.
+5. D1: choose a variation — rotate through `variations` by `recycled_count % (variations.length+1)` (0 = base caption, then each variation). Deterministic, so successive recycles visibly differ.
+6. D3: if `is_stale`, still publish (staleness never blocks), but the occurrence and the post card surface the flag; the freshness guard runs on a separate cadence (§4.4), not at fire time (keep fire fast).
+
+### 4.3 Fire → publish (reuses existing path)
+
+`fireOccurrence(occurrence)`:
+1. Resolve post + chosen variation → build a `ChannelDayContentJson` (caption swapped to the variation).
+2. Call the existing **`materializeAndEnqueue`**-equivalent to insert a `posts` row + enqueue `publish-post`. (Evergreen fires *immediately* on its own scheduled instant, so `scheduledAt = now`; the delayed job is effectively immediate.) Carry `destination` for messaging channels (D4).
+3. Write `posts_row_id` + `job_id` onto the occurrence.
+4. `bumpPost`: `recycled_count += 1`, `last_published_at = now`.
+5. **Enqueue the category's next fire** (§4.1) — the recurrence step.
+6. Occurrence `slot_status` tracks via the existing `CampaignStatusSyncListener` (published/failed), same as bulk/drip slots.
+
+### 4.4 Freshness guard (D3) & performance scoring (D2) cadence
+- **Performance score:** a scheduled job (reuse `channel-snapshots` cadence or a small periodic task) recomputes `performance_score` per evergreen post from its occurrences' `posts` → `post_metric_snapshots` (normalized engagement vs. the pool). Runs off the hot path.
+- **Freshness guard:** a low-frequency task (e.g. weekly, or on-demand from the UI "Check freshness" action) runs a cheap Groq check per active post; sets `is_stale`/`stale_reason`. Also offered as a **one-click per-post** action in the UI. Never auto-edits; only flags + suggests.
+
+### 4.5 Lifecycle
+- **launch**: validate ≥1 active category with ≥1 eligible post; enqueue first fire per active category; status → `active`.
+- **pause**: cancel all future `scheduled` occurrences' jobs (reuse `cancelSlotJob`), delete their not-yet-published `posts` rows; status → `paused`. Pool + categories untouched.
+- **resume**: re-arm first fire per active category; status → `active`.
+- Evergreen **never auto-completes** (it's forever). `completed` only via explicit archive (future) — v1 has no completed state for evergreen; pausing is the stop.
+
+---
+
+## 5. Backend API (extends campaigns controller, workspace-scoped)
+
+All under `campaigns/workspaces/:workspaceId/...`, `JwtAuthGuard`, return the
+assembled `CampaignDto` (or category/post sub-DTOs where noted). New DTOs in
+`dto/campaigns.dto.ts` (or a new `dto/evergreen.dto.ts`).
+
+**Create**
+- `POST /evergreen` → `CreateEvergreenCampaignDto { name; description?; startDate; timezone; channelIds; blackoutDates?; loop? }` → creates campaign (type evergreen), no categories yet. (`weekdays`/`times` live on categories, not the campaign default — but the campaign schedule keeps a sane default for `computeNextRun` display.)
+
+**Categories**
+- `POST /:id/evergreen/categories` → `{ name; color; schedule: { weekdays; times }; channelIds; seasonal? }`
+- `PATCH /:id/evergreen/categories/:catId` → partial
+- `DELETE /:id/evergreen/categories/:catId` (cascades pool posts; blocked/confirmed if it has posts)
+- `PATCH /:id/evergreen/categories/:catId/active` → `{ isActive }`
+
+**Pool posts**
+- `POST /:id/evergreen/categories/:catId/posts` → `{ content: ChannelDayContent; recyclePolicy?; minGapHours? }`
+- `PATCH /:id/evergreen/posts/:postId` → partial (content, policy, status)
+- `DELETE /:id/evergreen/posts/:postId`
+- `POST /:id/evergreen/posts/:postId/variations/generate` → D1, calls `GroqService.generateVariations` → appends AI variations
+- `POST /:id/evergreen/posts/:postId/variations` → manual add `{ caption; media? }`
+- `DELETE /:id/evergreen/posts/:postId/variations/:variationId`
+- `POST /:id/evergreen/posts/:postId/freshness-check` → D3 on-demand → `{ isStale; staleReason }`
+
+**Lifecycle**: reuse existing `POST /:id/{launch,pause,resume,duplicate}` (the service branches on `type==='evergreen'`).
+
+**Read**: the assembled `CampaignDto` for an evergreen campaign includes `categories[]`
+(each with its posts[] + computed `nextRunAt`) and an `upNext[]` array (the next N
+scheduled occurrences across categories, for the Up-Next strip).
+
+---
+
+## 6. Frontend (UX — the distinct part)
+
+New feature surface under `src/features/campaigns/` (same module, evergreen-specific
+components). The **type-chooser card already exists** (emerald / Recycle icon /
+"loops forever"); flipping it live = adding `'evergreen'` to `ACTIVE_TYPES` in
+`new-campaign-type-chooser.tsx` once built.
+
+### 6.1 Layout — Category-first + "Up Next" strip (approved)
+A dedicated evergreen builder view (NOT the 3-column day/slot bonzo builder):
+- **Top:** "Up Next" rotation strip — the next N occurrences (day/time · category · post preview), the live-autopilot signal that distinguishes evergreen from a calendar.
+- **Left rail:** categories (color dot + schedule chip + post count + seasonal badge + active toggle). `＋ New category`.
+- **Main:** selected category's post library as a **card grid**. Each card: caption preview + badges — `✎ N variations` (D1), `⚠ stale` (D3), `📈 top 10% / weak` (D2), `♻︎ recycled N×`. `＋ Add post`.
+
+### 6.2 Post editor
+Reuse the existing composer/event-composer building blocks where possible (same
+`ChannelDayContent` shape). Adds: a **Variations** panel (list + "✨ Generate with AI"
++ manual add), a **Recycle policy** control (forever / max N / until date + min-gap),
+and a **Freshness** row ("Check now" → flag + suggestion).
+
+### 6.3 States (per CLAUDE.md Rule 4)
+Every async surface: loading (skeleton cards / spinner-in-button), disabled, **empty**
+(no categories → "Create your first category" CTA; category with no posts → "Add
+evergreen posts" CTA; empty Up-Next → "Add posts to start the rotation"), **error**
+(toast + inline). AI generate / freshness-check show in-button spinners and never
+block the base flow on failure.
+
+### 6.4 Theming
+shadcn tokens only. Category colors from a **fixed token palette** (emerald/violet/
+sky/amber/rose/cyan — mapped to `bg-*-500/10` + `text-*-600 dark:text-*-400`, reusing
+the `ACCENT_CLASSES` pattern), never arbitrary hex. Evergreen accent stays emerald
+(matches the existing type card).
+
+### 6.5 FE data layer
+- `types/evergreen.ts` — `EvergreenCategory`, `EvergreenPost`, `EvergreenVariation`, `RecyclePolicy`, `EvergreenOccurrence`, extend `Campaign` assembled shape with `categories`/`upNext`.
+- `api/evergreen.api.ts` — typed wrappers for §5 endpoints (mirrors `campaigns.api.ts` style).
+- `hooks/` — `use-evergreen-categories`, `use-evergreen-posts`, `use-evergreen-mutations` (React Query v5; settle-then-invalidate pattern already established).
+
+---
+
+## 7. Reuse map (minimizes blast radius → "zero breakage")
+
+| Concern | Reused as-is | New |
+|---------|--------------|-----|
+| Publish a post | `materializeAndEnqueue`, `buildTargets`, `PostTarget.destination`, `post-publishing` queue, `PostPublishProcessor` | evergreen occurrence → materialize adapter |
+| Post→slot status sync | `CampaignStatusSyncListener` (extend to update occurrences by `posts.metadata`) | occurrence metadata tag |
+| Timezone / next-fire | `wallClockToUtc`, `zoneOffsetMinutes`, `computeNextRun` (already handles evergreen weekday+times) | `computeNextCategoryFire` (thin) |
+| AI variations | `GroqService.generateVariations`, `AiTokenService.executeWithTokens` | wiring only |
+| Metrics | `post_metric_snapshots`, `analytics.service` reads | performance-score task |
+| Campaign list / status / lifecycle | `CampaignsService.list/getOne/launch/pause/resume/duplicate` | evergreen branches inside these |
+| FE type-chooser, accent classes, composer | existing | evergreen builder view + editor panels |
+
+**Bulk/Drip:** untouched. Evergreen branches are additive (`if type==='evergreen'`);
+no shared code path is altered in a way that changes bulk/drip behavior. The
+`campaign_slot_content` / `campaign_days` tables are **not** used by evergreen, so no
+schema change to them.
+
+---
+
+## 8. Migrations
+Three new tables (§3.1–3.3) + their indexes + the two new status enums
+(`EvergreenPostStatus`). **Additive only** — no ALTER on existing tables. Generated
+via `npm run db:generate`; **the user applies** migrations (assistant never runs
+`db:*`).
+
+---
+
+## 9. Testing strategy
+- **Rotation picker** (`pickNextPost`): unit tests — round-robin ordering, min-gap exclusion, expiry/maxCount retire, empty-eligible → skip-not-crash, D2 weighting monotonicity, D2 null-score neutrality.
+- **Recurrence chain**: fire → next-fire enqueued at correct tz instant; failed fire still re-arms; reconcile re-arms a dead chain (idempotent, no double-fire).
+- **Variation selection**: successive recycles cycle base→var1→var2→base.
+- **Eligibility**: seasonal window, category inactive, post paused/retired.
+- **Lifecycle**: launch arms one fire/category; pause cancels + deletes unpublished; resume re-arms.
+- **Graceful degradation**: AI down → base caption publishes; no snapshots → neutral score; freshness error → not flagged, not blocked.
+- **FE**: category/post/variation hooks; Up-Next rendering; empty/loading/error states; type-chooser activation.
+- **Gates**: BE `nest build` + campaigns spec suite green; FE `tsc -b && vite build` + vitest green. Bulk/drip regression tests unchanged and passing.
+
+---
+
+## 10. Sequencing (informs the plan, not the plan itself)
+1. Schema + migrations (3 tables, enums) — additive.
+2. Categories + pool CRUD (service + controller + DTOs) — no rotation yet.
+3. Rotation engine: picker + fire + per-fire re-enqueue + launch/pause/resume branches + reconcile cron.
+4. D1 variations (generate + rotate at fire).
+5. D4 messaging destinations in fire path (mostly free via `destination`).
+6. D2 performance score task + picker weighting.
+7. D3 freshness guard task + on-demand + flags.
+8. FE: types + api + hooks.
+9. FE: evergreen builder view (category rail + Up-Next + post grid).
+10. FE: post editor (variations, policy, freshness) + empty/error states.
+11. FE: activate type-chooser card.
+12. Whole-branch review + build/test gates both repos.
+
+Each of 1–11 is independently testable; 4–7 (differentiators) each degrade
+gracefully so a partial merge is never broken.
+
+---
+
+## 11. Open questions resolved during brainstorming
+- **Core model:** category-based buckets (not flat pool). ✅
+- **v1 scope:** all four differentiators. ✅
+- **BE approach:** extend the campaign engine (new tables + branches, reuse publish path). ✅
+- **UX:** category-first + Up-Next strip. ✅
+- **Recurrence:** per-fire re-enqueue + reconcile (one safety cron), reusing `post-publishing`. ✅ (design decision, not user-facing)

--- a/drizzle/manual/2026-08-18-evergreen-recycling-tables.sql
+++ b/drizzle/manual/2026-08-18-evergreen-recycling-tables.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- Evergreen Recycling — manual migration (run on Railway prod psql console)
+-- ----------------------------------------------------------------------------
+-- WHY MANUAL: this repo's drizzle migration journal has pre-existing drift
+-- (0024_admin_login_challenges.sql is on disk with no journal entry), so
+-- `npm run db:generate` produces a bloated migration that re-creates ~15
+-- existing tables without IF NOT EXISTS. Per repo precedent (commit 2cf7946),
+-- evergreen's 3 tables are applied by hand-written idempotent SQL instead.
+--
+-- SAFE TO RE-RUN: every statement is IF NOT EXISTS / guarded, so running this
+-- twice does nothing the second time — no data loss, no errors on re-run.
+--
+-- HOW TO RUN (Railway):
+--   Railway dashboard → your Postgres service → "Connect" / "Data" → open a
+--   psql console (bash → `psql $DATABASE_URL`, db = railway), then paste this
+--   whole file and press Enter. Wrapped in a transaction so it's all-or-nothing.
+--
+-- Mirrors src/drizzle/schema/evergreen.schema.ts exactly (types, defaults,
+-- NOT NULLs, FKs with ON DELETE CASCADE, unique + secondary indexes).
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1. campaign_evergreen_categories — a bucket with its own schedule + rotation
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS campaign_evergreen_categories (
+  id               uuid           PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id      uuid           NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  name             varchar(120)   NOT NULL,
+  color            varchar(20)    NOT NULL,
+  schedule         jsonb          NOT NULL,
+  channel_ids      jsonb          NOT NULL DEFAULT '[]'::jsonb,
+  seasonal         jsonb,
+  is_active        boolean        NOT NULL DEFAULT true,
+  rotation_cursor  integer        NOT NULL DEFAULT 0,
+  sort_order       integer        NOT NULL DEFAULT 0,
+  created_at       timestamptz    NOT NULL DEFAULT now(),
+  updated_at       timestamptz    NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS evergreen_categories_campaign_name_uq
+  ON campaign_evergreen_categories (campaign_id, name);
+
+-- ----------------------------------------------------------------------------
+-- 2. campaign_evergreen_posts — a pool member (belongs to one category)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS campaign_evergreen_posts (
+  id                 uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id        uuid          NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  category_id        uuid          NOT NULL REFERENCES campaign_evergreen_categories(id) ON DELETE CASCADE,
+  content            jsonb         NOT NULL,
+  variations         jsonb         NOT NULL DEFAULT '[]'::jsonb,
+  recycle_policy     jsonb         NOT NULL,
+  min_gap_hours      integer       NOT NULL DEFAULT 0,
+  recycled_count     integer       NOT NULL DEFAULT 0,
+  last_published_at  timestamptz,
+  performance_score  real,
+  is_stale           boolean       NOT NULL DEFAULT false,
+  stale_reason       text,
+  status             varchar(20)   NOT NULL DEFAULT 'active',
+  created_at         timestamptz   NOT NULL DEFAULT now(),
+  updated_at         timestamptz   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS evergreen_posts_category_status_idx
+  ON campaign_evergreen_posts (category_id, status);
+CREATE INDEX IF NOT EXISTS evergreen_posts_campaign_idx
+  ON campaign_evergreen_posts (campaign_id);
+
+-- ----------------------------------------------------------------------------
+-- 3. campaign_evergreen_occurrences — append-only fire log → real posts row
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS campaign_evergreen_occurrences (
+  id             uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id    uuid          NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  category_id    uuid          NOT NULL REFERENCES campaign_evergreen_categories(id) ON DELETE CASCADE,
+  post_id_ref    uuid          NOT NULL REFERENCES campaign_evergreen_posts(id) ON DELETE CASCADE,
+  variation_id   varchar(64),
+  channel_id     varchar(255)  NOT NULL,
+  scheduled_at   timestamptz   NOT NULL,
+  slot_status    varchar(20)   NOT NULL DEFAULT 'scheduled',
+  posts_row_id   uuid,
+  job_id         varchar(160),
+  published_at   timestamptz,
+  last_error     text,
+  created_at     timestamptz   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS evergreen_occurrences_campaign_scheduled_idx
+  ON campaign_evergreen_occurrences (campaign_id, scheduled_at);
+CREATE INDEX IF NOT EXISTS evergreen_occurrences_post_ref_idx
+  ON campaign_evergreen_occurrences (post_id_ref);
+CREATE INDEX IF NOT EXISTS evergreen_occurrences_job_idx
+  ON campaign_evergreen_occurrences (job_id);
+
+COMMIT;
+
+-- ============================================================================
+-- Verify (optional) — after COMMIT, run this to confirm all 3 tables exist:
+--
+--   SELECT table_name
+--   FROM information_schema.tables
+--   WHERE table_name LIKE 'campaign_evergreen_%'
+--   ORDER BY table_name;
+--
+-- Expect 3 rows:
+--   campaign_evergreen_categories
+--   campaign_evergreen_occurrences
+--   campaign_evergreen_posts
+-- ============================================================================

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -503,6 +503,55 @@ Provide ${count} variations, numbered 1 through ${count}. Each should be complet
   }
 
   /**
+   * Cheap staleness check for evergreen recycled content: asks whether the
+   * caption is time-bound (mentions a specific past year, a since-passed
+   * event/promo, "this weekend", etc.) and therefore unsuitable to keep
+   * recycling as-is. Small token budget, low temperature (deterministic-ish
+   * judgment call, not creative writing). Parses defensively — any
+   * unexpected/non-JSON response is treated as "not stale" rather than
+   * thrown, so a flaky model response never wrongly flags a post (the
+   * caller additionally wraps this in try/catch for the same reason).
+   */
+  async checkFreshness(
+    caption: string,
+  ): Promise<{ isStale: boolean; reason: string | null }> {
+    const system =
+      'You check social media post captions for staleness. A caption is ' +
+      'stale if it mentions a specific past year/date, an expired ' +
+      'promotion or discount code, a one-time event that has already ' +
+      'passed, or other time-bound wording that would read as outdated if ' +
+      'republished today. Reply with ONLY a single-line JSON object: ' +
+      '{"isStale": boolean, "reason": string|null}. "reason" is a short ' +
+      'phrase (e.g. "mentions 2025") when isStale is true, otherwise null. ' +
+      'No markdown, no code fences, no extra text.';
+    const user = `Caption:\n"""${caption.slice(0, 500)}"""`;
+
+    const raw = await this.generateCompletion(system, user, {
+      temperature: 0.2,
+      maxTokens: 100,
+    });
+
+    try {
+      const cleaned = raw
+        .trim()
+        .replace(/^```(?:json)?/i, '')
+        .replace(/```$/, '')
+        .trim();
+      const parsed = JSON.parse(cleaned) as {
+        isStale?: unknown;
+        reason?: unknown;
+      };
+      const isStale = parsed.isStale === true;
+      const reason =
+        isStale && typeof parsed.reason === 'string' ? parsed.reason : null;
+      return { isStale, reason };
+    } catch (error) {
+      this.logger.warn(`checkFreshness: failed to parse Groq response: ${error}`);
+      return { isStale: false, reason: null };
+    }
+  }
+
+  /**
    * Analyze a post for improvements
    */
   async analyzePost(

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -5,6 +5,7 @@ import { EvergreenController } from './evergreen.controller';
 import { CampaignsService } from './campaigns.service';
 import { EvergreenService } from './evergreen.service';
 import { CampaignPublishingService } from './campaign-publishing.service';
+import { EvergreenFireProcessor } from './processors/evergreen-fire.processor';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { PostsModule } from '../posts/posts.module';
 import { QUEUES } from '../queue/queue.module';
@@ -12,11 +13,19 @@ import { QUEUES } from '../queue/queue.module';
 @Module({
   imports: [
     DrizzleModule,
-    BullModule.registerQueue({ name: QUEUES.POST_PUBLISHING }),
+    BullModule.registerQueue(
+      { name: QUEUES.POST_PUBLISHING },
+      { name: QUEUES.EVERGREEN_ROTATION },
+    ),
     PostsModule,
   ],
   controllers: [CampaignsController, EvergreenController],
-  providers: [CampaignsService, CampaignPublishingService, EvergreenService],
+  providers: [
+    CampaignsService,
+    CampaignPublishingService,
+    EvergreenService,
+    EvergreenFireProcessor,
+  ],
   exports: [CampaignsService],
 })
 export class CampaignsModule {}

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { CampaignsController } from './campaigns.controller';
+import { EvergreenController } from './evergreen.controller';
 import { CampaignsService } from './campaigns.service';
+import { EvergreenService } from './evergreen.service';
 import { CampaignPublishingService } from './campaign-publishing.service';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { PostsModule } from '../posts/posts.module';
@@ -13,8 +15,8 @@ import { QUEUES } from '../queue/queue.module';
     BullModule.registerQueue({ name: QUEUES.POST_PUBLISHING }),
     PostsModule,
   ],
-  controllers: [CampaignsController],
-  providers: [CampaignsService, CampaignPublishingService],
+  controllers: [CampaignsController, EvergreenController],
+  providers: [CampaignsService, CampaignPublishingService, EvergreenService],
   exports: [CampaignsService],
 })
 export class CampaignsModule {}

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -9,6 +9,7 @@ import { EvergreenFireProcessor } from './processors/evergreen-fire.processor';
 import { EvergreenReconcileCron } from './evergreen-reconcile.cron';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { PostsModule } from '../posts/posts.module';
+import { AiModule } from '../ai/ai.module';
 import { QUEUES } from '../queue/queue.module';
 
 @Module({
@@ -19,6 +20,7 @@ import { QUEUES } from '../queue/queue.module';
       { name: QUEUES.EVERGREEN_ROTATION },
     ),
     PostsModule,
+    AiModule,
   ],
   controllers: [CampaignsController, EvergreenController],
   providers: [

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -6,6 +6,7 @@ import { CampaignsService } from './campaigns.service';
 import { EvergreenService } from './evergreen.service';
 import { CampaignPublishingService } from './campaign-publishing.service';
 import { EvergreenFireProcessor } from './processors/evergreen-fire.processor';
+import { EvergreenReconcileCron } from './evergreen-reconcile.cron';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { PostsModule } from '../posts/posts.module';
 import { QUEUES } from '../queue/queue.module';
@@ -25,6 +26,7 @@ import { QUEUES } from '../queue/queue.module';
     CampaignPublishingService,
     EvergreenService,
     EvergreenFireProcessor,
+    EvergreenReconcileCron,
   ],
   exports: [CampaignsService],
 })

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -4,6 +4,7 @@ import { CampaignsController } from './campaigns.controller';
 import { EvergreenController } from './evergreen.controller';
 import { CampaignsService } from './campaigns.service';
 import { EvergreenService } from './evergreen.service';
+import { EvergreenScoringService } from './evergreen-scoring.service';
 import { CampaignPublishingService } from './campaign-publishing.service';
 import { EvergreenFireProcessor } from './processors/evergreen-fire.processor';
 import { EvergreenReconcileCron } from './evergreen-reconcile.cron';
@@ -27,6 +28,7 @@ import { QUEUES } from '../queue/queue.module';
     CampaignsService,
     CampaignPublishingService,
     EvergreenService,
+    EvergreenScoringService,
     EvergreenFireProcessor,
     EvergreenReconcileCron,
   ],

--- a/src/campaigns/campaigns.service.spec.ts
+++ b/src/campaigns/campaigns.service.spec.ts
@@ -500,6 +500,7 @@ describe('CampaignsService write methods (mocked db)', () => {
   function loadServiceWithFakeDb(
     fakeDb: unknown,
     publishing?: unknown,
+    evergreen?: unknown,
   ): InstanceType<typeof CampaignsService> {
     let ServiceCtor!: typeof CampaignsService;
     jest.isolateModules(() => {
@@ -507,7 +508,7 @@ describe('CampaignsService write methods (mocked db)', () => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       ServiceCtor = require('./campaigns.service').CampaignsService;
     });
-    return new ServiceCtor(publishing as never);
+    return new ServiceCtor(publishing as never, evergreen as never);
   }
 
   afterEach(() => {
@@ -700,6 +701,64 @@ describe('CampaignsService write methods (mocked db)', () => {
     expect(channelContent['42@09:00'].time).toBe('09:00');
     expect(channelContent['42@17:00'].caption).toBe('Evening post');
     expect(channelContent['42@17:00'].time).toBe('17:00');
+  });
+
+  // FIX 1 (C2/M1): getOne must branch on type === 'evergreen' and delegate
+  // to EvergreenService.assembleEvergreen instead of unconditionally calling
+  // the bulk/drip assembleFromRow — otherwise an evergreen campaign's GET
+  // returns a bulk-shaped DTO with no categories[]/upNext[].
+  it('getOne delegates to evergreen.assembleEvergreen for an evergreen campaign', async () => {
+    const campaignRow = makeCampaignRow({ type: 'evergreen' });
+
+    const service = loadServiceWithFakeDb(
+      {
+        select: () => ({
+          from: () => ({
+            where: () => Promise.resolve([campaignRow]),
+          }),
+        }),
+      },
+      undefined,
+      {
+        assembleEvergreen: jest.fn().mockResolvedValue({
+          id: CAMPAIGN_ID,
+          categories: [{ id: 'cat-1' }],
+          upNext: [],
+        }),
+      },
+    );
+
+    const dto = await service.getOne(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(
+      (service as any).evergreen.assembleEvergreen,
+    ).toHaveBeenCalledWith(CAMPAIGN_ID);
+    expect((dto as any).categories).toBeDefined();
+    expect((dto as any).categories).toEqual([{ id: 'cat-1' }]);
+  });
+
+  it('getOne still returns the bulk shape for a non-evergreen campaign (regression)', async () => {
+    const campaignRow = makeCampaignRow({ type: 'bulk' });
+    const selectResults = [[campaignRow], [], []];
+    let selectCall = 0;
+
+    const service = loadServiceWithFakeDb(
+      {
+        select: () => ({
+          from: () => ({
+            where: () => Promise.resolve(selectResults[selectCall++] ?? []),
+          }),
+        }),
+      },
+      undefined,
+      { assembleEvergreen: jest.fn() },
+    );
+
+    const dto = await service.getOne(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect((service as any).evergreen.assembleEvergreen).not.toHaveBeenCalled();
+    expect(dto.slotContent).toBeDefined();
+    expect((dto as any).categories).toBeUndefined();
   });
 
   it('duplicate resets status to draft on the copy even when the source is active', async () => {

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -22,6 +22,7 @@ import { socialMediaChannels } from '../drizzle/schema/channels.schema';
 import { posts } from '../drizzle/schema/posts.schema';
 import { computeSlotSchedule } from './campaign-schedule.util';
 import { CampaignPublishingService } from './campaign-publishing.service';
+import { EvergreenService, type EvergreenCampaignDto } from './evergreen.service';
 
 // ==========================================================================
 // Response DTO — mirrors the frontend `Campaign` shape byte-for-byte so the
@@ -172,7 +173,10 @@ const MAX_NEXT_RUN_SCAN_DAYS = 3660; // ~10 years
 export class CampaignsService {
   private readonly logger = new Logger(CampaignsService.name);
 
-  constructor(private readonly publishing: CampaignPublishingService) {}
+  constructor(
+    private readonly publishing: CampaignPublishingService,
+    private readonly evergreen: EvergreenService,
+  ) {}
 
   // ==========================================================================
   // Pure helpers — no DB access. Exported as instance methods so they're
@@ -894,8 +898,19 @@ export class CampaignsService {
    * Sets the campaign to `active` with `launchedAt` once all slots are
    * processed.
    */
-  async launch(workspaceId: string, id: string): Promise<CampaignDto> {
+  async launch(
+    workspaceId: string,
+    id: string,
+  ): Promise<CampaignDto | EvergreenCampaignDto> {
     const campaign = await this.getOne(workspaceId, id); // 404 if wrong workspace
+
+    // Evergreen campaigns have a wholly different lifecycle model (category
+    // rotation arming, not day/slot materialization) — delegate to
+    // EvergreenService and return immediately so the bulk/drip logic below
+    // is byte-for-byte unchanged for type !== 'evergreen'.
+    if (campaign.type === 'evergreen') {
+      return this.evergreen.launch(workspaceId, id);
+    }
 
     // Idempotency guard: a campaign that's already active must not be
     // relaunched (double-click, retry, launch->pause->launch race) — that
@@ -1023,8 +1038,15 @@ export class CampaignsService {
    * `published`/`publishing`/`failed`/`skipped` slots are left untouched —
    * pause only pulls back work that hasn't fired yet.
    */
-  async pause(workspaceId: string, id: string): Promise<CampaignDto> {
-    await this.getOne(workspaceId, id); // 404 if wrong workspace
+  async pause(
+    workspaceId: string,
+    id: string,
+  ): Promise<CampaignDto | EvergreenCampaignDto> {
+    const campaign = await this.getOne(workspaceId, id); // 404 if wrong workspace
+
+    if (campaign.type === 'evergreen') {
+      return this.evergreen.pause(workspaceId, id);
+    }
 
     const slots = await db
       .select()
@@ -1070,8 +1092,16 @@ export class CampaignsService {
    * whose channel no longer resolves are left `pending` (same skip behaviour
    * as `launch`) rather than blocking the whole resume.
    */
-  async resume(workspaceId: string, id: string): Promise<CampaignDto> {
+  async resume(
+    workspaceId: string,
+    id: string,
+  ): Promise<CampaignDto | EvergreenCampaignDto> {
     const campaign = await this.getOne(workspaceId, id); // 404 if wrong workspace
+
+    if (campaign.type === 'evergreen') {
+      return this.evergreen.resume(workspaceId, id);
+    }
+
     const createdById = await this.loadCreatedById(id);
 
     const [days, pendingSlots] = await Promise.all([

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -600,6 +600,17 @@ export class CampaignsService {
       throw new NotFoundException('Campaign not found');
     }
 
+    // FIX (C2/M1): evergreen campaigns don't use campaignDays/
+    // campaignSlotContent at all — assembleFromRow (the bulk/drip
+    // assembler) would silently return a DTO with no categories[]/
+    // upNext[]. Delegate to EvergreenService's own assembler, which knows
+    // how to load categories + pool posts. `list()` intentionally does NOT
+    // do this per-row (perf — the list view doesn't need the full pool),
+    // only this single-campaign read does.
+    if (row.type === 'evergreen') {
+      return this.evergreen.assembleEvergreen(id) as unknown as Promise<CampaignDto>;
+    }
+
     return this.assembleFromRow(row);
   }
 

--- a/src/campaigns/dto/evergreen.dto.spec.ts
+++ b/src/campaigns/dto/evergreen.dto.spec.ts
@@ -1,0 +1,104 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import {
+  CreateEvergreenCategoryDto,
+  CreateEvergreenCampaignDto,
+  RecyclePolicyDto,
+} from './evergreen.dto';
+
+describe('CreateEvergreenCategoryDto', () => {
+  it('accepts a valid category', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: 'Tips',
+      color: 'emerald',
+      schedule: { weekdays: [1, 3], times: ['09:00'] },
+      channelIds: ['12'],
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('rejects an empty name', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: '',
+      color: 'emerald',
+      schedule: { weekdays: [1], times: ['09:00'] },
+      channelIds: [],
+    });
+    expect((await validate(dto)).length).toBeGreaterThan(0);
+  });
+
+  it('rejects an invalid color', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: 'Tips',
+      color: 'magenta',
+      schedule: { weekdays: [1], times: ['09:00'] },
+      channelIds: ['12'],
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.property === 'color')).toBe(true);
+  });
+
+  it('rejects an invalid weekday and time format in schedule', async () => {
+    const dto = plainToInstance(CreateEvergreenCategoryDto, {
+      name: 'Tips',
+      color: 'emerald',
+      schedule: { weekdays: [7], times: ['9am'] },
+      channelIds: ['12'],
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('CreateEvergreenCampaignDto', () => {
+  it('requires name, startDate, timezone', async () => {
+    const dto = plainToInstance(CreateEvergreenCampaignDto, {
+      name: 'X',
+      startDate: '2026-08-20',
+      timezone: 'UTC',
+      channelIds: ['1'],
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('rejects a missing startDate', async () => {
+    const dto = plainToInstance(CreateEvergreenCampaignDto, {
+      name: 'X',
+      timezone: 'UTC',
+      channelIds: ['1'],
+    });
+    expect((await validate(dto)).length).toBeGreaterThan(0);
+  });
+});
+
+describe('RecyclePolicyDto', () => {
+  it('accepts mode=forever with no maxCount/expiryDate', async () => {
+    const dto = plainToInstance(RecyclePolicyDto, { mode: 'forever' });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('accepts mode=maxCount with a valid maxCount', async () => {
+    const dto = plainToInstance(RecyclePolicyDto, { mode: 'maxCount', maxCount: 5 });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('accepts mode=expiry with a valid expiryDate', async () => {
+    const dto = plainToInstance(RecyclePolicyDto, { mode: 'expiry', expiryDate: '2026-12-31' });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('rejects an invalid mode', async () => {
+    const dto = plainToInstance(RecyclePolicyDto, { mode: 'never' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.property === 'mode')).toBe(true);
+  });
+
+  it('rejects a maxCount below 1', async () => {
+    const dto = plainToInstance(RecyclePolicyDto, { mode: 'maxCount', maxCount: 0 });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/campaigns/dto/evergreen.dto.ts
+++ b/src/campaigns/dto/evergreen.dto.ts
@@ -211,3 +211,11 @@ export class AddVariationDto {
   @Type(() => EvergreenVariationMediaDto)
   media?: EvergreenVariationMediaDto[];
 }
+
+export class GenerateVariationsDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(6)
+  count?: number;
+}

--- a/src/campaigns/dto/evergreen.dto.ts
+++ b/src/campaigns/dto/evergreen.dto.ts
@@ -1,0 +1,213 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsObject,
+  IsIn,
+  IsInt,
+  Min,
+  Max,
+  Matches,
+  ArrayNotEmpty,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import type { ChannelDayContentJson } from '../../drizzle/schema/campaigns.schema';
+
+const EVERGREEN_CATEGORY_COLORS = ['emerald', 'violet', 'sky', 'amber', 'rose', 'cyan'] as const;
+const RECYCLE_POLICY_MODES = ['forever', 'maxCount', 'expiry'] as const;
+
+// =============================================================================
+// Shared nested DTOs
+// =============================================================================
+
+export class CategoryScheduleDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  @Max(6, { each: true })
+  weekdays: number[]; // 0=Sun … 6=Sat
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @Matches(/^\d{2}:\d{2}$/, { each: true, message: 'each time must be HH:mm' })
+  times: string[];
+}
+
+export class RecyclePolicyDto {
+  @IsIn(RECYCLE_POLICY_MODES)
+  mode: 'forever' | 'maxCount' | 'expiry';
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxCount?: number;
+
+  @IsOptional()
+  @IsDateString()
+  expiryDate?: string; // yyyy-MM-dd
+}
+
+export class EvergreenSeasonalDto {
+  @IsDateString()
+  startDate: string; // yyyy-MM-dd
+
+  @IsDateString()
+  endDate: string; // yyyy-MM-dd
+}
+
+class EvergreenVariationMediaDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  filename: string;
+
+  @IsIn(['image', 'video'])
+  kind: 'image' | 'video';
+
+  @IsOptional()
+  @IsString()
+  url?: string;
+}
+
+// =============================================================================
+// Campaign DTOs
+// =============================================================================
+
+export class CreateEvergreenCampaignDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsDateString()
+  startDate: string; // yyyy-MM-dd
+
+  @IsString()
+  timezone: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  channelIds: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  blackoutDates?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  loop?: boolean;
+}
+
+// =============================================================================
+// Category DTOs
+// =============================================================================
+
+export class CreateEvergreenCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsIn(EVERGREEN_CATEGORY_COLORS)
+  color: (typeof EVERGREEN_CATEGORY_COLORS)[number];
+
+  @ValidateNested()
+  @Type(() => CategoryScheduleDto)
+  schedule: CategoryScheduleDto;
+
+  @IsArray()
+  @IsString({ each: true })
+  channelIds: string[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => EvergreenSeasonalDto)
+  seasonal?: EvergreenSeasonalDto;
+}
+
+export class UpdateEvergreenCategoryDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @IsOptional()
+  @IsIn(EVERGREEN_CATEGORY_COLORS)
+  color?: (typeof EVERGREEN_CATEGORY_COLORS)[number];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CategoryScheduleDto)
+  schedule?: CategoryScheduleDto;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  channelIds?: string[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => EvergreenSeasonalDto)
+  seasonal?: EvergreenSeasonalDto;
+}
+
+export class SetCategoryActiveDto {
+  @IsBoolean()
+  isActive: boolean;
+}
+
+// =============================================================================
+// Post DTOs
+// =============================================================================
+
+export class CreateEvergreenPostDto {
+  @IsObject()
+  content: ChannelDayContentJson;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => RecyclePolicyDto)
+  recyclePolicy?: RecyclePolicyDto;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  minGapHours?: number;
+}
+
+export class UpdateEvergreenPostDto {
+  @IsOptional()
+  @IsObject()
+  content?: ChannelDayContentJson;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => RecyclePolicyDto)
+  recyclePolicy?: RecyclePolicyDto;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  minGapHours?: number;
+}
+
+export class AddVariationDto {
+  @IsString()
+  @IsNotEmpty()
+  caption: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => EvergreenVariationMediaDto)
+  media?: EvergreenVariationMediaDto[];
+}

--- a/src/campaigns/evergreen-lifecycle.spec.ts
+++ b/src/campaigns/evergreen-lifecycle.spec.ts
@@ -998,6 +998,14 @@ describe('CampaignsService lifecycle delegation to EvergreenService', () => {
       launch: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'active' }),
       pause: jest.fn(),
       resume: jest.fn(),
+      // getOne (called before the launch/pause/resume delegation below)
+      // now branches evergreen campaigns through assembleEvergreen — see
+      // FIX 1 (C2/M1).
+      assembleEvergreen: jest.fn().mockResolvedValue({
+        id: CAMPAIGN_ID,
+        type: 'evergreen',
+        status: 'draft',
+      }),
     };
     const service = loadCampaignsServiceWithFakeDb(
       db,
@@ -1018,6 +1026,11 @@ describe('CampaignsService lifecycle delegation to EvergreenService', () => {
       launch: jest.fn(),
       pause: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'paused' }),
       resume: jest.fn(),
+      assembleEvergreen: jest.fn().mockResolvedValue({
+        id: CAMPAIGN_ID,
+        type: 'evergreen',
+        status: 'active',
+      }),
     };
     const service = loadCampaignsServiceWithFakeDb(
       db,
@@ -1038,6 +1051,11 @@ describe('CampaignsService lifecycle delegation to EvergreenService', () => {
       launch: jest.fn(),
       pause: jest.fn(),
       resume: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'active' }),
+      assembleEvergreen: jest.fn().mockResolvedValue({
+        id: CAMPAIGN_ID,
+        type: 'evergreen',
+        status: 'paused',
+      }),
     };
     const service = loadCampaignsServiceWithFakeDb(
       db,

--- a/src/campaigns/evergreen-lifecycle.spec.ts
+++ b/src/campaigns/evergreen-lifecycle.spec.ts
@@ -1,0 +1,1117 @@
+import { getTableName } from 'drizzle-orm';
+import type { EvergreenService } from './evergreen.service';
+import type { CampaignsService } from './campaigns.service';
+import type {
+  EvergreenCategory,
+  EvergreenOccurrence,
+  EvergreenPost,
+} from '../drizzle/schema/evergreen.schema';
+import type { Campaign } from '../drizzle/schema/campaigns.schema';
+
+// ==========================================================================
+// Fake-DB test harness — mirrors evergreen.service.spec.ts's
+// `loadServiceWithFakeDb` / table-name-routed `buildFakeDb` pattern, extended
+// with a `posts` table (needed for `pause`'s not-yet-published-post cleanup).
+// ==========================================================================
+
+function buildFakePublishing() {
+  return {
+    materializeAndEnqueue: jest.fn().mockResolvedValue({
+      postId: 'materialized-post-1',
+      jobId: 'materialized-job-1',
+    }),
+    cancelSlotJob: jest.fn().mockResolvedValue(undefined),
+    buildJobId: jest.fn(),
+  };
+}
+
+function buildFakeQueue() {
+  return {
+    add: jest.fn().mockResolvedValue({ id: 'queue-job-1' }),
+    getJob: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Loads a fresh, isolated copy of `EvergreenService` with `../drizzle/db`
+ *  mocked to `fakeDb`. */
+function loadEvergreenServiceWithFakeDb(
+  fakeDb: unknown,
+  publishing: ReturnType<typeof buildFakePublishing> = buildFakePublishing(),
+  queue: ReturnType<typeof buildFakeQueue> = buildFakeQueue(),
+): InstanceType<typeof EvergreenService> {
+  let Ctor!: typeof EvergreenService;
+  jest.isolateModules(() => {
+    jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    Ctor = require('./evergreen.service').EvergreenService;
+  });
+  return new Ctor(publishing as never, queue as never);
+}
+
+/** Loads a fresh, isolated copy of `CampaignsService` with `../drizzle/db`
+ *  mocked to `fakeDb`, wired with a real `EvergreenService` (also pointed at
+ *  the same fake db) OR a jest.fn-mocked `EvergreenService` (for the
+ *  regression guard, where we must assert non-invocation). */
+function loadCampaignsServiceWithFakeDb(
+  fakeDb: unknown,
+  publishing: ReturnType<typeof buildFakePublishing> = buildFakePublishing(),
+  evergreen: unknown = undefined,
+): InstanceType<typeof CampaignsService> {
+  let Ctor!: typeof CampaignsService;
+  jest.isolateModules(() => {
+    jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    Ctor = require('./campaigns.service').CampaignsService;
+  });
+  return new Ctor(publishing as never, evergreen as never);
+}
+
+afterEach(() => {
+  jest.dontMock('../drizzle/db');
+  jest.resetModules();
+});
+
+const WORKSPACE_ID = 'ws-1';
+const CAMPAIGN_ID = 'campaign-1';
+const CATEGORY_ID = 'category-1';
+const POST_ID = 'post-1';
+const OCCURRENCE_ID = 'occurrence-1';
+
+function makeCampaignRow(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: CAMPAIGN_ID,
+    workspaceId: WORKSPACE_ID,
+    createdById: 'user-1',
+    name: 'Evergreen A',
+    description: null,
+    type: 'evergreen',
+    status: 'draft',
+    schedule: {
+      type: 'evergreen',
+      startDate: '2026-08-18',
+      weekdays: [],
+      times: [],
+      timezone: 'UTC',
+      blackoutDates: [],
+      loop: true,
+    },
+    contentSource: 'manual',
+    aiConfig: null,
+    libraryTemplateIds: [],
+    channelIds: [],
+    platforms: [],
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    launchedAt: null,
+    ...overrides,
+  } as Campaign;
+}
+
+function makeCategoryRow(
+  overrides: Partial<EvergreenCategory> = {},
+): EvergreenCategory {
+  return {
+    id: CATEGORY_ID,
+    campaignId: CAMPAIGN_ID,
+    name: 'Tips',
+    color: 'emerald',
+    schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    channelIds: ['12'],
+    seasonal: null,
+    isActive: true,
+    rotationCursor: 0,
+    sortOrder: 0,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenCategory;
+}
+
+function makePostRow(overrides: Partial<EvergreenPost> = {}): EvergreenPost {
+  return {
+    id: POST_ID,
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    content: {
+      mode: 'manual',
+      postType: 'text',
+      caption: 'Hello world',
+      media: [],
+      threadParts: [],
+      templateIds: [],
+    },
+    variations: [],
+    recyclePolicy: { mode: 'forever' },
+    minGapHours: 0,
+    recycledCount: 0,
+    lastPublishedAt: null,
+    performanceScore: null,
+    isStale: false,
+    staleReason: null,
+    status: 'active',
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenPost;
+}
+
+function makeOccurrenceRow(
+  overrides: Partial<EvergreenOccurrence> = {},
+): EvergreenOccurrence {
+  return {
+    id: OCCURRENCE_ID,
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    postIdRef: POST_ID,
+    variationId: null,
+    channelId: '12',
+    scheduledAt: new Date('2026-08-18T09:00:00Z'),
+    slotStatus: 'scheduled',
+    postsRowId: null,
+    jobId: null,
+    publishedAt: null,
+    lastError: null,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenOccurrence;
+}
+
+interface FakePostsRow {
+  id: string;
+  status: string;
+}
+
+function makeFakePostsRow(overrides: Partial<FakePostsRow> = {}): FakePostsRow {
+  return { id: 'posts-row-1', status: 'scheduled', ...overrides };
+}
+
+interface FakeChannelRow {
+  id: number;
+  platform: string;
+}
+
+function makeChannelRow(
+  overrides: Partial<FakeChannelRow> = {},
+): FakeChannelRow {
+  return { id: 12, platform: 'facebook', ...overrides };
+}
+
+/**
+ * Table-name-routed, stateful fake db shared by both `EvergreenService` and
+ * `CampaignsService` tests. SELECT always returns CLONES — never the same
+ * reference the fixture holds — per the mandatory no-in-place-mutation
+ * ruling (a prior effort's test harness masked a real bug by handing back
+ * live references).
+ */
+function buildFakeDb(fixture: {
+  campaignRows?: Campaign[];
+  categoryRows?: EvergreenCategory[];
+  postRows?: EvergreenPost[];
+  occurrenceRows?: EvergreenOccurrence[];
+  channelRows?: FakeChannelRow[];
+  postsTableRows?: FakePostsRow[];
+  // campaigns.schema tables — only needed for the bulk-campaign regression
+  // guard (CampaignsService.launch reads campaignDays/campaignSlotContent).
+  campaignDaysRows?: { id: string; campaignId: string; date: string; skip: boolean }[];
+  campaignSlotContentRows?: Record<string, unknown>[];
+}) {
+  const campaignRows = fixture.campaignRows ?? [];
+  const categoryRows = fixture.categoryRows ?? [];
+  const postRows = fixture.postRows ?? [];
+  const occurrenceRows = fixture.occurrenceRows ?? [];
+  const channelRows = fixture.channelRows ?? [];
+  const postsTableRows = fixture.postsTableRows ?? [];
+  const campaignDaysRows = fixture.campaignDaysRows ?? [];
+  const campaignSlotContentRows = fixture.campaignSlotContentRows ?? [];
+
+  const inserts: {
+    campaigns: unknown[];
+    categories: unknown[];
+    posts: unknown[];
+    occurrences: unknown[];
+    postsTable: unknown[];
+  } = { campaigns: [], categories: [], posts: [], occurrences: [], postsTable: [] };
+  const deletes: {
+    categoryIds: string[];
+    postIds: string[];
+    postsTableIds: string[];
+  } = {
+    categoryIds: [],
+    postIds: [],
+    postsTableIds: [],
+  };
+
+  function tableRows(name: string): Record<string, unknown>[] {
+    if (name === 'campaigns')
+      return campaignRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_categories')
+      return categoryRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_posts')
+      return postRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_occurrences')
+      return occurrenceRows as unknown as Record<string, unknown>[];
+    if (name === 'social_media_channels')
+      return channelRows as unknown as Record<string, unknown>[];
+    if (name === 'posts')
+      return postsTableRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_days')
+      return campaignDaysRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_slot_content')
+      return campaignSlotContentRows as unknown as Record<string, unknown>[];
+    return [];
+  }
+
+  const db = {
+    select: (_sel?: unknown) => ({
+      from: (table: unknown) => {
+        const name = getTableName(table as never);
+        const rows = tableRows(name);
+
+        const exec = (whereCond?: unknown) => {
+          if (!whereCond) return Promise.resolve(rows.map((r) => ({ ...r })));
+          const wanted = extractEqValues(whereCond);
+          const filtered = rows.filter((r) => {
+            if (wanted.id !== undefined && r.id !== wanted.id) return false;
+            if (
+              wanted.campaign_id !== undefined &&
+              r.campaignId !== wanted.campaign_id
+            )
+              return false;
+            if (
+              wanted.category_id !== undefined &&
+              r.categoryId !== wanted.category_id
+            )
+              return false;
+            if (wanted.workspace_id !== undefined) {
+              if (r.workspaceId !== wanted.workspace_id) return false;
+            }
+            if (wanted.status !== undefined && r.status !== wanted.status) {
+              return false;
+            }
+            if (wanted.slot_status !== undefined) {
+              if (r.slotStatus !== wanted.slot_status) return false;
+            }
+            if (wanted.channel_id !== undefined) {
+              const wantedChannelId = wanted.channel_id as string | number;
+              if (name === 'social_media_channels') {
+                if (String(r.id) !== String(wantedChannelId)) return false;
+              } else if (r.channelId !== wantedChannelId) {
+                return false;
+              }
+            }
+            return true;
+          });
+          // MANDATORY: clones, never fixture references.
+          return Promise.resolve(filtered.map((r) => ({ ...r })));
+        };
+
+        return {
+          where(whereCond: unknown) {
+            return {
+              orderBy: () => exec(whereCond),
+              then: (
+                resolve: (v: Record<string, unknown>[]) => void,
+                reject: (e: unknown) => void,
+              ) => exec(whereCond).then(resolve, reject),
+            };
+          },
+          orderBy() {
+            return exec();
+          },
+          then: (
+            resolve: (v: Record<string, unknown>[]) => void,
+            reject: (e: unknown) => void,
+          ) => exec().then(resolve, reject),
+        };
+      },
+    }),
+    insert: (table: unknown) => ({
+      values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
+        const name = getTableName(table as never);
+        const items = Array.isArray(vals) ? vals : [vals];
+        const rowsOut: Record<string, unknown>[] = [];
+
+        for (const item of items) {
+          let row: Record<string, unknown> | undefined;
+          if (name === 'campaigns') {
+            row = {
+              id: `campaign-new-${campaignRows.length + 1}`,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              launchedAt: null,
+              ...item,
+            };
+            campaignRows.push(row as unknown as Campaign);
+            inserts.campaigns.push(item);
+          } else if (name === 'campaign_evergreen_categories') {
+            row = {
+              id: `cat-${categoryRows.length + 1}`,
+              rotationCursor: 0,
+              sortOrder: 0,
+              seasonal: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              ...item,
+            };
+            categoryRows.push(row as unknown as EvergreenCategory);
+            inserts.categories.push(item);
+          } else if (name === 'campaign_evergreen_posts') {
+            row = {
+              id: `post-${postRows.length + 1}`,
+              recycledCount: 0,
+              lastPublishedAt: null,
+              performanceScore: null,
+              isStale: false,
+              staleReason: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              ...item,
+            };
+            postRows.push(row as unknown as EvergreenPost);
+            inserts.posts.push(item);
+          } else if (name === 'campaign_evergreen_occurrences') {
+            row = {
+              id: `occ-${occurrenceRows.length + 1}`,
+              variationId: null,
+              slotStatus: 'scheduled',
+              postsRowId: null,
+              jobId: null,
+              publishedAt: null,
+              lastError: null,
+              createdAt: new Date(),
+              ...item,
+            };
+            occurrenceRows.push(row as unknown as EvergreenOccurrence);
+            inserts.occurrences.push(item);
+          } else if (name === 'posts') {
+            row = {
+              id: `posts-row-${postsTableRows.length + 1}`,
+              status: 'scheduled',
+              ...item,
+            };
+            postsTableRows.push(row as unknown as FakePostsRow);
+            inserts.postsTable.push(item);
+          }
+          if (row) rowsOut.push(row);
+        }
+
+        const query = Promise.resolve(rowsOut) as Promise<
+          Record<string, unknown>[]
+        > & {
+          returning: () => Promise<Record<string, unknown>[]>;
+        };
+        query.returning = () => Promise.resolve(rowsOut.map((r) => ({ ...r })));
+        return query;
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (set: Record<string, unknown>) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const wanted = extractEqValues(whereCond);
+          const rows = tableRows(name);
+          for (const row of rows) {
+            if (wanted.id !== undefined && row.id !== wanted.id) continue;
+            if (
+              wanted.campaign_id !== undefined &&
+              row.campaignId !== wanted.campaign_id
+            )
+              continue;
+            Object.assign(row, set);
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+    delete: (table: unknown) => ({
+      where: (whereCond: unknown) => {
+        const name = getTableName(table as never);
+        const wanted = extractEqValues(whereCond);
+        if (name === 'campaign_evergreen_categories') {
+          const idx = categoryRows.findIndex((r) => r.id === wanted.id);
+          if (idx !== -1) {
+            deletes.categoryIds.push(categoryRows[idx].id);
+            categoryRows.splice(idx, 1);
+          }
+        }
+        if (name === 'campaign_evergreen_posts') {
+          if (wanted.id !== undefined) {
+            const idx = postRows.findIndex((r) => r.id === wanted.id);
+            if (idx !== -1) {
+              deletes.postIds.push(postRows[idx].id);
+              postRows.splice(idx, 1);
+            }
+          } else if (wanted.category_id !== undefined) {
+            for (let i = postRows.length - 1; i >= 0; i--) {
+              if (postRows[i].categoryId === wanted.category_id) {
+                deletes.postIds.push(postRows[i].id);
+                postRows.splice(i, 1);
+              }
+            }
+          }
+        }
+        if (name === 'campaign_evergreen_occurrences') {
+          const idx = occurrenceRows.findIndex((r) => r.id === wanted.id);
+          if (idx !== -1) occurrenceRows.splice(idx, 1);
+        }
+        if (name === 'posts') {
+          // `pause` guards the delete on status='scheduled' — mirror that: a
+          // delete whose where-clause includes status must only remove rows
+          // matching BOTH id and status (returning 0 rows deleted otherwise).
+          const idx = postsTableRows.findIndex((r) => {
+            if (wanted.id !== undefined && r.id !== wanted.id) return false;
+            if (wanted.status !== undefined && r.status !== wanted.status)
+              return false;
+            return true;
+          });
+          const deletedRows: Record<string, unknown>[] = [];
+          if (idx !== -1) {
+            deletedRows.push({ ...postsTableRows[idx] });
+            deletes.postsTableIds.push(postsTableRows[idx].id);
+            postsTableRows.splice(idx, 1);
+          }
+          const query = Promise.resolve(deletedRows) as Promise<
+            Record<string, unknown>[]
+          > & { returning: () => Promise<Record<string, unknown>[]> };
+          query.returning = () => Promise.resolve(deletedRows);
+          return query;
+        }
+        return Promise.resolve();
+      },
+    }),
+  };
+
+  return {
+    db,
+    inserts,
+    deletes,
+    campaignRows,
+    categoryRows,
+    postRows,
+    occurrenceRows,
+    channelRows,
+    postsTableRows,
+    campaignDaysRows,
+    campaignSlotContentRows,
+  };
+}
+
+/** Walk an `eq(col, v)` / `and(eq(colA, v1), eq(colB, v2))` drizzle condition
+ *  tree into `{ dbColumnName: value }`. */
+function extractEqValues(cond: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let pendingColumn: string | undefined;
+  function walk(node: unknown): void {
+    if (node == null || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      for (const c of chunks) walk(c);
+      return;
+    }
+    const named = node as {
+      name?: string;
+      columnType?: string;
+      value?: unknown;
+    };
+    if (
+      typeof named.name === 'string' &&
+      typeof named.columnType === 'string'
+    ) {
+      pendingColumn = named.name;
+    } else if (
+      pendingColumn &&
+      named.value !== undefined &&
+      typeof named.value !== 'object'
+    ) {
+      result[pendingColumn] = named.value;
+      pendingColumn = undefined;
+    }
+  }
+  walk(cond);
+  return result;
+}
+
+// ==========================================================================
+// EvergreenService.armCategory — multi-channel fan-out (folded in from T6
+// review). A category with N channelIds must arm N occurrences (one per
+// channel) at the SAME fire instant, sharing the picked post per instant.
+// ==========================================================================
+
+describe('EvergreenService.armCategory — multi-channel fan-out', () => {
+  it('a category with 2 channelIds arms 2 occurrences at one fire, sharing the picked post', async () => {
+    const category = makeCategoryRow({ channelIds: ['12', '34'] });
+    const campaign = makeCampaignRow();
+    const { db, inserts, occurrenceRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const queue = buildFakeQueue();
+    const service = loadEvergreenServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      queue,
+    );
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(2);
+    const channelIdsArmed = occurrenceRows.map((o) => o.channelId).sort();
+    expect(channelIdsArmed).toEqual(['12', '34']);
+
+    // Same fire instant, same picked post, for both.
+    expect(occurrenceRows[0].scheduledAt.getTime()).toBe(
+      occurrenceRows[1].scheduledAt.getTime(),
+    );
+    expect(occurrenceRows[0].postIdRef).toBe(POST_ID);
+    expect(occurrenceRows[1].postIdRef).toBe(POST_ID);
+
+    // One BullMQ job per occurrence, deterministic non-colliding jobIds.
+    expect(queue.add).toHaveBeenCalledTimes(2);
+    const jobIds = (
+      queue.add.mock.calls as unknown as [
+        string,
+        unknown,
+        { jobId: string },
+      ][]
+    ).map(([, , opts]) => opts.jobId);
+    expect(new Set(jobIds).size).toBe(2);
+    expect(jobIds.sort()).toEqual(
+      [`evg-${occurrenceRows[0].id}`, `evg-${occurrenceRows[1].id}`].sort(),
+    );
+  });
+
+  it('single-channel category still arms exactly 1 occurrence (no regression)', async () => {
+    const category = makeCategoryRow({ channelIds: ['12'] });
+    const campaign = makeCampaignRow();
+    const { db, inserts, occurrenceRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const queue = buildFakeQueue();
+    const service = loadEvergreenServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      queue,
+    );
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(1);
+    expect(occurrenceRows[0].channelId).toBe('12');
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('with no channelIds configured: arms nothing', async () => {
+    const category = makeCategoryRow({ channelIds: [] });
+    const campaign = makeCampaignRow();
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const queue = buildFakeQueue();
+    const service = loadEvergreenServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      queue,
+    );
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});
+
+// ==========================================================================
+// EvergreenService.launch
+// ==========================================================================
+
+describe('EvergreenService.launch', () => {
+  it('arms exactly one fire per active category (single channel) and sets status active + launchedAt', async () => {
+    const category = makeCategoryRow({ isActive: true, channelIds: ['12'] });
+    const campaign = makeCampaignRow({ status: 'draft' });
+    const { db, inserts, campaignRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    const dto = await service.launch(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(inserts.occurrences).toHaveLength(1);
+    expect(campaignRows[0].status).toBe('active');
+    expect(campaignRows[0].launchedAt).not.toBeNull();
+    expect(dto.status).toBe('active');
+  });
+
+  it('fans out across multiple active categories, each per their own channelIds', async () => {
+    const categoryA = makeCategoryRow({
+      id: 'category-a',
+      channelIds: ['12', '34'],
+    });
+    const categoryB = makeCategoryRow({
+      id: 'category-b',
+      name: 'Category B',
+      channelIds: ['56'],
+    });
+    const campaign = makeCampaignRow();
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [categoryA, categoryB],
+      postRows: [
+        makePostRow({ id: 'post-a', categoryId: 'category-a' }),
+        makePostRow({ id: 'post-b', categoryId: 'category-b' }),
+      ],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.launch(WORKSPACE_ID, CAMPAIGN_ID);
+
+    // categoryA fans out to 2 (channels 12+34), categoryB to 1 (channel 56).
+    expect(inserts.occurrences).toHaveLength(3);
+  });
+
+  it('a category with 0 eligible posts arms nothing for that category but the campaign still launches', async () => {
+    const categoryWithPosts = makeCategoryRow({
+      id: 'category-a',
+      channelIds: ['12'],
+    });
+    const categoryEmpty = makeCategoryRow({
+      id: 'category-b',
+      name: 'Empty',
+      channelIds: ['34'],
+    });
+    const campaign = makeCampaignRow();
+    const { db, inserts, campaignRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [categoryWithPosts, categoryEmpty],
+      postRows: [makePostRow({ id: 'post-a', categoryId: 'category-a' })],
+      // category-b has NO posts in the pool -> nothing eligible to arm.
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    const dto = await service.launch(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(inserts.occurrences).toHaveLength(1); // only category-a armed
+    expect(campaignRows[0].status).toBe('active'); // launch still succeeds
+    expect(dto.status).toBe('active');
+  });
+
+  it('throws when there is no active category with at least one eligible post', async () => {
+    const inactiveCategory = makeCategoryRow({ isActive: false });
+    const campaign = makeCampaignRow();
+    const { db } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [inactiveCategory],
+      postRows: [makePostRow()],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await expect(service.launch(WORKSPACE_ID, CAMPAIGN_ID)).rejects.toThrow();
+  });
+
+  it('throws when the only active category has zero pool posts', async () => {
+    const category = makeCategoryRow({ isActive: true });
+    const campaign = makeCampaignRow();
+    const { db } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await expect(service.launch(WORKSPACE_ID, CAMPAIGN_ID)).rejects.toThrow();
+  });
+});
+
+// ==========================================================================
+// EvergreenService.pause
+// ==========================================================================
+
+describe('EvergreenService.pause', () => {
+  it('cancels every future scheduled occurrence job + deletes its unpublished posts row, and sets status paused', async () => {
+    const category = makeCategoryRow();
+    const campaign = makeCampaignRow({ status: 'active' });
+    const scheduledOccurrence = makeOccurrenceRow({
+      slotStatus: 'scheduled',
+      jobId: 'evg-occurrence-1',
+      postsRowId: 'posts-row-1',
+      scheduledAt: new Date('2099-01-01T09:00:00Z'), // future
+    });
+    const publishedOccurrence = makeOccurrenceRow({
+      id: 'occurrence-2',
+      slotStatus: 'published',
+      jobId: null,
+      postsRowId: 'posts-row-2',
+      scheduledAt: new Date('2020-01-01T09:00:00Z'), // past, already fired
+    });
+    const { db, campaignRows, occurrenceRows, postsTableRows, deletes } =
+      buildFakeDb({
+        campaignRows: [campaign],
+        categoryRows: [category],
+        postRows: [makePostRow()],
+        occurrenceRows: [scheduledOccurrence, publishedOccurrence],
+        postsTableRows: [
+          makeFakePostsRow({ id: 'posts-row-1', status: 'scheduled' }),
+          makeFakePostsRow({ id: 'posts-row-2', status: 'published' }),
+        ],
+      });
+    const publishing = buildFakePublishing();
+    const service = loadEvergreenServiceWithFakeDb(db, publishing);
+
+    const dto = await service.pause(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(publishing.cancelSlotJob).toHaveBeenCalledWith('evg-occurrence-1');
+    expect(publishing.cancelSlotJob).toHaveBeenCalledTimes(1); // NOT the published one
+
+    // The scheduled slot's post row (still 'scheduled') got deleted.
+    expect(deletes.postsTableIds).toContain('posts-row-1');
+    expect(postsTableRows.map((r) => r.id)).not.toContain('posts-row-1');
+    // The published slot's post row is untouched.
+    expect(postsTableRows.map((r) => r.id)).toContain('posts-row-2');
+
+    // Only the scheduled occurrence was touched (removed or its slotStatus
+    // flipped away from scheduled) — verify it's no longer a live scheduled
+    // occurrence, while the published one is untouched.
+    const stillScheduled = occurrenceRows.some(
+      (o) => o.id === 'occurrence-1' && o.slotStatus === 'scheduled',
+    );
+    expect(stillScheduled).toBe(false);
+    expect(
+      occurrenceRows.find((o) => o.id === 'occurrence-2')?.slotStatus,
+    ).toBe('published');
+
+    expect(campaignRows[0].status).toBe('paused');
+    expect(dto.status).toBe('paused');
+  });
+
+  it('is a no-op on occurrences when there are none scheduled', async () => {
+    const category = makeCategoryRow();
+    const campaign = makeCampaignRow({ status: 'active' });
+    const { db, campaignRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+      occurrenceRows: [],
+    });
+    const publishing = buildFakePublishing();
+    const service = loadEvergreenServiceWithFakeDb(db, publishing);
+
+    const dto = await service.pause(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(publishing.cancelSlotJob).not.toHaveBeenCalled();
+    expect(campaignRows[0].status).toBe('paused');
+    expect(dto.status).toBe('paused');
+  });
+});
+
+// ==========================================================================
+// EvergreenService.resume
+// ==========================================================================
+
+describe('EvergreenService.resume', () => {
+  it('re-arms every active category and sets status active', async () => {
+    const activeCategory = makeCategoryRow({ isActive: true, channelIds: ['12'] });
+    const inactiveCategory = makeCategoryRow({
+      id: 'category-b',
+      isActive: false,
+      channelIds: ['34'],
+    });
+    const campaign = makeCampaignRow({ status: 'paused' });
+    const { db, inserts, campaignRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [activeCategory, inactiveCategory],
+      postRows: [
+        makePostRow({ id: 'post-a', categoryId: CATEGORY_ID }),
+        makePostRow({ id: 'post-b', categoryId: 'category-b' }),
+      ],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    const dto = await service.resume(WORKSPACE_ID, CAMPAIGN_ID);
+
+    // Only the active category gets re-armed.
+    expect(inserts.occurrences).toHaveLength(1);
+    expect((inserts.occurrences[0] as { categoryId: string }).categoryId).toBe(
+      CATEGORY_ID,
+    );
+
+    expect(campaignRows[0].status).toBe('active');
+    expect(dto.status).toBe('active');
+  });
+
+  it('fans out multi-channel categories on resume too', async () => {
+    const category = makeCategoryRow({ isActive: true, channelIds: ['12', '34'] });
+    const campaign = makeCampaignRow({ status: 'paused' });
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.resume(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(inserts.occurrences).toHaveLength(2);
+  });
+});
+
+// ==========================================================================
+// EvergreenService.reconcile
+// ==========================================================================
+
+describe('EvergreenService.reconcile', () => {
+  it('re-arms a category whose only occurrence is already published (dead chain)', async () => {
+    const category = makeCategoryRow({ isActive: true, channelIds: ['12'] });
+    const campaign = makeCampaignRow({ status: 'active' });
+    const deadOccurrence = makeOccurrenceRow({
+      slotStatus: 'published',
+      scheduledAt: new Date('2020-01-01T09:00:00Z'),
+    });
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+      occurrenceRows: [deadOccurrence],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.reconcile();
+
+    expect(inserts.occurrences).toHaveLength(1); // re-armed
+  });
+
+  it('is a no-op when a future scheduled occurrence already exists for the channel', async () => {
+    const category = makeCategoryRow({ isActive: true, channelIds: ['12'] });
+    const campaign = makeCampaignRow({ status: 'active' });
+    const liveOccurrence = makeOccurrenceRow({
+      slotStatus: 'scheduled',
+      channelId: '12',
+      scheduledAt: new Date('2099-01-01T09:00:00Z'),
+    });
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+      occurrenceRows: [liveOccurrence],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.reconcile();
+
+    expect(inserts.occurrences).toHaveLength(0); // untouched — already armed
+  });
+
+  it('re-arms per-channel: 2-channel category with only 1 channel covered gets the missing channel armed', async () => {
+    const category = makeCategoryRow({
+      isActive: true,
+      channelIds: ['12', '34'],
+    });
+    const campaign = makeCampaignRow({ status: 'active' });
+    // Only channel 12 has a live future occurrence; 34 has none.
+    const liveOccurrence = makeOccurrenceRow({
+      slotStatus: 'scheduled',
+      channelId: '12',
+      scheduledAt: new Date('2099-01-01T09:00:00Z'),
+    });
+    const { db, inserts, occurrenceRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+      occurrenceRows: [liveOccurrence],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.reconcile();
+
+    // armCategory fans out to BOTH channels again in the current
+    // (simple, idempotent-by-deterministic-jobId) implementation OR just
+    // the missing one — either way channel 34 must end up armed.
+    const channel34Armed = occurrenceRows.some(
+      (o) => o.channelId === '34' && o.slotStatus === 'scheduled',
+    );
+    expect(channel34Armed).toBe(true);
+    expect(inserts.occurrences.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ignores paused/draft campaigns and inactive categories', async () => {
+    const activeCatOnPausedCampaign = makeCategoryRow({ isActive: true });
+    const pausedCampaign = makeCampaignRow({
+      id: 'campaign-paused',
+      status: 'paused',
+    });
+    const inactiveCatOnActiveCampaign = makeCategoryRow({
+      id: 'category-inactive',
+      campaignId: 'campaign-active',
+      isActive: false,
+    });
+    const activeCampaign = makeCampaignRow({
+      id: 'campaign-active',
+      status: 'active',
+    });
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [pausedCampaign, activeCampaign],
+      categoryRows: [
+        { ...activeCatOnPausedCampaign, campaignId: 'campaign-paused' },
+        inactiveCatOnActiveCampaign,
+      ],
+      postRows: [
+        makePostRow({ id: 'post-1', categoryId: CATEGORY_ID }),
+        makePostRow({ id: 'post-2', categoryId: 'category-inactive' }),
+      ],
+    });
+    const service = loadEvergreenServiceWithFakeDb(db);
+
+    await service.reconcile();
+
+    expect(inserts.occurrences).toHaveLength(0);
+  });
+});
+
+// ==========================================================================
+// CampaignsService delegation — evergreen campaigns route through
+// EvergreenService; bulk/drip stays on the original path (byte-for-byte
+// unchanged — asserted directly below).
+// ==========================================================================
+
+describe('CampaignsService lifecycle delegation to EvergreenService', () => {
+  it('launch delegates to EvergreenService.launch for an evergreen campaign', async () => {
+    const campaign = makeCampaignRow({ type: 'evergreen', status: 'draft' });
+    const { db } = buildFakeDb({ campaignRows: [campaign] });
+    const fakeEvergreen = {
+      launch: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'active' }),
+      pause: jest.fn(),
+      resume: jest.fn(),
+    };
+    const service = loadCampaignsServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      fakeEvergreen,
+    );
+
+    const result = await service.launch(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(fakeEvergreen.launch).toHaveBeenCalledWith(WORKSPACE_ID, CAMPAIGN_ID);
+    expect(result).toEqual({ id: CAMPAIGN_ID, status: 'active' });
+  });
+
+  it('pause delegates to EvergreenService.pause for an evergreen campaign', async () => {
+    const campaign = makeCampaignRow({ type: 'evergreen', status: 'active' });
+    const { db } = buildFakeDb({ campaignRows: [campaign] });
+    const fakeEvergreen = {
+      launch: jest.fn(),
+      pause: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'paused' }),
+      resume: jest.fn(),
+    };
+    const service = loadCampaignsServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      fakeEvergreen,
+    );
+
+    const result = await service.pause(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(fakeEvergreen.pause).toHaveBeenCalledWith(WORKSPACE_ID, CAMPAIGN_ID);
+    expect(result).toEqual({ id: CAMPAIGN_ID, status: 'paused' });
+  });
+
+  it('resume delegates to EvergreenService.resume for an evergreen campaign', async () => {
+    const campaign = makeCampaignRow({ type: 'evergreen', status: 'paused' });
+    const { db } = buildFakeDb({ campaignRows: [campaign] });
+    const fakeEvergreen = {
+      launch: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn().mockResolvedValue({ id: CAMPAIGN_ID, status: 'active' }),
+    };
+    const service = loadCampaignsServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      fakeEvergreen,
+    );
+
+    const result = await service.resume(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(fakeEvergreen.resume).toHaveBeenCalledWith(WORKSPACE_ID, CAMPAIGN_ID);
+    expect(result).toEqual({ id: CAMPAIGN_ID, status: 'active' });
+  });
+
+  // ------------------------------------------------------------------------
+  // MANDATORY regression guard: a bulk campaign's launch must NEVER touch
+  // EvergreenService, proving the bulk/drip path is byte-for-byte unchanged.
+  // ------------------------------------------------------------------------
+  it('REGRESSION GUARD: launch for a bulk campaign does NOT call any EvergreenService method', async () => {
+    const bulkCampaign = makeCampaignRow({
+      type: 'bulk',
+      status: 'draft',
+      schedule: {
+        type: 'bulk',
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+        defaultTime: '09:00',
+        timezone: 'UTC',
+        blackoutDates: [],
+        skipWeekends: false,
+      },
+    });
+    const filledSlot = {
+      id: 'slot-1',
+      campaignId: CAMPAIGN_ID,
+      date: '2026-09-01',
+      channelId: 'channel-1',
+      time: '09:00',
+      content: {
+        mode: 'manual',
+        postType: 'text',
+        caption: 'Hello world',
+        media: [],
+        threadParts: [],
+        templateIds: [],
+      },
+      slotStatus: 'pending',
+      postId: null,
+      jobId: null,
+      scheduledAt: null,
+      updatedAt: new Date(),
+    };
+    const { db } = buildFakeDb({
+      campaignRows: [bulkCampaign],
+      campaignDaysRows: [],
+      campaignSlotContentRows: [filledSlot],
+    });
+    const fakeEvergreen = {
+      launch: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+    };
+    const service = loadCampaignsServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      fakeEvergreen,
+    );
+
+    const result = await service.launch(WORKSPACE_ID, CAMPAIGN_ID);
+
+    expect(fakeEvergreen.launch).not.toHaveBeenCalled();
+    expect(fakeEvergreen.pause).not.toHaveBeenCalled();
+    expect(fakeEvergreen.resume).not.toHaveBeenCalled();
+    // Bulk path ran its normal logic (not a stubbed-out branch).
+    expect(result.status).toBe('active');
+    expect(result.type).toBe('bulk');
+  });
+});

--- a/src/campaigns/evergreen-reconcile.cron.ts
+++ b/src/campaigns/evergreen-reconcile.cron.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { EvergreenService } from './evergreen.service';
+
+/**
+ * Fires daily at 03:00 UTC. Belt-and-suspenders sweep against a dead
+ * evergreen rotation chain: for every ACTIVE evergreen campaign's ACTIVE
+ * category, re-arms any channel that has no future `scheduled` occurrence.
+ * Idempotent — `EvergreenService.armCategory`'s own per-channel coverage
+ * check means a channel that's already armed is skipped, so running this
+ * against a perfectly healthy fleet of campaigns is a safe no-op.
+ *
+ * Mirrors `src/ads/schedulers/ad-insights-sync.scheduler.ts` for style.
+ * `ScheduleModule.forRoot()` is already registered in `AppModule` — this
+ * class only needs to be a `@Cron`-decorated provider in `CampaignsModule`.
+ */
+@Injectable()
+export class EvergreenReconcileCron {
+  private readonly logger = new Logger(EvergreenReconcileCron.name);
+
+  constructor(private readonly evergreen: EvergreenService) {}
+
+  @Cron('0 3 * * *', { timeZone: 'UTC', name: 'evergreenReconcile' })
+  async reconcile(): Promise<void> {
+    this.logger.log('evergreenReconcile: sweeping for dead rotation chains');
+    await this.evergreen.reconcile();
+  }
+}

--- a/src/campaigns/evergreen-rotation.util.spec.ts
+++ b/src/campaigns/evergreen-rotation.util.spec.ts
@@ -1,0 +1,83 @@
+import { computeNextCategoryFire, isPostEligible, pickNextPost, selectVariation } from './evergreen-rotation.util';
+
+const NOW = new Date('2026-08-17T12:00:00Z'); // Monday
+
+function post(overrides: any = {}): any {
+  return {
+    id: 'p1', status: 'active', recyclePolicy: { mode: 'forever' }, minGapHours: 0,
+    recycledCount: 0, lastPublishedAt: null, performanceScore: null, variations: [], ...overrides,
+  };
+}
+const liveCat = { isActive: true, seasonal: null };
+
+describe('computeNextCategoryFire', () => {
+  it('returns the next matching weekday+time after `after`', () => {
+    // Wednesday(3) 09:00 UTC, from Monday noon → 2026-08-19T09:00Z
+    const next = computeNextCategoryFire({ weekdays: [3], times: ['09:00'] }, 'UTC', [], NOW);
+    expect(next?.toISOString()).toBe('2026-08-19T09:00:00.000Z');
+  });
+  it('skips blackout dates', () => {
+    const next = computeNextCategoryFire({ weekdays: [1,2,3], times: ['09:00'] }, 'UTC', ['2026-08-18'], NOW);
+    // Mon noon → Tue 18th is blackout → Wed 19th 09:00
+    expect(next?.toISOString()).toBe('2026-08-19T09:00:00.000Z');
+  });
+  it('returns null when no weekday configured', () => {
+    expect(computeNextCategoryFire({ weekdays: [], times: ['09:00'] }, 'UTC', [], NOW)).toBeNull();
+  });
+});
+
+describe('isPostEligible', () => {
+  it('true for an active post in an active category', () => {
+    expect(isPostEligible(post(), liveCat, NOW)).toBe(true);
+  });
+  it('false for a paused/retired post', () => {
+    expect(isPostEligible(post({ status: 'paused' }), liveCat, NOW)).toBe(false);
+    expect(isPostEligible(post({ status: 'retired' }), liveCat, NOW)).toBe(false);
+  });
+  it('false when category is inactive', () => {
+    expect(isPostEligible(post(), { isActive: false, seasonal: null }, NOW)).toBe(false);
+  });
+  it('false outside a seasonal window', () => {
+    expect(isPostEligible(post(), { isActive: true, seasonal: { startDate: '2026-12-01', endDate: '2026-12-31' } }, NOW)).toBe(false);
+  });
+  it('false when maxCount reached', () => {
+    expect(isPostEligible(post({ recyclePolicy: { mode: 'maxCount', maxCount: 3 }, recycledCount: 3 }), liveCat, NOW)).toBe(false);
+  });
+  it('false when past expiry', () => {
+    expect(isPostEligible(post({ recyclePolicy: { mode: 'expiry', expiryDate: '2026-08-01' } }), liveCat, NOW)).toBe(false);
+  });
+  it('false when min-gap not satisfied', () => {
+    expect(isPostEligible(post({ minGapHours: 48, lastPublishedAt: new Date('2026-08-17T00:00:00Z') }), liveCat, NOW)).toBe(false);
+  });
+});
+
+describe('pickNextPost', () => {
+  it('returns null when nothing eligible', () => {
+    expect(pickNextPost([post({ status: 'retired' })], liveCat, NOW)).toBeNull();
+  });
+  it('prefers the least-recently-published post', () => {
+    const a = post({ id: 'a', lastPublishedAt: new Date('2026-08-16T00:00:00Z') });
+    const b = post({ id: 'b', lastPublishedAt: new Date('2026-08-10T00:00:00Z') }); // older
+    expect(pickNextPost([a, b], liveCat, NOW)?.id).toBe('b');
+  });
+  it('weights a strong performer ahead of a slightly-older weak one', () => {
+    const weakOld = post({ id: 'weakOld', lastPublishedAt: new Date('2026-08-10T00:00:00Z'), performanceScore: 0.0 });
+    const strongNewer = post({ id: 'strongNewer', lastPublishedAt: new Date('2026-08-11T00:00:00Z'), performanceScore: 1.0 });
+    expect(pickNextPost([weakOld, strongNewer], liveCat, NOW)?.id).toBe('strongNewer');
+  });
+  it('treats null performanceScore as neutral (never excludes on score)', () => {
+    const only = post({ id: 'only', performanceScore: null });
+    expect(pickNextPost([only], liveCat, NOW)?.id).toBe('only');
+  });
+});
+
+describe('selectVariation', () => {
+  it('uses base caption on the first fire', () => {
+    const p = post({ content: { caption: 'BASE' } as any, variations: [{ id: 'v1', caption: 'V1', source: 'ai' }], recycledCount: 0 });
+    expect(selectVariation({ ...p, content: { caption: 'BASE' } } as any)).toEqual({ variationId: null, caption: 'BASE' });
+  });
+  it('cycles to variation 1 on the second fire', () => {
+    const p = { content: { caption: 'BASE' }, variations: [{ id: 'v1', caption: 'V1', source: 'ai' }], recycledCount: 1 } as any;
+    expect(selectVariation(p)).toEqual({ variationId: 'v1', caption: 'V1' });
+  });
+});

--- a/src/campaigns/evergreen-rotation.util.ts
+++ b/src/campaigns/evergreen-rotation.util.ts
@@ -1,0 +1,236 @@
+import type {
+  EvergreenCategoryScheduleJson,
+  EvergreenPost,
+  EvergreenSeasonalJson,
+  RecyclePolicyJson,
+} from '../drizzle/schema/evergreen.schema';
+
+// ---------------------------------------------------------------------------
+// Timezone helpers (replicated from campaign-schedule.util.ts — not exported
+// there, so we keep a private DST-correct copy here rather than inventing a
+// naive `new Date(string)` conversion).
+// ---------------------------------------------------------------------------
+
+/** Offset (minutes) of `timeZone` from UTC at the given UTC instant.
+ *  Positive means east of UTC (e.g. Asia/Karachi → +300). */
+function zoneOffsetMinutes(timeZone: string, at: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const parts = dtf.formatToParts(at);
+  const get = (t: string) => Number(parts.find((p) => p.type === t)?.value);
+  const asUtc = Date.UTC(
+    get('year'),
+    get('month') - 1,
+    get('day'),
+    get('hour'),
+    get('minute'),
+    get('second'),
+  );
+  return Math.round((asUtc - at.getTime()) / 60000);
+}
+
+/** Convert wall-clock `date` (yyyy-MM-dd) + `time` (HH:mm) in `timeZone` to a
+ *  UTC Date. Falls back to treating the wall-clock as UTC if the zone is
+ *  invalid. Returns null if date/time are malformed. */
+function wallClockToUtc(date: string, time: string, timeZone: string): Date | null {
+  const dm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const tm = /^(\d{2}):(\d{2})$/.exec(time);
+  if (!dm || !tm) return null;
+  // First approximation: treat the wall-clock as UTC.
+  const naiveUtcMs = Date.UTC(+dm[1], +dm[2] - 1, +dm[3], +tm[1], +tm[2], 0, 0);
+  let offsetMin = 0;
+  try {
+    offsetMin = zoneOffsetMinutes(timeZone, new Date(naiveUtcMs));
+  } catch {
+    offsetMin = 0; // invalid zone → UTC fallback
+  }
+  // Real UTC instant = wall-clock minus the zone's offset.
+  return new Date(naiveUtcMs - offsetMin * 60000);
+}
+
+/** Format a UTC-midnight-anchored y/m/d as yyyy-MM-dd. */
+function formatDate(y: number, m: number, d: number): string {
+  const mm = String(m).padStart(2, '0');
+  const dd = String(d).padStart(2, '0');
+  return `${y}-${mm}-${dd}`;
+}
+
+// ---------------------------------------------------------------------------
+// computeNextCategoryFire
+// ---------------------------------------------------------------------------
+
+const MAX_SCAN_DAYS = 366;
+
+/**
+ * Find the next instant, strictly after `after`, that matches one of
+ * `schedule.weekdays` (0=Sun..6=Sat) at one of `schedule.times` (HH:mm),
+ * interpreted in `timezone`, skipping any date present in `blackoutDates`.
+ * Scans day-by-day up to `MAX_SCAN_DAYS` days from `after`. Returns null if
+ * no weekdays are configured or nothing is found within the scan window.
+ */
+export function computeNextCategoryFire(
+  schedule: EvergreenCategoryScheduleJson,
+  timezone: string,
+  blackoutDates: string[],
+  after: Date,
+): Date | null {
+  if (!schedule.weekdays || schedule.weekdays.length === 0) return null;
+  if (!schedule.times || schedule.times.length === 0) return null;
+
+  const weekdaySet = new Set(schedule.weekdays);
+  const blackoutSet = new Set(blackoutDates ?? []);
+  const sortedTimes = [...schedule.times].sort();
+
+  // Anchor the scan at the UTC calendar day of `after` and walk forward.
+  const startY = after.getUTCFullYear();
+  const startM = after.getUTCMonth() + 1;
+  const startD = after.getUTCDate();
+  const startUtcMidnight = Date.UTC(startY, startM - 1, startD);
+
+  for (let dayOffset = 0; dayOffset <= MAX_SCAN_DAYS; dayOffset++) {
+    const dayMs = startUtcMidnight + dayOffset * 86400000;
+    const dayDate = new Date(dayMs);
+    const y = dayDate.getUTCFullYear();
+    const m = dayDate.getUTCMonth() + 1;
+    const d = dayDate.getUTCDate();
+    const weekday = dayDate.getUTCDay();
+
+    if (!weekdaySet.has(weekday)) continue;
+
+    const dateStr = formatDate(y, m, d);
+    if (blackoutSet.has(dateStr)) continue;
+
+    for (const time of sortedTimes) {
+      const candidate = wallClockToUtc(dateStr, time, timezone);
+      if (!candidate) continue;
+      if (candidate.getTime() > after.getTime()) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// isPostEligible
+// ---------------------------------------------------------------------------
+
+function isWithinSeasonalWindow(seasonal: EvergreenSeasonalJson | null, now: Date): boolean {
+  if (!seasonal) return true;
+  const start = wallClockToUtc(seasonal.startDate, '00:00', 'UTC');
+  // End date is inclusive through end-of-day.
+  const end = wallClockToUtc(seasonal.endDate, '23:59', 'UTC');
+  if (!start || !end) return true; // malformed window — don't block on bad data
+  return now.getTime() >= start.getTime() && now.getTime() <= end.getTime();
+}
+
+function isPolicySatisfied(policy: RecyclePolicyJson, recycledCount: number, now: Date): boolean {
+  if (policy.mode === 'maxCount') {
+    if (policy.maxCount == null) return true;
+    return recycledCount < policy.maxCount;
+  }
+  if (policy.mode === 'expiry') {
+    if (!policy.expiryDate) return true;
+    const expiry = wallClockToUtc(policy.expiryDate, '23:59', 'UTC');
+    if (!expiry) return true;
+    return now.getTime() <= expiry.getTime();
+  }
+  return true; // 'forever'
+}
+
+function isMinGapSatisfied(minGapHours: number, lastPublishedAt: Date | null, now: Date): boolean {
+  if (!minGapHours || minGapHours <= 0) return true;
+  if (!lastPublishedAt) return true;
+  const gapMs = now.getTime() - lastPublishedAt.getTime();
+  return gapMs >= minGapHours * 3600000;
+}
+
+/**
+ * True when a post can fire right now: post is 'active', its category is
+ * active, `now` falls within the category's seasonal window (if any), the
+ * recycle policy hasn't been exhausted, and the min-gap since last publish
+ * has elapsed.
+ */
+export function isPostEligible(
+  post: EvergreenPost,
+  category: { isActive: boolean; seasonal: EvergreenSeasonalJson | null },
+  now: Date,
+): boolean {
+  if (post.status !== 'active') return false;
+  if (!category.isActive) return false;
+  if (!isWithinSeasonalWindow(category.seasonal, now)) return false;
+  if (!isPolicySatisfied(post.recyclePolicy as RecyclePolicyJson, post.recycledCount, now)) return false;
+  if (!isMinGapSatisfied(post.minGapHours, post.lastPublishedAt, now)) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// pickNextPost
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter to eligible posts, then rank least-recently-published-first (a
+ * never-published post — `lastPublishedAt === null` — ranks highest), scaled
+ * by a D2 performance multiplier `(0.5 + (performanceScore ?? 0.5))` so a
+ * null score is neutral (×1.0) and never excludes a post. Deterministic: on
+ * an exact tie the first post in input order wins. Returns null when no
+ * post is eligible.
+ */
+export function pickNextPost(
+  posts: EvergreenPost[],
+  category: { isActive: boolean; seasonal: EvergreenSeasonalJson | null },
+  now: Date,
+): EvergreenPost | null {
+  const eligible = posts.filter((p) => isPostEligible(p, category, now));
+  if (eligible.length === 0) return null;
+
+  // Base "age priority": larger = should fire sooner. Never-published posts
+  // get the largest possible value so they always sort first among ties.
+  const agePriority = (p: EvergreenPost): number => {
+    if (!p.lastPublishedAt) return Number.MAX_SAFE_INTEGER;
+    // Older lastPublishedAt → smaller timestamp → larger "time since" → higher priority.
+    return now.getTime() - p.lastPublishedAt.getTime();
+  };
+
+  let best: EvergreenPost | null = null;
+  let bestScore = -Infinity;
+  for (const p of eligible) {
+    const multiplier = 0.5 + (p.performanceScore ?? 0.5);
+    const score = agePriority(p) * multiplier;
+    if (score > bestScore) {
+      bestScore = score;
+      best = p;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// selectVariation
+// ---------------------------------------------------------------------------
+
+/**
+ * Cycle base → variation[0] → variation[1] → ... by
+ * `recycledCount % (variations.length + 1)`. Index 0 = base content's
+ * caption (variationId null); index N (N>0) = `variations[N-1]`.
+ */
+export function selectVariation(post: EvergreenPost): { variationId: string | null; caption: string } {
+  const variations = post.variations ?? [];
+  const cycleLength = variations.length + 1;
+  const index = cycleLength > 0 ? post.recycledCount % cycleLength : 0;
+
+  if (index === 0) {
+    return { variationId: null, caption: post.content.caption };
+  }
+  const variation = variations[index - 1];
+  return { variationId: variation.id, caption: variation.caption };
+}

--- a/src/campaigns/evergreen-scoring.service.ts
+++ b/src/campaigns/evergreen-scoring.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db } from '../drizzle/db';
 import { campaigns } from '../drizzle/schema/campaigns.schema';
 import {
@@ -235,6 +235,27 @@ export class EvergreenScoringService {
     return existing;
   }
 
+  /** Scopes a campaign id to its workspace, 404ing otherwise. Mirrors
+   *  `EvergreenService.loadOwnedCampaign` — every other evergreen mutation
+   *  binds `campaignId` to `workspaceId` this way before touching
+   *  category/post rows; `checkFreshness` must too, since it accepts
+   *  `campaignId` directly from the route and otherwise never verifies it
+   *  belongs to the caller's workspace (IDOR). */
+  private async loadOwnedCampaign(
+    workspaceId: string,
+    campaignId: string,
+  ): Promise<void> {
+    const [row] = await db
+      .select()
+      .from(campaigns)
+      .where(
+        and(eq(campaigns.id, campaignId), eq(campaigns.workspaceId, workspaceId)),
+      );
+    if (!row) {
+      throw new NotFoundException('Campaign not found');
+    }
+  }
+
   /**
    * Runs a cheap Groq staleness check against a pool post's base caption
    * and writes the verdict onto `isStale`/`staleReason`.
@@ -253,6 +274,11 @@ export class EvergreenScoringService {
     categoryId: string,
     postId: string,
   ): Promise<{ isStale: boolean; reason: string | null }> {
+    // IDOR guard (M2): bind campaignId to workspaceId BEFORE touching
+    // anything else, and before the graceful-degrade try/catch below —
+    // an unowned campaign must 404, not silently no-op.
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+
     const post = await this.loadOwnedPost(categoryId, postId);
     if (!post || post.campaignId !== campaignId) {
       return { isStale: false, reason: null };

--- a/src/campaigns/evergreen-scoring.service.ts
+++ b/src/campaigns/evergreen-scoring.service.ts
@@ -1,0 +1,293 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '../drizzle/db';
+import { campaigns } from '../drizzle/schema/campaigns.schema';
+import {
+  evergreenCategories,
+  evergreenOccurrences,
+  evergreenPosts,
+  type EvergreenPost,
+} from '../drizzle/schema/evergreen.schema';
+import { postMetricSnapshots } from '../drizzle/schema/post-metric-snapshots.schema';
+import { GroqService } from '../ai/groq.service';
+import { AiTokenService } from '../ai/services/ai-token.service';
+
+/**
+ * D2 (performance-aware scoring) + D3 (freshness guard) for evergreen pool
+ * posts. Deliberately a SEPARATE service from `EvergreenService` — scoring
+ * is a background/on-demand concern, never on the fire hot-path
+ * (`fireOccurrence`/`armCategory` never call into this file).
+ */
+@Injectable()
+export class EvergreenScoringService {
+  private readonly logger = new Logger(EvergreenScoringService.name);
+
+  constructor(
+    private readonly groq: GroqService,
+    private readonly aiTokens: AiTokenService,
+  ) {}
+
+  // ========================================================================
+  // D2 — performance-aware scoring
+  // ========================================================================
+
+  /**
+   * Recomputes `performanceScore` for every ACTIVE pool post in a campaign.
+   *
+   * For each post: gathers its `evergreenOccurrences` rows, collects their
+   * `postsRowId`s (the materialized `posts.id` each occurrence published
+   * to), reads the LATEST `post_metric_snapshots` row per `postsRowId`
+   * (mirrors `analytics.service.ts`'s "latest snapshot per post" basis —
+   * summing across snapshots would double-count since snapshots accumulate
+   * cumulative metrics over time), and sums `likesCount + commentsCount +
+   * sharesCount` per snapshot, then across the post's snapshots, as the
+   * post's total engagement.
+   *
+   * Engagement is then min-max normalized to [0,1] across the campaign's
+   * scored pool (0 = lowest-engagement post in the pool, 1 = highest).
+   * Posts with NO snapshots (never fired yet, or fired but no metrics
+   * synced) are left at `performanceScore = null` — unscored is neutral,
+   * never 0, since a 0 would wrongly sink an untested post to the bottom
+   * of the rotation picker before it ever got a fair shot.
+   *
+   * Never throws on an empty snapshot set (e.g. a brand-new campaign with
+   * no published occurrences yet) — it simply leaves every post's score at
+   * `null` and returns.
+   */
+  async recomputeScores(campaignId: string): Promise<void> {
+    const categoryRows = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.campaignId, campaignId));
+
+    const categoryIds = categoryRows.map((c) => c.id);
+    if (categoryIds.length === 0) {
+      this.logger.log(
+        `recomputeScores(${campaignId}): no categories — nothing to score.`,
+      );
+      return;
+    }
+
+    const allPostRows = await db
+      .select()
+      .from(evergreenPosts)
+      .where(eq(evergreenPosts.campaignId, campaignId));
+
+    const activePosts = allPostRows.filter((p) => p.status === 'active');
+    if (activePosts.length === 0) {
+      this.logger.log(
+        `recomputeScores(${campaignId}): no active pool posts — nothing to score.`,
+      );
+      return;
+    }
+
+    const occurrenceRows = await db
+      .select()
+      .from(evergreenOccurrences)
+      .where(eq(evergreenOccurrences.campaignId, campaignId));
+
+    // postId (evergreenPosts.id) -> Set of materialized posts.id rows it has
+    // ever published to.
+    const postsRowIdsByPost = new Map<string, Set<string>>();
+    for (const occ of occurrenceRows) {
+      if (!occ.postsRowId) continue;
+      const set = postsRowIdsByPost.get(occ.postIdRef) ?? new Set<string>();
+      set.add(occ.postsRowId);
+      postsRowIdsByPost.set(occ.postIdRef, set);
+    }
+
+    const allPostsRowIds = Array.from(
+      new Set(occurrenceRows.map((o) => o.postsRowId).filter((v): v is string => !!v)),
+    );
+
+    const snapshotRows =
+      allPostsRowIds.length > 0
+        ? await db
+            .select()
+            .from(postMetricSnapshots)
+            .where(inArray(postMetricSnapshots.postId, allPostsRowIds))
+        : [];
+
+    // Latest snapshot per posts-row-id.
+    const latestSnapshotByPostsRowId = new Map<
+      string,
+      (typeof snapshotRows)[number]
+    >();
+    for (const snap of snapshotRows) {
+      const existing = latestSnapshotByPostsRowId.get(snap.postId);
+      if (!existing || snap.snapshotAt.getTime() > existing.snapshotAt.getTime()) {
+        latestSnapshotByPostsRowId.set(snap.postId, snap);
+      }
+    }
+
+    // Total engagement per evergreen pool post (sum of its posts-rows'
+    // latest-snapshot engagement — a post recycled across multiple channels
+    // accumulates one posts-row per fire, so this sums across all of them).
+    const engagementByPostId = new Map<string, number>();
+    for (const post of activePosts) {
+      const postsRowIds = postsRowIdsByPost.get(post.id);
+      if (!postsRowIds || postsRowIds.size === 0) continue;
+
+      let total = 0;
+      let hasAnySnapshot = false;
+      for (const postsRowId of postsRowIds) {
+        const snap = latestSnapshotByPostsRowId.get(postsRowId);
+        if (!snap) continue;
+        hasAnySnapshot = true;
+        total +=
+          (snap.likesCount ?? 0) +
+          (snap.commentsCount ?? 0) +
+          (snap.sharesCount ?? 0);
+      }
+      if (hasAnySnapshot) {
+        engagementByPostId.set(post.id, total);
+      }
+    }
+
+    if (engagementByPostId.size === 0) {
+      this.logger.log(
+        `recomputeScores(${campaignId}): no posts have any metric snapshots yet — leaving all scores null.`,
+      );
+      return;
+    }
+
+    const engagementValues = Array.from(engagementByPostId.values());
+    const min = Math.min(...engagementValues);
+    const max = Math.max(...engagementValues);
+    const range = max - min;
+
+    const now = new Date();
+    for (const post of activePosts) {
+      const engagement = engagementByPostId.get(post.id);
+      if (engagement === undefined) {
+        // No snapshots — leave null (only write if it wasn't already null,
+        // to avoid needless churn — but a plain unconditional write is also
+        // safe; keep it simple and always write for now-null convergence).
+        if (post.performanceScore !== null) {
+          await db
+            .update(evergreenPosts)
+            .set({ performanceScore: null, updatedAt: now })
+            .where(eq(evergreenPosts.id, post.id));
+        }
+        continue;
+      }
+
+      // min-max normalize; a pool where every scored post has identical
+      // engagement (range === 0) scores everyone at 1 (all equally "best"
+      // among the scored set) rather than dividing by zero.
+      const score = range === 0 ? 1 : (engagement - min) / range;
+
+      await db
+        .update(evergreenPosts)
+        .set({ performanceScore: score, updatedAt: now })
+        .where(eq(evergreenPosts.id, post.id));
+    }
+  }
+
+  /**
+   * Weekly sweep: recomputes scores for every campaign that has evergreen
+   * content and is currently active. Fires Sunday 04:00 UTC — after the
+   * daily 03:00 UTC ad-insights/reconcile crons, deliberately off the
+   * publish hot-path.
+   */
+  @Cron('0 4 * * 0', { timeZone: 'UTC', name: 'evergreenScoring' })
+  async recomputeAllActiveScores(): Promise<void> {
+    const activeCampaigns = (await db.select().from(campaigns)).filter(
+      (c) => c.type === 'evergreen' && c.status === 'active',
+    );
+
+    if (activeCampaigns.length === 0) {
+      this.logger.verbose('evergreenScoring: no active evergreen campaigns');
+      return;
+    }
+
+    this.logger.log(
+      `evergreenScoring: recomputing scores for ${activeCampaigns.length} campaign(s)`,
+    );
+
+    for (const campaign of activeCampaigns) {
+      try {
+        await this.recomputeScores(campaign.id);
+      } catch (error) {
+        this.logger.error(
+          `evergreenScoring: failed to recompute scores for campaign ${campaign.id}: ${error}`,
+        );
+      }
+    }
+  }
+
+  // ========================================================================
+  // D3 — freshness guard
+  // ========================================================================
+
+  private async loadOwnedPost(
+    categoryId: string,
+    postId: string,
+  ): Promise<EvergreenPost | undefined> {
+    const [existing] = await db
+      .select()
+      .from(evergreenPosts)
+      .where(eq(evergreenPosts.id, postId));
+    if (!existing || existing.categoryId !== categoryId) {
+      return undefined;
+    }
+    return existing;
+  }
+
+  /**
+   * Runs a cheap Groq staleness check against a pool post's base caption
+   * and writes the verdict onto `isStale`/`staleReason`.
+   *
+   * GRACEFUL DEGRADATION: if Groq (or `AiTokenService.executeWithTokens`
+   * wrapping it — insufficient tokens, no active subscription, etc.) throws
+   * for ANY reason, this returns `{ isStale: false, reason: null }` and
+   * does NOT write to the post at all. A freshness check must never block
+   * the caller or false-flag a perfectly fine post just because the AI
+   * provider had a bad moment.
+   */
+  async checkFreshness(
+    workspaceId: string,
+    userId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+  ): Promise<{ isStale: boolean; reason: string | null }> {
+    const post = await this.loadOwnedPost(categoryId, postId);
+    if (!post || post.campaignId !== campaignId) {
+      return { isStale: false, reason: null };
+    }
+
+    const caption = post.content.caption;
+
+    try {
+      const { result: verdict } = await this.aiTokens.executeWithTokens(
+        workspaceId,
+        userId,
+        'freshness_check',
+        undefined,
+        `Freshness check: ${caption.substring(0, 100)}`,
+        async () => {
+          const result = await this.groq.checkFreshness(caption);
+          return { result, outputLength: (result.reason ?? '').length };
+        },
+      );
+
+      await db
+        .update(evergreenPosts)
+        .set({
+          isStale: verdict.isStale,
+          staleReason: verdict.reason,
+          updatedAt: new Date(),
+        })
+        .where(eq(evergreenPosts.id, postId));
+
+      return verdict;
+    } catch (error) {
+      this.logger.warn(
+        `checkFreshness(${postId}): Groq/token check failed, treating as not-stale (graceful): ${error}`,
+      );
+      return { isStale: false, reason: null };
+    }
+  }
+}

--- a/src/campaigns/evergreen-scoring.spec.ts
+++ b/src/campaigns/evergreen-scoring.spec.ts
@@ -1,0 +1,610 @@
+import { getTableName } from 'drizzle-orm';
+import type { EvergreenScoringService } from './evergreen-scoring.service';
+import type {
+  EvergreenCategory,
+  EvergreenOccurrence,
+  EvergreenPost,
+} from '../drizzle/schema/evergreen.schema';
+import type { Campaign } from '../drizzle/schema/campaigns.schema';
+import type { PostMetricSnapshot } from '../drizzle/schema/post-metric-snapshots.schema';
+
+// ==========================================================================
+// Fake-DB test harness — mirrors evergreen-variations.spec.ts's
+// `loadServiceWithFakeDb` / table-name-routed `buildFakeDb` pattern, scoped
+// to what EvergreenScoringService touches (campaigns, categories, posts,
+// occurrences, post_metric_snapshots).
+// ==========================================================================
+
+function buildFakeGroq(overrides: Partial<{ checkFreshness: jest.Mock }> = {}) {
+  return {
+    checkFreshness: jest.fn().mockResolvedValue({
+      isStale: false,
+      reason: null,
+    }),
+    ...overrides,
+  };
+}
+
+function buildFakeAiTokens() {
+  return {
+    executeWithTokens: jest.fn(
+      async (
+        _ws: string,
+        _u: string,
+        _op: string,
+        _pl: string | undefined,
+        _sum: string,
+        fn: () => Promise<{ result: unknown; outputLength?: number }>,
+      ) => {
+        const { result } = await fn();
+        return { result, usage: {} };
+      },
+    ),
+  };
+}
+
+function loadServiceWithFakeDb(
+  fakeDb: unknown,
+  groq: ReturnType<typeof buildFakeGroq> = buildFakeGroq(),
+  aiTokens: ReturnType<typeof buildFakeAiTokens> = buildFakeAiTokens(),
+): InstanceType<typeof EvergreenScoringService> {
+  let Ctor!: typeof EvergreenScoringService;
+  jest.isolateModules(() => {
+    jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    Ctor = require('./evergreen-scoring.service').EvergreenScoringService;
+  });
+  return new Ctor(groq as never, aiTokens as never);
+}
+
+afterEach(() => {
+  jest.dontMock('../drizzle/db');
+  jest.resetModules();
+});
+
+const WORKSPACE_ID = 'ws-1';
+const CAMPAIGN_ID = 'campaign-1';
+const CATEGORY_ID = 'category-1';
+const USER_ID = 'user-1';
+
+function makeCampaignRow(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: CAMPAIGN_ID,
+    workspaceId: WORKSPACE_ID,
+    createdById: 'user-1',
+    name: 'Evergreen A',
+    description: null,
+    type: 'evergreen',
+    status: 'active',
+    schedule: {
+      type: 'evergreen',
+      startDate: '2026-08-18',
+      weekdays: [],
+      times: [],
+      timezone: 'UTC',
+      blackoutDates: [],
+      loop: true,
+    },
+    contentSource: 'manual',
+    aiConfig: null,
+    libraryTemplateIds: [],
+    channelIds: [],
+    platforms: [],
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    launchedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as Campaign;
+}
+
+function makeCategoryRow(
+  overrides: Partial<EvergreenCategory> = {},
+): EvergreenCategory {
+  return {
+    id: CATEGORY_ID,
+    campaignId: CAMPAIGN_ID,
+    name: 'Tips',
+    color: 'emerald',
+    schedule: { weekdays: [1, 3], times: ['09:00'] },
+    channelIds: ['12'],
+    seasonal: null,
+    isActive: true,
+    rotationCursor: 0,
+    sortOrder: 0,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenCategory;
+}
+
+function makePostRow(overrides: Partial<EvergreenPost> = {}): EvergreenPost {
+  return {
+    id: 'post-1',
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    content: {
+      mode: 'manual',
+      postType: 'text',
+      caption: 'Hello world',
+      media: [],
+      threadParts: [],
+      templateIds: [],
+    },
+    variations: [],
+    recyclePolicy: { mode: 'forever' },
+    minGapHours: 0,
+    recycledCount: 0,
+    lastPublishedAt: null,
+    performanceScore: null,
+    isStale: false,
+    staleReason: null,
+    status: 'active',
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenPost;
+}
+
+function makeOccurrenceRow(
+  overrides: Partial<EvergreenOccurrence> = {},
+): EvergreenOccurrence {
+  return {
+    id: 'occ-1',
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    postIdRef: 'post-1',
+    variationId: null,
+    channelId: '12',
+    scheduledAt: new Date('2026-08-10T09:00:00Z'),
+    slotStatus: 'published',
+    postsRowId: 'posts-row-1',
+    jobId: null,
+    publishedAt: new Date('2026-08-10T09:00:00Z'),
+    lastError: null,
+    createdAt: new Date('2026-08-10T09:00:00Z'),
+    ...overrides,
+  } as EvergreenOccurrence;
+}
+
+function makeSnapshotRow(
+  overrides: Partial<PostMetricSnapshot> = {},
+): PostMetricSnapshot {
+  return {
+    id: 1,
+    postId: 'posts-row-1',
+    channelId: 12,
+    snapshotAt: new Date('2026-08-11T09:00:00Z'),
+    ageBucket: '24h',
+    likesCount: 10,
+    commentsCount: 5,
+    sharesCount: 2,
+    impressionsCount: 100,
+    reachCount: 90,
+    platformMetrics: {},
+    metricsSchemaVersion: 1,
+    fetchedAt: new Date('2026-08-11T09:00:00Z'),
+    syncStatus: 'ok',
+    ...overrides,
+  } as unknown as PostMetricSnapshot;
+}
+
+/** Table-name-routed, stateful fake db. SELECT always returns CLONES. */
+function buildFakeDb(fixture: {
+  campaignRows?: Campaign[];
+  categoryRows?: EvergreenCategory[];
+  postRows?: EvergreenPost[];
+  occurrenceRows?: EvergreenOccurrence[];
+  snapshotRows?: PostMetricSnapshot[];
+}) {
+  const campaignRows = fixture.campaignRows ?? [];
+  const categoryRows = fixture.categoryRows ?? [];
+  const postRows = fixture.postRows ?? [];
+  const occurrenceRows = fixture.occurrenceRows ?? [];
+  const snapshotRows = fixture.snapshotRows ?? [];
+
+  const updates: { posts: Record<string, unknown>[] } = { posts: [] };
+
+  function tableRows(name: string): Record<string, unknown>[] {
+    if (name === 'campaigns')
+      return campaignRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_categories')
+      return categoryRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_posts')
+      return postRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_occurrences')
+      return occurrenceRows as unknown as Record<string, unknown>[];
+    if (name === 'post_metric_snapshots')
+      return snapshotRows as unknown as Record<string, unknown>[];
+    return [];
+  }
+
+  const db = {
+    select: (_sel?: unknown) => ({
+      from: (table: unknown) => {
+        const name = getTableName(table as never);
+
+        const resolveAll = () =>
+          Promise.resolve(tableRows(name).map((r) => ({ ...r })));
+
+        return {
+          where: (whereCond: unknown) => {
+            const rows = tableRows(name);
+            const wanted = extractEqValues(whereCond);
+            const wantedIn = extractInValues(whereCond);
+            const filtered = rows.filter((r) => {
+              if (wanted.id !== undefined && r.id !== wanted.id) return false;
+              if (
+                wanted.campaign_id !== undefined &&
+                r.campaignId !== wanted.campaign_id
+              )
+                return false;
+              if (
+                wanted.category_id !== undefined &&
+                r.categoryId !== wanted.category_id
+              )
+                return false;
+              if (
+                wanted.post_id_ref !== undefined &&
+                r.postIdRef !== wanted.post_id_ref
+              )
+                return false;
+              if (wanted.post_id !== undefined && r.postId !== wanted.post_id)
+                return false;
+              if (
+                wantedIn.post_id !== undefined &&
+                !wantedIn.post_id.includes(r.postId as string)
+              )
+                return false;
+              return true;
+            });
+            // MANDATORY: clones, never fixture references.
+            return Promise.resolve(filtered.map((r) => ({ ...r })));
+          },
+          // Support `db.select().from(table)` with no `.where()` (used to
+          // load the full campaign/category/post pool up front).
+          then: (resolve: (v: unknown) => unknown) => resolveAll().then(resolve),
+        };
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (set: Record<string, unknown>) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const wanted = extractEqValues(whereCond);
+          const rows = tableRows(name);
+          const row = rows.find((r) => r.id === wanted.id);
+          if (row) {
+            Object.assign(row, set);
+            if (name === 'campaign_evergreen_posts') {
+              updates.posts.push({ ...row });
+            }
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+  };
+
+  return {
+    db,
+    updates,
+    campaignRows,
+    categoryRows,
+    postRows,
+    occurrenceRows,
+    snapshotRows,
+  };
+}
+
+function extractEqValues(cond: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let pendingColumn: string | undefined;
+  function walk(node: unknown): void {
+    if (node == null || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      for (const c of chunks) walk(c);
+      return;
+    }
+    const named = node as {
+      name?: string;
+      columnType?: string;
+      value?: unknown;
+    };
+    if (
+      typeof named.name === 'string' &&
+      typeof named.columnType === 'string'
+    ) {
+      pendingColumn = named.name;
+    } else if (
+      pendingColumn &&
+      named.value !== undefined &&
+      typeof named.value !== 'object'
+    ) {
+      result[pendingColumn] = named.value;
+      pendingColumn = undefined;
+    }
+  }
+  walk(cond);
+  return result;
+}
+
+/** Extracts `inArray(col, [...])`-style conditions: `{ post_id: ['a','b'] }`.
+ *  Drizzle's `inArray` SQL shape is `queryChunks: [prefix, <column>, " in ",
+ *  [<param>, <param>, ...], suffix]` — the params array is a plain array of
+ *  `{ value, encoder }` objects (not itself carrying a `columnType`), so it
+ *  needs its own branch distinct from the single-value `eq()` case. */
+function extractInValues(cond: unknown): Record<string, unknown[]> {
+  const result: Record<string, unknown[]> = {};
+  let pendingColumn: string | undefined;
+  function walk(node: unknown): void {
+    if (node == null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      // A raw array of param nodes (the `inArray` values list) — only
+      // meaningful if we just saw a column name.
+      const isParamList =
+        node.length > 0 &&
+        node.every(
+          (n) =>
+            n != null &&
+            typeof n === 'object' &&
+            'value' in (n as Record<string, unknown>) &&
+            !Array.isArray((n as { value?: unknown }).value),
+        );
+      if (pendingColumn && isParamList) {
+        result[pendingColumn] = node.map(
+          (n) => (n as { value: unknown }).value,
+        );
+        pendingColumn = undefined;
+        return;
+      }
+      for (const c of node) walk(c);
+      return;
+    }
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      for (const c of chunks) walk(c);
+      return;
+    }
+    const named = node as {
+      name?: string;
+      columnType?: string;
+      value?: unknown;
+    };
+    if (
+      typeof named.name === 'string' &&
+      typeof named.columnType === 'string'
+    ) {
+      pendingColumn = named.name;
+    }
+    // NOTE: deliberately no "else if (Array.isArray(named.value))" branch
+    // here — raw SQL text fragments (e.g. the `" in "` operator chunk) are
+    // ALSO shaped as `{ value: [...] }` with string contents, and would be
+    // wrongly captured as the values list. The actual param list only
+    // arrives as a raw top-level array (handled by the `Array.isArray(node)`
+    // branch above), never as a `.value` array on an object node.
+  }
+  walk(cond);
+  return result;
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+describe('EvergreenScoringService.recomputeScores', () => {
+  it('normalizes engagement to [0,1] across the pool and leaves unsnapshotted posts null', async () => {
+    const postHigh = makePostRow({ id: 'post-high' });
+    const postLow = makePostRow({ id: 'post-low' });
+    const postNone = makePostRow({ id: 'post-none' });
+
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [postHigh, postLow, postNone],
+      occurrenceRows: [
+        makeOccurrenceRow({
+          id: 'occ-high',
+          postIdRef: 'post-high',
+          postsRowId: 'posts-row-high',
+        }),
+        makeOccurrenceRow({
+          id: 'occ-low',
+          postIdRef: 'post-low',
+          postsRowId: 'posts-row-low',
+        }),
+        // post-none has no occurrence at all — never fired yet.
+      ],
+      snapshotRows: [
+        // High engagement post: 100 likes + 50 comments + 20 shares = 170
+        makeSnapshotRow({
+          id: 1,
+          postId: 'posts-row-high',
+          likesCount: 100,
+          commentsCount: 50,
+          sharesCount: 20,
+          snapshotAt: new Date('2026-08-11T09:00:00Z'),
+        }),
+        // Low engagement post: 1 like + 0 comments + 0 shares = 1
+        makeSnapshotRow({
+          id: 2,
+          postId: 'posts-row-low',
+          likesCount: 1,
+          commentsCount: 0,
+          sharesCount: 0,
+          snapshotAt: new Date('2026-08-11T09:00:00Z'),
+        }),
+      ],
+    });
+
+    const service = loadServiceWithFakeDb(db);
+    await service.recomputeScores(CAMPAIGN_ID);
+
+    const high = postRows.find((p) => p.id === 'post-high')!;
+    const low = postRows.find((p) => p.id === 'post-low')!;
+    const none = postRows.find((p) => p.id === 'post-none')!;
+
+    expect(high.performanceScore).toBe(1);
+    expect(low.performanceScore).toBe(0);
+    // Never-snapshotted post stays null — NOT 0 — so it isn't wrongly sunk
+    // in the rotation picker.
+    expect(none.performanceScore).toBeNull();
+  });
+
+  it('does not throw on an empty snapshot set (brand-new campaign) and leaves all scores null', async () => {
+    const post = makePostRow({ id: 'post-fresh' });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+      occurrenceRows: [],
+      snapshotRows: [],
+    });
+
+    const service = loadServiceWithFakeDb(db);
+
+    await expect(service.recomputeScores(CAMPAIGN_ID)).resolves.not.toThrow();
+    expect(postRows[0].performanceScore).toBeNull();
+  });
+
+  it('uses only the latest snapshot per post row (not a sum across snapshots)', async () => {
+    const post = makePostRow({ id: 'post-1' });
+    const other = makePostRow({ id: 'post-2' });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post, other],
+      occurrenceRows: [
+        makeOccurrenceRow({
+          id: 'occ-1',
+          postIdRef: 'post-1',
+          postsRowId: 'posts-row-1',
+        }),
+        makeOccurrenceRow({
+          id: 'occ-2',
+          postIdRef: 'post-2',
+          postsRowId: 'posts-row-2',
+        }),
+      ],
+      snapshotRows: [
+        // Older, larger snapshot — should be ignored in favor of latest.
+        makeSnapshotRow({
+          id: 1,
+          postId: 'posts-row-1',
+          likesCount: 1000,
+          commentsCount: 0,
+          sharesCount: 0,
+          snapshotAt: new Date('2026-08-01T00:00:00Z'),
+        }),
+        // Latest snapshot — this is what should count.
+        makeSnapshotRow({
+          id: 2,
+          postId: 'posts-row-1',
+          likesCount: 5,
+          commentsCount: 0,
+          sharesCount: 0,
+          snapshotAt: new Date('2026-08-15T00:00:00Z'),
+        }),
+        makeSnapshotRow({
+          id: 3,
+          postId: 'posts-row-2',
+          likesCount: 50,
+          commentsCount: 0,
+          sharesCount: 0,
+          snapshotAt: new Date('2026-08-15T00:00:00Z'),
+        }),
+      ],
+    });
+
+    const service = loadServiceWithFakeDb(db);
+    await service.recomputeScores(CAMPAIGN_ID);
+
+    const p1 = postRows.find((p) => p.id === 'post-1')!;
+    const p2 = postRows.find((p) => p.id === 'post-2')!;
+    // post-1's latest (5) << post-2's (50), so post-1 should score near 0,
+    // not near 1 (which the stale 1000-like snapshot would have produced).
+    expect(p1.performanceScore).toBe(0);
+    expect(p2.performanceScore).toBe(1);
+  });
+});
+
+describe('EvergreenScoringService.checkFreshness', () => {
+  it('sets isStale/staleReason from a Groq verdict and returns it', async () => {
+    const post = makePostRow({ id: 'post-1', isStale: false, staleReason: null });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const groq = buildFakeGroq({
+      checkFreshness: jest
+        .fn()
+        .mockResolvedValue({ isStale: true, reason: 'mentions 2025' }),
+    });
+    const service = loadServiceWithFakeDb(db, groq, buildFakeAiTokens());
+
+    const verdict = await service.checkFreshness(
+      WORKSPACE_ID,
+      USER_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      'post-1',
+    );
+
+    expect(verdict).toEqual({ isStale: true, reason: 'mentions 2025' });
+    const updated = postRows.find((p) => p.id === 'post-1')!;
+    expect(updated.isStale).toBe(true);
+    expect(updated.staleReason).toBe('mentions 2025');
+  });
+
+  it('on Groq throw: returns {isStale:false, reason:null} and does NOT write to the post', async () => {
+    const post = makePostRow({ id: 'post-1', isStale: false, staleReason: null });
+    const { db, updates } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const groq = buildFakeGroq({
+      checkFreshness: jest.fn().mockRejectedValue(new Error('groq boom')),
+    });
+    const service = loadServiceWithFakeDb(db, groq, buildFakeAiTokens());
+
+    const verdict = await service.checkFreshness(
+      WORKSPACE_ID,
+      USER_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      'post-1',
+    );
+
+    expect(verdict).toEqual({ isStale: false, reason: null });
+    expect(updates.posts).toHaveLength(0);
+  });
+
+  it('on executeWithTokens throw (e.g. insufficient tokens): returns {isStale:false, reason:null}, no write', async () => {
+    const post = makePostRow({ id: 'post-1', isStale: false, staleReason: null });
+    const { db, updates } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const groq = buildFakeGroq();
+    const aiTokens = {
+      executeWithTokens: jest
+        .fn()
+        .mockRejectedValue(new Error('insufficient tokens')),
+    };
+    const service = loadServiceWithFakeDb(db, groq, aiTokens as never);
+
+    const verdict = await service.checkFreshness(
+      WORKSPACE_ID,
+      USER_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      'post-1',
+    );
+
+    expect(verdict).toEqual({ isStale: false, reason: null });
+    expect(updates.posts).toHaveLength(0);
+  });
+});

--- a/src/campaigns/evergreen-scoring.spec.ts
+++ b/src/campaigns/evergreen-scoring.spec.ts
@@ -234,6 +234,11 @@ function buildFakeDb(fixture: {
             const filtered = rows.filter((r) => {
               if (wanted.id !== undefined && r.id !== wanted.id) return false;
               if (
+                wanted.workspace_id !== undefined &&
+                r.workspaceId !== wanted.workspace_id
+              )
+                return false;
+              if (
                 wanted.campaign_id !== undefined &&
                 r.campaignId !== wanted.campaign_id
               )
@@ -606,5 +611,63 @@ describe('EvergreenScoringService.checkFreshness', () => {
 
     expect(verdict).toEqual({ isStale: false, reason: null });
     expect(updates.posts).toHaveLength(0);
+  });
+
+  // FIX 2 (M2 — IDOR): checkFreshness validated the post -> category ->
+  // campaign chain but never bound campaignId to workspaceId, unlike every
+  // other evergreen mutation (which calls loadOwnedCampaign(workspaceId,
+  // campaignId) first). A caller from ANOTHER workspace who knows/guesses a
+  // campaignId/categoryId/postId triple could run (and pay for) a freshness
+  // check against content they don't own.
+  it('throws when campaignId does not belong to workspaceId (IDOR guard), and does not call Groq or write', async () => {
+    const post = makePostRow({ id: 'post-1', isStale: false, staleReason: null });
+    const { db, updates } = buildFakeDb({
+      // Campaign is owned by a DIFFERENT workspace than the caller passes.
+      campaignRows: [makeCampaignRow({ workspaceId: 'ws-other' })],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const groq = buildFakeGroq();
+    const service = loadServiceWithFakeDb(db, groq, buildFakeAiTokens());
+
+    await expect(
+      service.checkFreshness(
+        WORKSPACE_ID, // caller's workspace — does NOT own CAMPAIGN_ID
+        USER_ID,
+        CAMPAIGN_ID,
+        CATEGORY_ID,
+        'post-1',
+      ),
+    ).rejects.toThrow();
+
+    expect(groq.checkFreshness).not.toHaveBeenCalled();
+    expect(updates.posts).toHaveLength(0);
+  });
+
+  it('still works normally for a campaign the workspace owns (regression)', async () => {
+    const post = makePostRow({ id: 'post-1', isStale: false, staleReason: null });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow({ workspaceId: WORKSPACE_ID })],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const groq = buildFakeGroq({
+      checkFreshness: jest
+        .fn()
+        .mockResolvedValue({ isStale: true, reason: 'mentions 2025' }),
+    });
+    const service = loadServiceWithFakeDb(db, groq, buildFakeAiTokens());
+
+    const verdict = await service.checkFreshness(
+      WORKSPACE_ID,
+      USER_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      'post-1',
+    );
+
+    expect(verdict).toEqual({ isStale: true, reason: 'mentions 2025' });
+    const updated = postRows.find((p) => p.id === 'post-1')!;
+    expect(updated.isStale).toBe(true);
   });
 });

--- a/src/campaigns/evergreen-variations.spec.ts
+++ b/src/campaigns/evergreen-variations.spec.ts
@@ -1,0 +1,467 @@
+import { getTableName } from 'drizzle-orm';
+import type { EvergreenService } from './evergreen.service';
+import type { EvergreenCategory, EvergreenPost } from '../drizzle/schema/evergreen.schema';
+import type { Campaign } from '../drizzle/schema/campaigns.schema';
+
+// ==========================================================================
+// Fake-DB test harness — mirrors evergreen.service.spec.ts's
+// `loadServiceWithFakeDb` / table-name-routed `buildFakeDb` pattern exactly,
+// scoped down to just what generateVariations/addVariation/removeVariation
+// touch (campaigns, categories, posts).
+// ==========================================================================
+
+function buildFakePublishing() {
+  return {
+    materializeAndEnqueue: jest.fn().mockResolvedValue({
+      postId: 'materialized-post-1',
+      jobId: 'materialized-job-1',
+    }),
+    cancelSlotJob: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function buildFakeQueue() {
+  return {
+    add: jest.fn().mockResolvedValue({ id: 'queue-job-1' }),
+    getJob: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function buildFakeGroq(overrides: Partial<{ generateVariations: jest.Mock }> = {}) {
+  return {
+    generateVariations: jest.fn().mockResolvedValue(['V1', 'V2']),
+    ...overrides,
+  };
+}
+
+function buildFakeAiTokens() {
+  return {
+    executeWithTokens: jest.fn(
+      async (
+        _ws: string,
+        _u: string,
+        _op: string,
+        _pl: string | undefined,
+        _sum: string,
+        fn: () => Promise<{ result: unknown; outputLength?: number }>,
+      ) => {
+        const { result } = await fn();
+        return { result, usage: {} };
+      },
+    ),
+  };
+}
+
+function loadServiceWithFakeDb(
+  fakeDb: unknown,
+  publishing: ReturnType<typeof buildFakePublishing> = buildFakePublishing(),
+  queue: ReturnType<typeof buildFakeQueue> = buildFakeQueue(),
+  groq: ReturnType<typeof buildFakeGroq> = buildFakeGroq(),
+  aiTokens: ReturnType<typeof buildFakeAiTokens> = buildFakeAiTokens(),
+): InstanceType<typeof EvergreenService> {
+  let Ctor!: typeof EvergreenService;
+  jest.isolateModules(() => {
+    jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    Ctor = require('./evergreen.service').EvergreenService;
+  });
+  return new Ctor(publishing as never, queue as never, groq as never, aiTokens as never);
+}
+
+afterEach(() => {
+  jest.dontMock('../drizzle/db');
+  jest.resetModules();
+});
+
+const WORKSPACE_ID = 'ws-1';
+const CAMPAIGN_ID = 'campaign-1';
+const CATEGORY_ID = 'category-1';
+const POST_ID = 'post-1';
+const USER_ID = 'user-1';
+
+function makeCampaignRow(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: CAMPAIGN_ID,
+    workspaceId: WORKSPACE_ID,
+    createdById: 'user-1',
+    name: 'Evergreen A',
+    description: null,
+    type: 'evergreen',
+    status: 'draft',
+    schedule: {
+      type: 'evergreen',
+      startDate: '2026-08-18',
+      weekdays: [],
+      times: [],
+      timezone: 'UTC',
+      blackoutDates: [],
+      loop: true,
+    },
+    contentSource: 'manual',
+    aiConfig: null,
+    libraryTemplateIds: [],
+    channelIds: [],
+    platforms: [],
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    launchedAt: null,
+    ...overrides,
+  } as Campaign;
+}
+
+function makeCategoryRow(
+  overrides: Partial<EvergreenCategory> = {},
+): EvergreenCategory {
+  return {
+    id: CATEGORY_ID,
+    campaignId: CAMPAIGN_ID,
+    name: 'Tips',
+    color: 'emerald',
+    schedule: { weekdays: [1, 3], times: ['09:00'] },
+    channelIds: ['12'],
+    seasonal: null,
+    isActive: true,
+    rotationCursor: 0,
+    sortOrder: 0,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenCategory;
+}
+
+function makePostRow(overrides: Partial<EvergreenPost> = {}): EvergreenPost {
+  return {
+    id: POST_ID,
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    content: {
+      mode: 'manual',
+      postType: 'text',
+      caption: 'Hello world',
+      media: [],
+      threadParts: [],
+      templateIds: [],
+    },
+    variations: [],
+    recyclePolicy: { mode: 'forever' },
+    minGapHours: 0,
+    recycledCount: 0,
+    lastPublishedAt: null,
+    performanceScore: null,
+    isStale: false,
+    staleReason: null,
+    status: 'active',
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenPost;
+}
+
+interface FakeChannelRow {
+  id: number;
+  platform: string;
+}
+
+function makeChannelRow(
+  overrides: Partial<FakeChannelRow> = {},
+): FakeChannelRow {
+  return { id: 12, platform: 'facebook', ...overrides };
+}
+
+/** Table-name-routed, stateful fake db (scoped subset of the full harness in
+ *  evergreen.service.spec.ts). SELECT always returns CLONES — never the same
+ *  reference the fixture holds — per the mandatory no-in-place-mutation
+ *  ruling (this is exactly what catches accidental partial-write bugs: if
+ *  the service mutated the row in place before the DB write, this harness
+ *  wouldn't reveal it — but if it mutates a cloned/derived object and only
+ *  persists on success, the update() call itself is the assertion point). */
+function buildFakeDb(fixture: {
+  campaignRows?: Campaign[];
+  categoryRows?: EvergreenCategory[];
+  postRows?: EvergreenPost[];
+  channelRows?: FakeChannelRow[];
+}) {
+  const campaignRows = fixture.campaignRows ?? [];
+  const categoryRows = fixture.categoryRows ?? [];
+  const postRows = fixture.postRows ?? [];
+  const channelRows = fixture.channelRows ?? [];
+
+  const updates: { posts: Record<string, unknown>[] } = { posts: [] };
+
+  function tableRows(name: string): Record<string, unknown>[] {
+    if (name === 'campaigns')
+      return campaignRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_categories')
+      return categoryRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_posts')
+      return postRows as unknown as Record<string, unknown>[];
+    if (name === 'social_media_channels')
+      return channelRows as unknown as Record<string, unknown>[];
+    return [];
+  }
+
+  const db = {
+    select: (_sel?: unknown) => ({
+      from: (table: unknown) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const rows = tableRows(name);
+          const wanted = extractEqValues(whereCond);
+          const filtered = rows.filter((r) => {
+            if (wanted.id !== undefined && r.id !== wanted.id) return false;
+            if (
+              wanted.campaign_id !== undefined &&
+              r.campaignId !== wanted.campaign_id
+            )
+              return false;
+            if (
+              wanted.category_id !== undefined &&
+              r.categoryId !== wanted.category_id
+            )
+              return false;
+            if (wanted.channel_id !== undefined) {
+              const wantedChannelId = wanted.channel_id as string | number;
+              if (name === 'social_media_channels') {
+                if (String(r.id) !== String(wantedChannelId)) return false;
+              } else if (r.channelId !== wantedChannelId) {
+                return false;
+              }
+            }
+            return true;
+          });
+          // MANDATORY: clones, never fixture references.
+          return Promise.resolve(filtered.map((r) => ({ ...r })));
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (set: Record<string, unknown>) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const wanted = extractEqValues(whereCond);
+          const rows = tableRows(name);
+          const row = rows.find((r) => r.id === wanted.id);
+          if (row) {
+            Object.assign(row, set);
+            if (name === 'campaign_evergreen_posts') {
+              updates.posts.push({ ...row });
+            }
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+  };
+
+  return { db, updates, campaignRows, categoryRows, postRows, channelRows };
+}
+
+function extractEqValues(cond: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let pendingColumn: string | undefined;
+  function walk(node: unknown): void {
+    if (node == null || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      for (const c of chunks) walk(c);
+      return;
+    }
+    const named = node as {
+      name?: string;
+      columnType?: string;
+      value?: unknown;
+    };
+    if (
+      typeof named.name === 'string' &&
+      typeof named.columnType === 'string'
+    ) {
+      pendingColumn = named.name;
+    } else if (
+      pendingColumn &&
+      named.value !== undefined &&
+      typeof named.value !== 'object'
+    ) {
+      result[pendingColumn] = named.value;
+      pendingColumn = undefined;
+    }
+  }
+  walk(cond);
+  return result;
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+describe('EvergreenService.generateVariations', () => {
+  it('appends AI-generated variations (source: "ai") with unique ids, preserving existing variations', async () => {
+    const existingVariation = { id: 'v-existing', caption: 'Existing', source: 'manual' as const };
+    const post = makePostRow({ variations: [existingVariation] });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+      channelRows: [makeChannelRow()],
+    });
+    const groq = buildFakeGroq();
+    const aiTokens = buildFakeAiTokens();
+    const service = loadServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      buildFakeQueue(),
+      groq,
+      aiTokens,
+    );
+
+    const dto = await service.generateVariations(
+      WORKSPACE_ID,
+      USER_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      POST_ID,
+      2,
+    );
+
+    expect(groq.generateVariations).toHaveBeenCalledWith(
+      'Hello world',
+      'facebook',
+      2,
+    );
+    expect(aiTokens.executeWithTokens).toHaveBeenCalledTimes(1);
+    expect(aiTokens.executeWithTokens.mock.calls[0][2]).toBe('generate_variations');
+
+    const persisted = postRows[0].variations;
+    expect(persisted).toHaveLength(3);
+    expect(persisted[0]).toEqual(existingVariation);
+    const aiVariations = persisted.slice(1);
+    expect(aiVariations.map((v) => v.caption)).toEqual(['V1', 'V2']);
+    expect(aiVariations.every((v) => v.source === 'ai')).toBe(true);
+    const ids = aiVariations.map((v) => v.id);
+    expect(new Set(ids).size).toBe(2); // unique ids
+
+    const dtoPost = dto.categories[0].posts[0];
+    expect(dtoPost.variations).toHaveLength(3);
+  });
+
+  it('when groq.generateVariations throws: rejects and does NOT write to the post (no partial write)', async () => {
+    const existingVariation = { id: 'v-existing', caption: 'Existing', source: 'manual' as const };
+    const post = makePostRow({ variations: [existingVariation] });
+    const { db, postRows, updates } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+      channelRows: [makeChannelRow()],
+    });
+    const groq = buildFakeGroq({
+      generateVariations: jest.fn().mockRejectedValue(new Error('groq boom')),
+    });
+    const aiTokens = buildFakeAiTokens();
+    const service = loadServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      buildFakeQueue(),
+      groq,
+      aiTokens,
+    );
+
+    await expect(
+      service.generateVariations(
+        WORKSPACE_ID,
+        USER_ID,
+        CAMPAIGN_ID,
+        CATEGORY_ID,
+        POST_ID,
+        2,
+      ),
+    ).rejects.toThrow('groq boom');
+
+    // No partial write: post.variations unchanged, no update() call reached posts.
+    expect(postRows[0].variations).toEqual([existingVariation]);
+    expect(updates.posts).toHaveLength(0);
+  });
+
+  it('when executeWithTokens itself throws (e.g. insufficient tokens): rejects and does NOT write to the post', async () => {
+    const post = makePostRow({ variations: [] });
+    const { db, postRows, updates } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+      channelRows: [makeChannelRow()],
+    });
+    const groq = buildFakeGroq();
+    const aiTokens = {
+      executeWithTokens: jest.fn().mockRejectedValue(new Error('insufficient tokens')),
+    };
+    const service = loadServiceWithFakeDb(
+      db,
+      buildFakePublishing(),
+      buildFakeQueue(),
+      groq,
+      aiTokens as never,
+    );
+
+    await expect(
+      service.generateVariations(
+        WORKSPACE_ID,
+        USER_ID,
+        CAMPAIGN_ID,
+        CATEGORY_ID,
+        POST_ID,
+        2,
+      ),
+    ).rejects.toThrow('insufficient tokens');
+
+    expect(postRows[0].variations).toEqual([]);
+    expect(updates.posts).toHaveLength(0);
+  });
+});
+
+describe('EvergreenService.addVariation', () => {
+  it('appends a manual variation (source: "manual")', async () => {
+    const post = makePostRow({ variations: [] });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.addVariation(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, POST_ID, {
+      caption: 'Manual caption',
+    });
+
+    expect(postRows[0].variations).toHaveLength(1);
+    expect(postRows[0].variations[0]).toMatchObject({
+      caption: 'Manual caption',
+      source: 'manual',
+    });
+    expect(typeof postRows[0].variations[0].id).toBe('string');
+
+    expect(dto.categories[0].posts[0].variations).toHaveLength(1);
+  });
+});
+
+describe('EvergreenService.removeVariation', () => {
+  it('filters out the variation by id', async () => {
+    const keep = { id: 'v-keep', caption: 'Keep me', source: 'manual' as const };
+    const remove = { id: 'v-remove', caption: 'Remove me', source: 'ai' as const };
+    const post = makePostRow({ variations: [keep, remove] });
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [post],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.removeVariation(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      POST_ID,
+      'v-remove',
+    );
+
+    expect(postRows[0].variations).toEqual([keep]);
+    expect(dto.categories[0].posts[0].variations).toEqual([keep]);
+  });
+});

--- a/src/campaigns/evergreen.controller.spec.ts
+++ b/src/campaigns/evergreen.controller.spec.ts
@@ -1,0 +1,118 @@
+import { EvergreenController } from './evergreen.controller';
+import type {
+  CreateEvergreenCampaignDto,
+  CreateEvergreenCategoryDto,
+  UpdateEvergreenCategoryDto,
+  SetCategoryActiveDto,
+  CreateEvergreenPostDto,
+  UpdateEvergreenPostDto,
+} from './dto/evergreen.dto';
+
+describe('EvergreenController', () => {
+  const workspaceId = 'ws-1';
+  const campaignId = 'campaign-1';
+  const categoryId = 'category-1';
+  const postId = 'post-1';
+  const user = { userId: 'user-1', email: 'user@example.com' };
+
+  let mockService: {
+    createCampaign: jest.Mock;
+    addCategory: jest.Mock;
+    updateCategory: jest.Mock;
+    setCategoryActive: jest.Mock;
+    removeCategory: jest.Mock;
+    addPost: jest.Mock;
+    updatePost: jest.Mock;
+    removePost: jest.Mock;
+  };
+  let controller: EvergreenController;
+
+  beforeEach(() => {
+    mockService = {
+      createCampaign: jest.fn().mockResolvedValue({ id: campaignId }),
+      addCategory: jest.fn().mockResolvedValue({ id: campaignId }),
+      updateCategory: jest.fn().mockResolvedValue({ id: campaignId }),
+      setCategoryActive: jest.fn().mockResolvedValue({ id: campaignId }),
+      removeCategory: jest.fn().mockResolvedValue({ id: campaignId }),
+      addPost: jest.fn().mockResolvedValue({ id: campaignId }),
+      updatePost: jest.fn().mockResolvedValue({ id: campaignId }),
+      removePost: jest.fn().mockResolvedValue({ id: campaignId }),
+    };
+    controller = new EvergreenController(mockService as any);
+  });
+
+  it('createCampaign delegates to service.createCampaign(workspaceId, userId, dto)', async () => {
+    const dto = { name: 'Evergreen' } as CreateEvergreenCampaignDto;
+    const result = await controller.createCampaign(workspaceId, user, dto);
+    expect(mockService.createCampaign).toHaveBeenCalledWith(workspaceId, user.userId, dto);
+    expect(result).toEqual({ id: campaignId });
+  });
+
+  it('addCategory delegates to service.addCategory(workspaceId, campaignId, dto)', async () => {
+    const dto = { name: 'Tips' } as CreateEvergreenCategoryDto;
+    await controller.addCategory(workspaceId, campaignId, dto);
+    expect(mockService.addCategory).toHaveBeenCalledWith(workspaceId, campaignId, dto);
+  });
+
+  it('updateCategory delegates to service.updateCategory(workspaceId, campaignId, categoryId, dto)', async () => {
+    const dto = { name: 'Renamed' } as UpdateEvergreenCategoryDto;
+    await controller.updateCategory(workspaceId, campaignId, categoryId, dto);
+    expect(mockService.updateCategory).toHaveBeenCalledWith(
+      workspaceId,
+      campaignId,
+      categoryId,
+      dto,
+    );
+  });
+
+  it('setCategoryActive delegates to service.setCategoryActive(workspaceId, campaignId, categoryId, dto.isActive)', async () => {
+    const dto: SetCategoryActiveDto = { isActive: false };
+    await controller.setCategoryActive(workspaceId, campaignId, categoryId, dto);
+    expect(mockService.setCategoryActive).toHaveBeenCalledWith(
+      workspaceId,
+      campaignId,
+      categoryId,
+      false,
+    );
+  });
+
+  it('removeCategory delegates to service.removeCategory(workspaceId, campaignId, categoryId)', async () => {
+    await controller.removeCategory(workspaceId, campaignId, categoryId);
+    expect(mockService.removeCategory).toHaveBeenCalledWith(workspaceId, campaignId, categoryId);
+  });
+
+  it('addPost delegates to service.addPost(workspaceId, campaignId, categoryId, dto)', async () => {
+    const dto = { content: {} } as CreateEvergreenPostDto;
+    await controller.addPost(workspaceId, campaignId, categoryId, dto);
+    expect(mockService.addPost).toHaveBeenCalledWith(workspaceId, campaignId, categoryId, dto);
+  });
+
+  it('updatePost delegates to service.updatePost(workspaceId, campaignId, categoryId, postId, dto)', async () => {
+    const dto = { content: {} } as UpdateEvergreenPostDto;
+    await controller.updatePost(workspaceId, campaignId, categoryId, postId, dto);
+    expect(mockService.updatePost).toHaveBeenCalledWith(
+      workspaceId,
+      campaignId,
+      categoryId,
+      postId,
+      dto,
+    );
+  });
+
+  // NOTE ON ROUTE SHAPE: the EvergreenService.updatePost/removePost signatures
+  // (Task 4, already committed) are `(workspaceId, campaignId, categoryId, postId, ...)`
+  // — categoryId is a required positional arg. The route therefore carries
+  // `:catId` for these two endpoints (`.../categories/:catId/posts/:postId`)
+  // rather than the flatter `.../posts/:postId` shape, so the controller has
+  // something to pass. See task-5-report.md for the full rationale.
+
+  it('removePost delegates to service.removePost(workspaceId, campaignId, categoryId, postId)', async () => {
+    await controller.removePost(workspaceId, campaignId, categoryId, postId);
+    expect(mockService.removePost).toHaveBeenCalledWith(
+      workspaceId,
+      campaignId,
+      categoryId,
+      postId,
+    );
+  });
+});

--- a/src/campaigns/evergreen.controller.ts
+++ b/src/campaigns/evergreen.controller.ts
@@ -9,6 +9,8 @@ import {
   SetCategoryActiveDto,
   CreateEvergreenPostDto,
   UpdateEvergreenPostDto,
+  AddVariationDto,
+  GenerateVariationsDto,
 } from './dto/evergreen.dto';
 
 @Controller('campaigns')
@@ -113,5 +115,62 @@ export class EvergreenController {
     @Param('postId') postId: string,
   ) {
     return this.evergreen.removePost(workspaceId, id, catId, postId);
+  }
+
+  // ==========================================================================
+  // Variations (D1 — AI + manual)
+  //
+  // Same category-scoped path shape as the post CRUD routes above (Task 5's
+  // ruling: `EvergreenService`'s post-scoped methods require categoryId as a
+  // positional arg, so the route carries `:catId` rather than the flatter
+  // `.../posts/:postId/variations` shape).
+  // ==========================================================================
+
+  @Post(
+    'workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId/variations/generate',
+  )
+  @HttpCode(HttpStatus.OK)
+  async generateVariations(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+    @CurrentUser() user: { userId: string; email: string },
+    @Body() dto: GenerateVariationsDto,
+  ) {
+    return this.evergreen.generateVariations(
+      workspaceId,
+      user.userId,
+      id,
+      catId,
+      postId,
+      dto?.count,
+    );
+  }
+
+  @Post('workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId/variations')
+  @HttpCode(HttpStatus.OK)
+  async addVariation(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+    @Body() dto: AddVariationDto,
+  ) {
+    return this.evergreen.addVariation(workspaceId, id, catId, postId, dto);
+  }
+
+  @Delete(
+    'workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId/variations/:variationId',
+  )
+  @HttpCode(HttpStatus.OK)
+  async removeVariation(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+    @Param('variationId') variationId: string,
+  ) {
+    return this.evergreen.removeVariation(workspaceId, id, catId, postId, variationId);
   }
 }

--- a/src/campaigns/evergreen.controller.ts
+++ b/src/campaigns/evergreen.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Patch, Delete, Body, Param, UseGuards, HttpCode, Http
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { EvergreenService } from './evergreen.service';
+import { EvergreenScoringService } from './evergreen-scoring.service';
 import {
   CreateEvergreenCampaignDto,
   CreateEvergreenCategoryDto,
@@ -16,7 +17,10 @@ import {
 @Controller('campaigns')
 @UseGuards(JwtAuthGuard)
 export class EvergreenController {
-  constructor(private readonly evergreen: EvergreenService) {}
+  constructor(
+    private readonly evergreen: EvergreenService,
+    private readonly scoring: EvergreenScoringService,
+  ) {}
 
   // ==========================================================================
   // Campaign
@@ -172,5 +176,30 @@ export class EvergreenController {
     @Param('variationId') variationId: string,
   ) {
     return this.evergreen.removeVariation(workspaceId, id, catId, postId, variationId);
+  }
+
+  // ==========================================================================
+  // Freshness guard (D3) — same category-scoped path shape as the pool-post
+  // and variations routes above.
+  //
+  // Returns the re-assembled `EvergreenCampaignDto` (not just the bare
+  // verdict) so the frontend can refresh a single card's stale badge from
+  // this response the same way every other mutation route here does,
+  // without a second round-trip.
+  // ==========================================================================
+
+  @Post(
+    'workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId/freshness-check',
+  )
+  @HttpCode(HttpStatus.OK)
+  async checkFreshness(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+    @CurrentUser() user: { userId: string; email: string },
+  ) {
+    await this.scoring.checkFreshness(workspaceId, user.userId, id, catId, postId);
+    return this.evergreen.assembleEvergreen(id);
   }
 }

--- a/src/campaigns/evergreen.controller.ts
+++ b/src/campaigns/evergreen.controller.ts
@@ -1,0 +1,117 @@
+import { Controller, Post, Patch, Delete, Body, Param, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { EvergreenService } from './evergreen.service';
+import {
+  CreateEvergreenCampaignDto,
+  CreateEvergreenCategoryDto,
+  UpdateEvergreenCategoryDto,
+  SetCategoryActiveDto,
+  CreateEvergreenPostDto,
+  UpdateEvergreenPostDto,
+} from './dto/evergreen.dto';
+
+@Controller('campaigns')
+@UseGuards(JwtAuthGuard)
+export class EvergreenController {
+  constructor(private readonly evergreen: EvergreenService) {}
+
+  // ==========================================================================
+  // Campaign
+  // ==========================================================================
+
+  @Post('workspaces/:workspaceId/evergreen')
+  @HttpCode(HttpStatus.CREATED)
+  async createCampaign(
+    @Param('workspaceId') workspaceId: string,
+    @CurrentUser() user: { userId: string; email: string },
+    @Body() dto: CreateEvergreenCampaignDto,
+  ) {
+    return this.evergreen.createCampaign(workspaceId, user.userId, dto);
+  }
+
+  // ==========================================================================
+  // Categories
+  // ==========================================================================
+
+  @Post('workspaces/:workspaceId/evergreen/:id/categories')
+  @HttpCode(HttpStatus.OK)
+  async addCategory(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Body() dto: CreateEvergreenCategoryDto,
+  ) {
+    return this.evergreen.addCategory(workspaceId, id, dto);
+  }
+
+  @Patch('workspaces/:workspaceId/evergreen/:id/categories/:catId')
+  async updateCategory(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Body() dto: UpdateEvergreenCategoryDto,
+  ) {
+    return this.evergreen.updateCategory(workspaceId, id, catId, dto);
+  }
+
+  @Patch('workspaces/:workspaceId/evergreen/:id/categories/:catId/active')
+  async setCategoryActive(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Body() dto: SetCategoryActiveDto,
+  ) {
+    return this.evergreen.setCategoryActive(workspaceId, id, catId, dto.isActive);
+  }
+
+  @Delete('workspaces/:workspaceId/evergreen/:id/categories/:catId')
+  @HttpCode(HttpStatus.OK)
+  async removeCategory(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+  ) {
+    return this.evergreen.removeCategory(workspaceId, id, catId);
+  }
+
+  // ==========================================================================
+  // Pool posts
+  // ==========================================================================
+
+  @Post('workspaces/:workspaceId/evergreen/:id/categories/:catId/posts')
+  @HttpCode(HttpStatus.OK)
+  async addPost(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Body() dto: CreateEvergreenPostDto,
+  ) {
+    return this.evergreen.addPost(workspaceId, id, catId, dto);
+  }
+
+  // NOTE: EvergreenService.updatePost/removePost require categoryId as a
+  // positional arg (Task 4, already committed), so these routes carry
+  // `:catId` even though the design doc's flatter `.../posts/:postId` shape
+  // does not. See task-5-report.md for the full rationale.
+  @Patch('workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId')
+  async updatePost(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+    @Body() dto: UpdateEvergreenPostDto,
+  ) {
+    return this.evergreen.updatePost(workspaceId, id, catId, postId, dto);
+  }
+
+  @Delete('workspaces/:workspaceId/evergreen/:id/categories/:catId/posts/:postId')
+  @HttpCode(HttpStatus.OK)
+  async removePost(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+    @Param('catId') catId: string,
+    @Param('postId') postId: string,
+  ) {
+    return this.evergreen.removePost(workspaceId, id, catId, postId);
+  }
+}

--- a/src/campaigns/evergreen.service.spec.ts
+++ b/src/campaigns/evergreen.service.spec.ts
@@ -1,0 +1,595 @@
+import { getTableName } from 'drizzle-orm';
+import type { EvergreenService } from './evergreen.service';
+import type {
+  EvergreenCategory,
+  EvergreenPost,
+} from '../drizzle/schema/evergreen.schema';
+import type { Campaign } from '../drizzle/schema/campaigns.schema';
+
+// ==========================================================================
+// Fake-DB test harness — mirrors campaigns.service.spec.ts's
+// `loadServiceWithFakeDb` / table-name-routed `buildFakeDb` pattern exactly.
+// ==========================================================================
+
+/**
+ * Loads a fresh, isolated copy of the service module with `../drizzle/db`
+ * mocked to `fakeDb`. `jest.isolateModules` scopes the mock + require to
+ * this call only, so tests don't leak mocks between each other.
+ */
+function loadServiceWithFakeDb(fakeDb: unknown): InstanceType<typeof EvergreenService> {
+  let Ctor!: typeof EvergreenService;
+  jest.isolateModules(() => {
+    jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    Ctor = require('./evergreen.service').EvergreenService;
+  });
+  return new Ctor();
+}
+
+afterEach(() => {
+  jest.dontMock('../drizzle/db');
+  jest.resetModules();
+});
+
+const WORKSPACE_ID = 'ws-1';
+const CAMPAIGN_ID = 'campaign-1';
+const CATEGORY_ID = 'category-1';
+const POST_ID = 'post-1';
+
+function makeCampaignRow(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: CAMPAIGN_ID,
+    workspaceId: WORKSPACE_ID,
+    createdById: 'user-1',
+    name: 'Evergreen A',
+    description: null,
+    type: 'evergreen',
+    status: 'draft',
+    schedule: {
+      type: 'evergreen',
+      startDate: '2026-08-18',
+      weekdays: [],
+      times: [],
+      timezone: 'UTC',
+      blackoutDates: [],
+      loop: true,
+    },
+    contentSource: 'manual',
+    aiConfig: null,
+    libraryTemplateIds: [],
+    channelIds: [],
+    platforms: [],
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    launchedAt: null,
+    ...overrides,
+  } as Campaign;
+}
+
+function makeCategoryRow(overrides: Partial<EvergreenCategory> = {}): EvergreenCategory {
+  return {
+    id: CATEGORY_ID,
+    campaignId: CAMPAIGN_ID,
+    name: 'Tips',
+    color: 'emerald',
+    schedule: { weekdays: [1, 3], times: ['09:00'] },
+    channelIds: ['12'],
+    seasonal: null,
+    isActive: true,
+    rotationCursor: 0,
+    sortOrder: 0,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenCategory;
+}
+
+function makePostRow(overrides: Partial<EvergreenPost> = {}): EvergreenPost {
+  return {
+    id: POST_ID,
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    content: {
+      mode: 'manual',
+      postType: 'text',
+      caption: 'Hello world',
+      media: [],
+      threadParts: [],
+      templateIds: [],
+    },
+    variations: [],
+    recyclePolicy: { mode: 'forever' },
+    minGapHours: 0,
+    recycledCount: 0,
+    lastPublishedAt: null,
+    performanceScore: null,
+    isStale: false,
+    staleReason: null,
+    status: 'active',
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    updatedAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenPost;
+}
+
+/**
+ * Table-name-routed, stateful fake db. Selects filter the in-memory fixture
+ * arrays by campaignId/categoryId where relevant (good enough for this
+ * service's simple equality-only where-clauses); updates/deletes/inserts
+ * write through to the live fixture so a later select in the same call sees
+ * the new state. SELECT always returns CLONES — never the same reference the
+ * fixture holds — per the mandatory no-in-place-mutation ruling.
+ */
+function buildFakeDb(fixture: {
+  campaignRows?: Campaign[];
+  categoryRows?: EvergreenCategory[];
+  postRows?: EvergreenPost[];
+}) {
+  const campaignRows = fixture.campaignRows ?? [];
+  const categoryRows = fixture.categoryRows ?? [];
+  const postRows = fixture.postRows ?? [];
+
+  const inserts: {
+    campaigns: unknown[];
+    categories: unknown[];
+    posts: unknown[];
+  } = { campaigns: [], categories: [], posts: [] };
+  const deletes: { categoryIds: string[]; postIds: string[] } = {
+    categoryIds: [],
+    postIds: [],
+  };
+
+  function tableRows(name: string): Record<string, unknown>[] {
+    if (name === 'campaigns') return campaignRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_categories')
+      return categoryRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_posts')
+      return postRows as unknown as Record<string, unknown>[];
+    return [];
+  }
+
+  const db = {
+    select: (_sel?: unknown) => ({
+      from: (table: unknown) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const rows = tableRows(name);
+          const wanted = extractEqValues(whereCond);
+          const filtered = rows.filter((r) => {
+            if (wanted.id !== undefined && r.id !== wanted.id) return false;
+            if (wanted.campaign_id !== undefined && r.campaignId !== wanted.campaign_id)
+              return false;
+            if (wanted.category_id !== undefined && r.categoryId !== wanted.category_id)
+              return false;
+            return true;
+          });
+          // MANDATORY: clones, never fixture references.
+          return Promise.resolve(filtered.map((r) => ({ ...r })));
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      // Performs the write immediately (matching real drizzle: `.values()`
+      // itself is the awaitable query — `.returning()` is optional chaining
+      // on top of it, not a separate execution step). Returning a thenable
+      // object with both `.then()` (direct await) and `.returning()` covers
+      // both call styles the service uses.
+      values: (vals: Record<string, unknown>) => {
+        const name = getTableName(table as never);
+        let row: Record<string, unknown> | undefined;
+        if (name === 'campaigns') {
+          row = {
+            id: `campaign-new-${campaignRows.length + 1}`,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            launchedAt: null,
+            ...vals,
+          };
+          campaignRows.push(row as unknown as Campaign);
+          inserts.campaigns.push(vals);
+        } else if (name === 'campaign_evergreen_categories') {
+          row = {
+            id: `cat-${categoryRows.length + 1}`,
+            rotationCursor: 0,
+            sortOrder: 0,
+            seasonal: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            ...vals,
+          };
+          categoryRows.push(row as unknown as EvergreenCategory);
+          inserts.categories.push(vals);
+        } else if (name === 'campaign_evergreen_posts') {
+          row = {
+            id: `post-${postRows.length + 1}`,
+            recycledCount: 0,
+            lastPublishedAt: null,
+            performanceScore: null,
+            isStale: false,
+            staleReason: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            ...vals,
+          };
+          postRows.push(row as unknown as EvergreenPost);
+          inserts.posts.push(vals);
+        }
+
+        const resultRows = row ? [{ ...row }] : [];
+        const query = Promise.resolve(resultRows) as Promise<unknown[]> & {
+          returning: () => Promise<unknown[]>;
+        };
+        query.returning = () => Promise.resolve(resultRows);
+        return query;
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (set: Record<string, unknown>) => ({
+        where: (whereCond: unknown) => {
+          const name = getTableName(table as never);
+          const wanted = extractEqValues(whereCond);
+          const rows = tableRows(name);
+          const row = rows.find((r) => r.id === wanted.id);
+          if (row) Object.assign(row, set);
+          return Promise.resolve();
+        },
+      }),
+    }),
+    delete: (table: unknown) => ({
+      where: (whereCond: unknown) => {
+        const name = getTableName(table as never);
+        const wanted = extractEqValues(whereCond);
+        if (name === 'campaign_evergreen_categories') {
+          const idx = categoryRows.findIndex((r) => r.id === wanted.id);
+          if (idx !== -1) {
+            deletes.categoryIds.push(categoryRows[idx].id);
+            categoryRows.splice(idx, 1);
+          }
+        }
+        if (name === 'campaign_evergreen_posts') {
+          if (wanted.id !== undefined) {
+            const idx = postRows.findIndex((r) => r.id === wanted.id);
+            if (idx !== -1) {
+              deletes.postIds.push(postRows[idx].id);
+              postRows.splice(idx, 1);
+            }
+          } else if (wanted.category_id !== undefined) {
+            // Bulk delete-by-category (the removeCategory cascade path) —
+            // no `id` in the where clause, only `categoryId`.
+            for (let i = postRows.length - 1; i >= 0; i--) {
+              if (postRows[i].categoryId === wanted.category_id) {
+                deletes.postIds.push(postRows[i].id);
+                postRows.splice(i, 1);
+              }
+            }
+          }
+        }
+        return Promise.resolve();
+      },
+    }),
+  };
+
+  return { db, inserts, deletes, campaignRows, categoryRows, postRows };
+}
+
+/** Walk an `eq(col, v)` / `and(eq(colA, v1), eq(colB, v2))` drizzle condition
+ *  tree into `{ dbColumnName: value }`. */
+function extractEqValues(cond: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let pendingColumn: string | undefined;
+  function walk(node: unknown): void {
+    if (node == null || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      for (const c of chunks) walk(c);
+      return;
+    }
+    const named = node as { name?: string; columnType?: string; value?: unknown };
+    if (typeof named.name === 'string' && typeof named.columnType === 'string') {
+      pendingColumn = named.name;
+    } else if (pendingColumn && named.value !== undefined && typeof named.value !== 'object') {
+      result[pendingColumn] = named.value;
+      pendingColumn = undefined;
+    }
+  }
+  walk(cond);
+  return result;
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+describe('EvergreenService.createCampaign', () => {
+  it("inserts a campaigns row with type='evergreen', status='draft', and an evergreen schedule", async () => {
+    const { db, inserts } = buildFakeDb({});
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.createCampaign(WORKSPACE_ID, 'user-1', {
+      name: 'Evergreen A',
+      startDate: '2026-08-18',
+      timezone: 'UTC',
+      channelIds: ['12'],
+    });
+
+    expect(inserts.campaigns).toHaveLength(1);
+    const inserted = inserts.campaigns[0] as {
+      type: string;
+      status: string;
+      schedule: { type: string; weekdays: number[]; times: string[]; loop: boolean };
+      channelIds: string[];
+    };
+    expect(inserted.type).toBe('evergreen');
+    expect(inserted.status).toBe('draft');
+    expect(inserted.schedule.type).toBe('evergreen');
+    expect(inserted.schedule.weekdays).toEqual([]);
+    expect(inserted.schedule.times).toEqual([]);
+    expect(inserted.schedule.loop).toBe(true);
+    expect(inserted.channelIds).toEqual(['12']);
+
+    expect(dto.type).toBe('evergreen');
+    expect(dto.status).toBe('draft');
+    expect(dto.categories).toEqual([]);
+    expect(dto.upNext).toEqual([]);
+  });
+
+  it('defaults loop to true and blackoutDates to [] when omitted', async () => {
+    const { db, inserts } = buildFakeDb({});
+    const service = loadServiceWithFakeDb(db);
+
+    await service.createCampaign(WORKSPACE_ID, 'user-1', {
+      name: 'Evergreen B',
+      startDate: '2026-08-18',
+      timezone: 'UTC',
+      channelIds: [],
+    });
+
+    const inserted = inserts.campaigns[0] as {
+      schedule: { loop: boolean; blackoutDates: string[] };
+    };
+    expect(inserted.schedule.loop).toBe(true);
+    expect(inserted.schedule.blackoutDates).toEqual([]);
+  });
+
+  it('respects an explicit loop:false and blackoutDates', async () => {
+    const { db, inserts } = buildFakeDb({});
+    const service = loadServiceWithFakeDb(db);
+
+    await service.createCampaign(WORKSPACE_ID, 'user-1', {
+      name: 'Evergreen C',
+      startDate: '2026-08-18',
+      timezone: 'UTC',
+      channelIds: [],
+      loop: false,
+      blackoutDates: ['2026-12-25'],
+    });
+
+    const inserted = inserts.campaigns[0] as {
+      schedule: { loop: boolean; blackoutDates: string[] };
+    };
+    expect(inserted.schedule.loop).toBe(false);
+    expect(inserted.schedule.blackoutDates).toEqual(['2026-12-25']);
+  });
+});
+
+describe('EvergreenService.addCategory', () => {
+  it('persists a category row and returns the assembled campaign with the new category', async () => {
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.addCategory(WORKSPACE_ID, CAMPAIGN_ID, {
+      name: 'Tips',
+      color: 'emerald',
+      schedule: { weekdays: [1, 3], times: ['09:00'] },
+      channelIds: ['12'],
+    });
+
+    expect(inserts.categories).toHaveLength(1);
+    const inserted = inserts.categories[0] as { campaignId: string; name: string };
+    expect(inserted.campaignId).toBe(CAMPAIGN_ID);
+    expect(inserted.name).toBe('Tips');
+
+    expect(dto.categories).toHaveLength(1);
+    expect(dto.categories[0].name).toBe('Tips');
+    expect(dto.categories[0].posts).toEqual([]);
+  });
+});
+
+describe('EvergreenService.updateCategory', () => {
+  it('patches the category fields and returns the assembled campaign', async () => {
+    const { db } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.updateCategory(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, {
+      name: 'Tips & Tricks',
+    });
+
+    expect(dto.categories[0].name).toBe('Tips & Tricks');
+  });
+});
+
+describe('EvergreenService.setCategoryActive', () => {
+  it('flips isActive and returns the assembled campaign', async () => {
+    const { db } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow({ isActive: true })],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.setCategoryActive(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, false);
+
+    expect(dto.categories[0].isActive).toBe(false);
+  });
+});
+
+describe('EvergreenService.removeCategory', () => {
+  it('cascades: removes the category and its posts', async () => {
+    const { db, deletes, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [makePostRow(), makePostRow({ id: 'post-2' })],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.removeCategory(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID);
+
+    expect(deletes.categoryIds).toContain(CATEGORY_ID);
+    expect(deletes.postIds.sort()).toEqual(['post-1', 'post-2']);
+    expect(postRows).toHaveLength(0);
+    expect(dto.categories).toEqual([]);
+  });
+});
+
+describe('EvergreenService.addPost', () => {
+  it('defaults recyclePolicy to {mode: "forever"} when omitted', async () => {
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.addPost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, {
+      content: {
+        mode: 'manual',
+        postType: 'text',
+        caption: 'Hello',
+        media: [],
+        threadParts: [],
+        templateIds: [],
+      },
+    });
+
+    expect(inserts.posts).toHaveLength(1);
+    const inserted = inserts.posts[0] as {
+      recyclePolicy: { mode: string };
+      variations: unknown[];
+      status: string;
+    };
+    expect(inserted.recyclePolicy).toEqual({ mode: 'forever' });
+    expect(inserted.variations).toEqual([]);
+    expect(inserted.status).toBe('active');
+
+    expect(dto.categories[0].posts).toHaveLength(1);
+    expect(dto.categories[0].posts[0].recyclePolicy).toEqual({ mode: 'forever' });
+  });
+
+  it('respects an explicit recyclePolicy', async () => {
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    await service.addPost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, {
+      content: {
+        mode: 'manual',
+        postType: 'text',
+        caption: 'Hello',
+        media: [],
+        threadParts: [],
+        templateIds: [],
+      },
+      recyclePolicy: { mode: 'maxCount', maxCount: 5 },
+    });
+
+    const inserted = inserts.posts[0] as { recyclePolicy: { mode: string; maxCount?: number } };
+    expect(inserted.recyclePolicy).toEqual({ mode: 'maxCount', maxCount: 5 });
+  });
+});
+
+describe('EvergreenService.updatePost', () => {
+  it('patches the post fields and returns the assembled campaign', async () => {
+    const { db } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [makePostRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.updatePost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, POST_ID, {
+      minGapHours: 12,
+    });
+
+    expect(dto.categories[0].posts[0].minGapHours).toBe(12);
+  });
+});
+
+describe('EvergreenService.removePost', () => {
+  it('removes the post row', async () => {
+    const { db, postRows } = buildFakeDb({
+      campaignRows: [makeCampaignRow()],
+      categoryRows: [makeCategoryRow()],
+      postRows: [makePostRow(), makePostRow({ id: 'post-2' })],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.removePost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, POST_ID);
+
+    expect(postRows.map((p) => p.id)).toEqual(['post-2']);
+    expect(dto.categories[0].posts).toHaveLength(1);
+    expect(dto.categories[0].posts[0].id).toBe('post-2');
+  });
+});
+
+describe('EvergreenService.assembleEvergreen', () => {
+  it('computes each category nextRunAt via computeNextCategoryFire and returns upNext: []', async () => {
+    const campaignRow = makeCampaignRow({
+      schedule: {
+        type: 'evergreen',
+        startDate: '2026-08-18',
+        weekdays: [],
+        times: [],
+        timezone: 'UTC',
+        blackoutDates: [],
+        loop: true,
+      },
+    });
+    const categoryRow = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const { db } = buildFakeDb({
+      campaignRows: [campaignRow],
+      categoryRows: [categoryRow],
+      postRows: [makePostRow()],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.assembleEvergreen(CAMPAIGN_ID);
+
+    expect(dto.id).toBe(CAMPAIGN_ID);
+    expect(dto.categories).toHaveLength(1);
+    expect(dto.categories[0].id).toBe(CATEGORY_ID);
+    expect(dto.categories[0].posts).toHaveLength(1);
+    expect(dto.categories[0].nextRunAt).not.toBeNull();
+    // Mon/Wed/Fri 09:00 UTC after 'now' — just assert it parses to a real date.
+    expect(new Date(dto.categories[0].nextRunAt as string).getTime()).not.toBeNaN();
+    expect(dto.upNext).toEqual([]);
+  });
+
+  it('returns nextRunAt: null for a category with no weekdays/times configured', async () => {
+    const campaignRow = makeCampaignRow();
+    const categoryRow = makeCategoryRow({ schedule: { weekdays: [], times: [] } });
+    const { db } = buildFakeDb({
+      campaignRows: [campaignRow],
+      categoryRows: [categoryRow],
+      postRows: [],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.assembleEvergreen(CAMPAIGN_ID);
+
+    expect(dto.categories[0].nextRunAt).toBeNull();
+  });
+
+  it('throws NotFoundException when the campaign does not exist', async () => {
+    const { db } = buildFakeDb({});
+    const service = loadServiceWithFakeDb(db);
+
+    await expect(service.assembleEvergreen('missing-id')).rejects.toThrow('Campaign not found');
+  });
+});

--- a/src/campaigns/evergreen.service.spec.ts
+++ b/src/campaigns/evergreen.service.spec.ts
@@ -1068,4 +1068,50 @@ describe('EvergreenService.fireOccurrence', () => {
 
     expect(queue.add).not.toHaveBeenCalled();
   });
+
+  // FIX 3 (m1 — orphan posts row on BullMQ retry): if a prior attempt threw
+  // AFTER materializeAndEnqueue succeeded but BEFORE the status-flip write
+  // (postsRowId/jobId/slotStatus), the occurrence row is left with
+  // postsRowId already set but slotStatus still nominally 'scheduled'. A
+  // BullMQ retry (attempts:3) re-running fireOccurrence must NOT
+  // re-materialize — that would insert a SECOND orphan `posts` row — it
+  // should treat the occurrence as already-fired and just re-arm the next
+  // fire (self-heal stays intact).
+  it('when the occurrence already has postsRowId set (retry after a post-materialize crash): does NOT call materializeAndEnqueue again, but still arms the next fire', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    const post = makePostRow();
+    // Simulates the crash window: materializeAndEnqueue already ran and
+    // wrote postsRowId/jobId on a prior attempt, but slotStatus never got
+    // flipped off 'scheduled' (the write that would have flipped it is what
+    // threw / never ran).
+    const occurrence = makeOccurrenceRow({
+      postsRowId: 'already-materialized-post-1',
+      jobId: 'already-materialized-job-1',
+      slotStatus: 'scheduled',
+    });
+    const { db, occurrenceRows, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [post],
+      occurrenceRows: [occurrence],
+      channelRows: [makeChannelRow()],
+    });
+    const publishing = buildFakePublishing();
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await service.fireOccurrence(OCCURRENCE_ID);
+
+    expect(publishing.materializeAndEnqueue).not.toHaveBeenCalled();
+    // Occurrence is left consistent — still pointing at the ALREADY
+    // materialized post, flipped to published rather than orphaned mid-state.
+    expect(occurrenceRows[0].postsRowId).toBe('already-materialized-post-1');
+    expect(occurrenceRows[0].slotStatus).toBe('published');
+    // Self-heal stays intact — next fire still armed.
+    expect(inserts.occurrences).toHaveLength(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/campaigns/evergreen.service.spec.ts
+++ b/src/campaigns/evergreen.service.spec.ts
@@ -2,6 +2,7 @@ import { getTableName } from 'drizzle-orm';
 import type { EvergreenService } from './evergreen.service';
 import type {
   EvergreenCategory,
+  EvergreenOccurrence,
   EvergreenPost,
 } from '../drizzle/schema/evergreen.schema';
 import type { Campaign } from '../drizzle/schema/campaigns.schema';
@@ -11,19 +12,42 @@ import type { Campaign } from '../drizzle/schema/campaigns.schema';
 // `loadServiceWithFakeDb` / table-name-routed `buildFakeDb` pattern exactly.
 // ==========================================================================
 
+/** Minimal fake `CampaignPublishingService` — jest.fn mocks, no real DB/queue. */
+function buildFakePublishing() {
+  return {
+    materializeAndEnqueue: jest.fn().mockResolvedValue({
+      postId: 'materialized-post-1',
+      jobId: 'materialized-job-1',
+    }),
+    cancelSlotJob: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Minimal fake BullMQ `Queue` — jest.fn mocks, no real Redis. */
+function buildFakeQueue() {
+  return {
+    add: jest.fn().mockResolvedValue({ id: 'queue-job-1' }),
+    getJob: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 /**
  * Loads a fresh, isolated copy of the service module with `../drizzle/db`
  * mocked to `fakeDb`. `jest.isolateModules` scopes the mock + require to
  * this call only, so tests don't leak mocks between each other.
  */
-function loadServiceWithFakeDb(fakeDb: unknown): InstanceType<typeof EvergreenService> {
+function loadServiceWithFakeDb(
+  fakeDb: unknown,
+  publishing: ReturnType<typeof buildFakePublishing> = buildFakePublishing(),
+  queue: ReturnType<typeof buildFakeQueue> = buildFakeQueue(),
+): InstanceType<typeof EvergreenService> {
   let Ctor!: typeof EvergreenService;
   jest.isolateModules(() => {
     jest.doMock('../drizzle/db', () => ({ db: fakeDb }));
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     Ctor = require('./evergreen.service').EvergreenService;
   });
-  return new Ctor();
+  return new Ctor(publishing as never, queue as never);
 }
 
 afterEach(() => {
@@ -66,7 +90,9 @@ function makeCampaignRow(overrides: Partial<Campaign> = {}): Campaign {
   } as Campaign;
 }
 
-function makeCategoryRow(overrides: Partial<EvergreenCategory> = {}): EvergreenCategory {
+function makeCategoryRow(
+  overrides: Partial<EvergreenCategory> = {},
+): EvergreenCategory {
   return {
     id: CATEGORY_ID,
     campaignId: CAMPAIGN_ID,
@@ -112,6 +138,40 @@ function makePostRow(overrides: Partial<EvergreenPost> = {}): EvergreenPost {
   } as EvergreenPost;
 }
 
+const OCCURRENCE_ID = 'occurrence-1';
+
+function makeOccurrenceRow(
+  overrides: Partial<EvergreenOccurrence> = {},
+): EvergreenOccurrence {
+  return {
+    id: OCCURRENCE_ID,
+    campaignId: CAMPAIGN_ID,
+    categoryId: CATEGORY_ID,
+    postIdRef: POST_ID,
+    variationId: null,
+    channelId: '12',
+    scheduledAt: new Date('2026-08-18T09:00:00Z'),
+    slotStatus: 'scheduled',
+    postsRowId: null,
+    jobId: null,
+    publishedAt: null,
+    lastError: null,
+    createdAt: new Date('2026-08-18T00:00:00Z'),
+    ...overrides,
+  } as EvergreenOccurrence;
+}
+
+interface FakeChannelRow {
+  id: number;
+  platform: string;
+}
+
+function makeChannelRow(
+  overrides: Partial<FakeChannelRow> = {},
+): FakeChannelRow {
+  return { id: 12, platform: 'facebook', ...overrides };
+}
+
 /**
  * Table-name-routed, stateful fake db. Selects filter the in-memory fixture
  * arrays by campaignId/categoryId where relevant (good enough for this
@@ -124,27 +184,37 @@ function buildFakeDb(fixture: {
   campaignRows?: Campaign[];
   categoryRows?: EvergreenCategory[];
   postRows?: EvergreenPost[];
+  occurrenceRows?: EvergreenOccurrence[];
+  channelRows?: FakeChannelRow[];
 }) {
   const campaignRows = fixture.campaignRows ?? [];
   const categoryRows = fixture.categoryRows ?? [];
   const postRows = fixture.postRows ?? [];
+  const occurrenceRows = fixture.occurrenceRows ?? [];
+  const channelRows = fixture.channelRows ?? [];
 
   const inserts: {
     campaigns: unknown[];
     categories: unknown[];
     posts: unknown[];
-  } = { campaigns: [], categories: [], posts: [] };
+    occurrences: unknown[];
+  } = { campaigns: [], categories: [], posts: [], occurrences: [] };
   const deletes: { categoryIds: string[]; postIds: string[] } = {
     categoryIds: [],
     postIds: [],
   };
 
   function tableRows(name: string): Record<string, unknown>[] {
-    if (name === 'campaigns') return campaignRows as unknown as Record<string, unknown>[];
+    if (name === 'campaigns')
+      return campaignRows as unknown as Record<string, unknown>[];
     if (name === 'campaign_evergreen_categories')
       return categoryRows as unknown as Record<string, unknown>[];
     if (name === 'campaign_evergreen_posts')
       return postRows as unknown as Record<string, unknown>[];
+    if (name === 'campaign_evergreen_occurrences')
+      return occurrenceRows as unknown as Record<string, unknown>[];
+    if (name === 'social_media_channels')
+      return channelRows as unknown as Record<string, unknown>[];
     return [];
   }
 
@@ -157,10 +227,25 @@ function buildFakeDb(fixture: {
           const wanted = extractEqValues(whereCond);
           const filtered = rows.filter((r) => {
             if (wanted.id !== undefined && r.id !== wanted.id) return false;
-            if (wanted.campaign_id !== undefined && r.campaignId !== wanted.campaign_id)
+            if (
+              wanted.campaign_id !== undefined &&
+              r.campaignId !== wanted.campaign_id
+            )
               return false;
-            if (wanted.category_id !== undefined && r.categoryId !== wanted.category_id)
+            if (
+              wanted.category_id !== undefined &&
+              r.categoryId !== wanted.category_id
+            )
               return false;
+            if (wanted.channel_id !== undefined) {
+              // channels table: numeric `id`. occurrences table: varchar `channelId`.
+              const wantedChannelId = wanted.channel_id as string | number;
+              if (name === 'social_media_channels') {
+                if (String(r.id) !== String(wantedChannelId)) return false;
+              } else if (r.channelId !== wantedChannelId) {
+                return false;
+              }
+            }
             return true;
           });
           // MANDATORY: clones, never fixture references.
@@ -213,6 +298,20 @@ function buildFakeDb(fixture: {
           };
           postRows.push(row as unknown as EvergreenPost);
           inserts.posts.push(vals);
+        } else if (name === 'campaign_evergreen_occurrences') {
+          row = {
+            id: `occ-${occurrenceRows.length + 1}`,
+            variationId: null,
+            slotStatus: 'scheduled',
+            postsRowId: null,
+            jobId: null,
+            publishedAt: null,
+            lastError: null,
+            createdAt: new Date(),
+            ...vals,
+          };
+          occurrenceRows.push(row as unknown as EvergreenOccurrence);
+          inserts.occurrences.push(vals);
         }
 
         const resultRows = row ? [{ ...row }] : [];
@@ -269,7 +368,16 @@ function buildFakeDb(fixture: {
     }),
   };
 
-  return { db, inserts, deletes, campaignRows, categoryRows, postRows };
+  return {
+    db,
+    inserts,
+    deletes,
+    campaignRows,
+    categoryRows,
+    postRows,
+    occurrenceRows,
+    channelRows,
+  };
 }
 
 /** Walk an `eq(col, v)` / `and(eq(colA, v1), eq(colB, v2))` drizzle condition
@@ -284,10 +392,21 @@ function extractEqValues(cond: unknown): Record<string, unknown> {
       for (const c of chunks) walk(c);
       return;
     }
-    const named = node as { name?: string; columnType?: string; value?: unknown };
-    if (typeof named.name === 'string' && typeof named.columnType === 'string') {
+    const named = node as {
+      name?: string;
+      columnType?: string;
+      value?: unknown;
+    };
+    if (
+      typeof named.name === 'string' &&
+      typeof named.columnType === 'string'
+    ) {
       pendingColumn = named.name;
-    } else if (pendingColumn && named.value !== undefined && typeof named.value !== 'object') {
+    } else if (
+      pendingColumn &&
+      named.value !== undefined &&
+      typeof named.value !== 'object'
+    ) {
       result[pendingColumn] = named.value;
       pendingColumn = undefined;
     }
@@ -316,7 +435,12 @@ describe('EvergreenService.createCampaign', () => {
     const inserted = inserts.campaigns[0] as {
       type: string;
       status: string;
-      schedule: { type: string; weekdays: number[]; times: string[]; loop: boolean };
+      schedule: {
+        type: string;
+        weekdays: number[];
+        times: string[];
+        loop: boolean;
+      };
       channelIds: string[];
     };
     expect(inserted.type).toBe('evergreen');
@@ -387,7 +511,10 @@ describe('EvergreenService.addCategory', () => {
     });
 
     expect(inserts.categories).toHaveLength(1);
-    const inserted = inserts.categories[0] as { campaignId: string; name: string };
+    const inserted = inserts.categories[0] as {
+      campaignId: string;
+      name: string;
+    };
     expect(inserted.campaignId).toBe(CAMPAIGN_ID);
     expect(inserted.name).toBe('Tips');
 
@@ -405,9 +532,14 @@ describe('EvergreenService.updateCategory', () => {
     });
     const service = loadServiceWithFakeDb(db);
 
-    const dto = await service.updateCategory(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, {
-      name: 'Tips & Tricks',
-    });
+    const dto = await service.updateCategory(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      {
+        name: 'Tips & Tricks',
+      },
+    );
 
     expect(dto.categories[0].name).toBe('Tips & Tricks');
   });
@@ -421,7 +553,12 @@ describe('EvergreenService.setCategoryActive', () => {
     });
     const service = loadServiceWithFakeDb(db);
 
-    const dto = await service.setCategoryActive(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, false);
+    const dto = await service.setCategoryActive(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      false,
+    );
 
     expect(dto.categories[0].isActive).toBe(false);
   });
@@ -436,7 +573,11 @@ describe('EvergreenService.removeCategory', () => {
     });
     const service = loadServiceWithFakeDb(db);
 
-    const dto = await service.removeCategory(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID);
+    const dto = await service.removeCategory(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+    );
 
     expect(deletes.categoryIds).toContain(CATEGORY_ID);
     expect(deletes.postIds.sort()).toEqual(['post-1', 'post-2']);
@@ -475,7 +616,9 @@ describe('EvergreenService.addPost', () => {
     expect(inserted.status).toBe('active');
 
     expect(dto.categories[0].posts).toHaveLength(1);
-    expect(dto.categories[0].posts[0].recyclePolicy).toEqual({ mode: 'forever' });
+    expect(dto.categories[0].posts[0].recyclePolicy).toEqual({
+      mode: 'forever',
+    });
   });
 
   it('respects an explicit recyclePolicy', async () => {
@@ -497,7 +640,9 @@ describe('EvergreenService.addPost', () => {
       recyclePolicy: { mode: 'maxCount', maxCount: 5 },
     });
 
-    const inserted = inserts.posts[0] as { recyclePolicy: { mode: string; maxCount?: number } };
+    const inserted = inserts.posts[0] as {
+      recyclePolicy: { mode: string; maxCount?: number };
+    };
     expect(inserted.recyclePolicy).toEqual({ mode: 'maxCount', maxCount: 5 });
   });
 });
@@ -511,9 +656,15 @@ describe('EvergreenService.updatePost', () => {
     });
     const service = loadServiceWithFakeDb(db);
 
-    const dto = await service.updatePost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, POST_ID, {
-      minGapHours: 12,
-    });
+    const dto = await service.updatePost(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      POST_ID,
+      {
+        minGapHours: 12,
+      },
+    );
 
     expect(dto.categories[0].posts[0].minGapHours).toBe(12);
   });
@@ -528,7 +679,12 @@ describe('EvergreenService.removePost', () => {
     });
     const service = loadServiceWithFakeDb(db);
 
-    const dto = await service.removePost(WORKSPACE_ID, CAMPAIGN_ID, CATEGORY_ID, POST_ID);
+    const dto = await service.removePost(
+      WORKSPACE_ID,
+      CAMPAIGN_ID,
+      CATEGORY_ID,
+      POST_ID,
+    );
 
     expect(postRows.map((p) => p.id)).toEqual(['post-2']);
     expect(dto.categories[0].posts).toHaveLength(1);
@@ -567,13 +723,17 @@ describe('EvergreenService.assembleEvergreen', () => {
     expect(dto.categories[0].posts).toHaveLength(1);
     expect(dto.categories[0].nextRunAt).not.toBeNull();
     // Mon/Wed/Fri 09:00 UTC after 'now' — just assert it parses to a real date.
-    expect(new Date(dto.categories[0].nextRunAt as string).getTime()).not.toBeNaN();
+    expect(
+      new Date(dto.categories[0].nextRunAt as string).getTime(),
+    ).not.toBeNaN();
     expect(dto.upNext).toEqual([]);
   });
 
   it('returns nextRunAt: null for a category with no weekdays/times configured', async () => {
     const campaignRow = makeCampaignRow();
-    const categoryRow = makeCategoryRow({ schedule: { weekdays: [], times: [] } });
+    const categoryRow = makeCategoryRow({
+      schedule: { weekdays: [], times: [] },
+    });
     const { db } = buildFakeDb({
       campaignRows: [campaignRow],
       categoryRows: [categoryRow],
@@ -590,6 +750,322 @@ describe('EvergreenService.assembleEvergreen', () => {
     const { db } = buildFakeDb({});
     const service = loadServiceWithFakeDb(db);
 
-    await expect(service.assembleEvergreen('missing-id')).rejects.toThrow('Campaign not found');
+    await expect(service.assembleEvergreen('missing-id')).rejects.toThrow(
+      'Campaign not found',
+    );
+  });
+
+  it('fills upNext from scheduled evergreenOccurrences, ordered by scheduledAt asc', async () => {
+    const campaignRow = makeCampaignRow();
+    const categoryRow = makeCategoryRow({
+      schedule: { weekdays: [], times: [] },
+    });
+    const laterOccurrence = makeOccurrenceRow({
+      id: 'occ-later',
+      scheduledAt: new Date('2026-08-20T09:00:00Z'),
+    });
+    const soonerOccurrence = makeOccurrenceRow({
+      id: 'occ-sooner',
+      scheduledAt: new Date('2026-08-19T09:00:00Z'),
+    });
+    const pastOccurrence = makeOccurrenceRow({
+      id: 'occ-past',
+      scheduledAt: new Date('2020-01-01T09:00:00Z'),
+    });
+    const publishedOccurrence = makeOccurrenceRow({
+      id: 'occ-published',
+      scheduledAt: new Date('2026-08-21T09:00:00Z'),
+      slotStatus: 'published',
+    });
+    const { db } = buildFakeDb({
+      campaignRows: [campaignRow],
+      categoryRows: [categoryRow],
+      postRows: [],
+      occurrenceRows: [
+        laterOccurrence,
+        soonerOccurrence,
+        pastOccurrence,
+        publishedOccurrence,
+      ],
+    });
+    const service = loadServiceWithFakeDb(db);
+
+    const dto = await service.assembleEvergreen(CAMPAIGN_ID);
+
+    expect(dto.upNext).toHaveLength(2);
+    expect(dto.upNext[0]).toMatchObject({ occurrenceId: 'occ-sooner' });
+    expect(dto.upNext[1]).toMatchObject({ occurrenceId: 'occ-later' });
+  });
+});
+
+describe('EvergreenService.armCategory', () => {
+  it('with no configured weekdays/times: inserts no occurrence and does not enqueue', async () => {
+    const category = makeCategoryRow({ schedule: { weekdays: [], times: [] } });
+    const campaign = makeCampaignRow();
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+    });
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, buildFakePublishing(), queue);
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('with a configured schedule: inserts a scheduled occurrence and enqueues a delayed job with deterministic jobId', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    const { db, inserts, occurrenceRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [makePostRow()],
+    });
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, buildFakePublishing(), queue);
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(1);
+    const inserted = inserts.occurrences[0] as {
+      categoryId: string;
+      campaignId: string;
+      slotStatus: string;
+      postIdRef: string;
+    };
+    expect(inserted.categoryId).toBe(CATEGORY_ID);
+    expect(inserted.campaignId).toBe(CAMPAIGN_ID);
+    expect(inserted.slotStatus).toBe('scheduled');
+    expect(inserted.postIdRef).toBe(POST_ID); // picked at arm-time
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [, jobData, jobOpts] = queue.add.mock.calls[0] as [
+      string,
+      { occurrenceId: string },
+      { jobId: string; delay: number },
+    ];
+    const occurrenceId = occurrenceRows[0].id;
+    expect(jobData).toEqual({ occurrenceId });
+    expect(jobOpts.jobId).toBe(`evg-${occurrenceId}`);
+    expect(jobOpts.delay).toBeGreaterThanOrEqual(0);
+
+    // jobId written back onto the occurrence row.
+    expect(occurrenceRows[0].jobId).toBe(jobOpts.jobId);
+  });
+
+  it('when no post is eligible at arm-time, still does nothing (no occurrence, no enqueue)', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    const { db, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [], // no posts in the pool → nothing eligible
+    });
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, buildFakePublishing(), queue);
+
+    await service.armCategory(
+      category,
+      campaign,
+      new Date('2026-08-18T00:00:00Z'),
+    );
+
+    expect(inserts.occurrences).toHaveLength(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('EvergreenService.fireOccurrence', () => {
+  it('fires with an eligible post: calls materializeAndEnqueue with the selected variation caption + destination, bumps the post, writes postsRowId/jobId, and arms the next fire', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    const post = makePostRow({
+      recycledCount: 1,
+      variations: [
+        { id: 'v1', caption: 'Variation caption', source: 'manual' },
+      ],
+      content: {
+        mode: 'manual',
+        postType: 'text',
+        caption: 'Base caption',
+        media: [],
+        threadParts: [],
+        templateIds: [],
+        destination: { id: 'chan-dest-1', name: 'general' },
+      },
+    });
+    const occurrence = makeOccurrenceRow();
+    const channel = makeChannelRow({ id: 12, platform: 'facebook' });
+    const { db, occurrenceRows, postRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [post],
+      occurrenceRows: [occurrence],
+      channelRows: [channel],
+    });
+    const publishing = buildFakePublishing();
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await service.fireOccurrence(OCCURRENCE_ID);
+
+    expect(publishing.materializeAndEnqueue).toHaveBeenCalledTimes(1);
+    const calls = publishing.materializeAndEnqueue.mock.calls as unknown as [
+      {
+        content: { caption: string; destination?: { id: string } };
+        platform: string;
+        channelId: string;
+      },
+    ][];
+    const call = calls[0][0];
+    // recycledCount=1, 1 variation → cycleLength=2, index = 1 % 2 = 1 → variations[0]
+    expect(call.content.caption).toBe('Variation caption');
+    expect(call.content.destination).toEqual({
+      id: 'chan-dest-1',
+      name: 'general',
+    });
+    expect(call.platform).toBe('facebook');
+    expect(call.channelId).toBe('12');
+
+    // post bumped
+    expect(postRows[0].recycledCount).toBe(2);
+    expect(postRows[0].lastPublishedAt).not.toBeNull();
+
+    // occurrence updated
+    expect(occurrenceRows[0].postsRowId).toBe('materialized-post-1');
+    expect(occurrenceRows[0].jobId).toBe('materialized-job-1');
+    expect(occurrenceRows[0].slotStatus).toBe('published');
+
+    // next fire armed
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('with no eligible post pool-wide: marks the occurrence skipped, and armCategory is still attempted (no-op since nothing is eligible to arm against either)', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    // Only post in the pool is ineligible: status 'retired'.
+    const post = makePostRow({ status: 'retired' });
+    const occurrence = makeOccurrenceRow();
+    const { db, occurrenceRows } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [post],
+      occurrenceRows: [occurrence],
+      channelRows: [makeChannelRow()],
+    });
+    const publishing = buildFakePublishing();
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await service.fireOccurrence(OCCURRENCE_ID);
+
+    expect(publishing.materializeAndEnqueue).not.toHaveBeenCalled();
+    expect(occurrenceRows[0].slotStatus).toBe('skipped');
+    // No eligible post exists to arm the next occurrence against either (the
+    // NOT NULL postIdRef FK means armCategory can't insert without a pick),
+    // so the chain correctly stays dormant rather than inserting garbage.
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('re-validates at fire time: when the stored postIdRef has since gone ineligible but another pool post is still eligible, fires the still-eligible one instead', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    // The occurrence's stored postIdRef points at a post that's since been
+    // retired (e.g. edited after arm-time, before fire-time). A second pool
+    // post is still eligible — fire-time re-validation must re-pick it
+    // rather than blindly trusting/failing on the stale stored id.
+    const stalePost = makePostRow({ id: 'post-stale', status: 'retired' });
+    const eligiblePost = makePostRow({ id: 'post-eligible' });
+    const occurrence = makeOccurrenceRow({ postIdRef: 'post-stale' });
+    const { db, occurrenceRows, inserts } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [stalePost, eligiblePost],
+      occurrenceRows: [occurrence],
+      channelRows: [makeChannelRow()],
+    });
+    const publishing = buildFakePublishing();
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await service.fireOccurrence(OCCURRENCE_ID);
+
+    expect(publishing.materializeAndEnqueue).toHaveBeenCalledTimes(1);
+    expect(occurrenceRows[0].slotStatus).toBe('published');
+    expect(occurrenceRows[0].postIdRef).toBe('post-eligible'); // re-picked, not the stale stored id
+    expect(inserts.occurrences).toHaveLength(1); // next fire armed
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('when materializeAndEnqueue throws: the next fire is STILL armed (self-healing chain)', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+    });
+    const campaign = makeCampaignRow();
+    const post = makePostRow();
+    const occurrence = makeOccurrenceRow();
+    const { db } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [post],
+      occurrenceRows: [occurrence],
+      channelRows: [makeChannelRow()],
+    });
+    const publishing = buildFakePublishing();
+    publishing.materializeAndEnqueue.mockRejectedValueOnce(
+      new Error('publish boom'),
+    );
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await expect(service.fireOccurrence(OCCURRENCE_ID)).rejects.toThrow(
+      'publish boom',
+    );
+
+    expect(queue.add).toHaveBeenCalledTimes(1); // chain self-heals even though fire threw
+  });
+
+  it('when the category has gone inactive, does NOT arm a next fire', async () => {
+    const category = makeCategoryRow({
+      schedule: { weekdays: [1, 3, 5], times: ['09:00'] },
+      isActive: false,
+    });
+    const campaign = makeCampaignRow();
+    const post = makePostRow();
+    const occurrence = makeOccurrenceRow();
+    const { db } = buildFakeDb({
+      campaignRows: [campaign],
+      categoryRows: [category],
+      postRows: [post],
+      occurrenceRows: [occurrence],
+      channelRows: [makeChannelRow()],
+    });
+    const publishing = buildFakePublishing();
+    const queue = buildFakeQueue();
+    const service = loadServiceWithFakeDb(db, publishing, queue);
+
+    await service.fireOccurrence(OCCURRENCE_ID);
+
+    expect(queue.add).not.toHaveBeenCalled();
   });
 });

--- a/src/campaigns/evergreen.service.ts
+++ b/src/campaigns/evergreen.service.ts
@@ -1,0 +1,451 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../drizzle/db';
+import {
+  campaigns,
+  type Campaign,
+  type CampaignScheduleEvergreenJson,
+} from '../drizzle/schema/campaigns.schema';
+import {
+  evergreenCategories,
+  evergreenPosts,
+  type EvergreenCategory,
+  type EvergreenPost,
+  type RecyclePolicyJson,
+} from '../drizzle/schema/evergreen.schema';
+import { computeNextCategoryFire } from './evergreen-rotation.util';
+import type {
+  CreateEvergreenCampaignDto,
+  CreateEvergreenCategoryDto,
+  UpdateEvergreenCategoryDto,
+  CreateEvergreenPostDto,
+  UpdateEvergreenPostDto,
+} from './dto/evergreen.dto';
+
+// ==========================================================================
+// Response DTO — extends the existing `CampaignDto` shape (see
+// `CampaignsService.assembleCampaign`) with evergreen-specific nesting.
+//
+// Return-shape note (for later tasks): evergreen campaigns don't use the
+// bulk/drip `campaignDays`/`campaignSlotContent` tables at all — categories +
+// pool posts stand in their place — so `slotContent`/`metrics` are always
+// empty/zeroed here rather than omitted, keeping the object a structural
+// superset of `CampaignDto` for any shared frontend code that reads those
+// fields defensively.
+// ==========================================================================
+
+export interface EvergreenPostDto {
+  id: string;
+  campaignId: string;
+  categoryId: string;
+  content: EvergreenPost['content'];
+  variations: EvergreenPost['variations'];
+  recyclePolicy: RecyclePolicyJson;
+  minGapHours: number;
+  recycledCount: number;
+  lastPublishedAt: string | null;
+  performanceScore: number | null;
+  isStale: boolean;
+  staleReason: string | null;
+  status: EvergreenPost['status'];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EvergreenCategoryDto {
+  id: string;
+  campaignId: string;
+  name: string;
+  color: string;
+  schedule: EvergreenCategory['schedule'];
+  channelIds: string[];
+  seasonal: EvergreenCategory['seasonal'];
+  isActive: boolean;
+  rotationCursor: number;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  posts: EvergreenPostDto[];
+  /** Next instant this category is due to fire, per Task 2's
+   *  `computeNextCategoryFire`. Null when the category has no
+   *  weekdays/times configured or nothing falls within the scan window. */
+  nextRunAt: string | null;
+}
+
+export interface EvergreenCampaignDto {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  type: string;
+  status: string;
+  channelIds: string[];
+  platforms: string[];
+  schedule: CampaignScheduleEvergreenJson;
+  contentSource: string;
+  aiConfig: Record<string, unknown> | null;
+  libraryTemplateIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  launchedAt: string | null;
+  categories: EvergreenCategoryDto[];
+  /** Upcoming occurrences across all categories. Deliberately empty here —
+   *  populated once the occurrences table + rotation land (Task 6). */
+  upNext: unknown[];
+}
+
+@Injectable()
+export class EvergreenService {
+  constructor() {}
+
+  // ========================================================================
+  // Assembly
+  // ========================================================================
+
+  /**
+   * Loads a campaign row + its categories + each category's pool posts and
+   * assembles the nested `EvergreenCampaignDto`, computing each category's
+   * `nextRunAt`. `upNext` is always `[]` — Task 6 fills it once occurrences
+   * exist. Throws `NotFoundException` if the campaign id doesn't exist.
+   */
+  async assembleEvergreen(campaignId: string): Promise<EvergreenCampaignDto> {
+    const [row] = await db.select().from(campaigns).where(eq(campaigns.id, campaignId));
+    if (!row) {
+      throw new NotFoundException('Campaign not found');
+    }
+    return this.assembleFromRow(row);
+  }
+
+  private async assembleFromRow(row: Campaign): Promise<EvergreenCampaignDto> {
+    const schedule = row.schedule as CampaignScheduleEvergreenJson;
+
+    const categoryRows = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.campaignId, row.id));
+
+    const categories: EvergreenCategoryDto[] = await Promise.all(
+      categoryRows.map(async (cat) => {
+        const postRows = await db
+          .select()
+          .from(evergreenPosts)
+          .where(eq(evergreenPosts.categoryId, cat.id));
+
+        const nextRunAt = computeNextCategoryFire(
+          cat.schedule,
+          schedule.timezone,
+          schedule.blackoutDates ?? [],
+          new Date(),
+        );
+
+        return this.toCategoryDto(cat, postRows, nextRunAt);
+      }),
+    );
+
+    return {
+      id: row.id,
+      workspaceId: row.workspaceId,
+      name: row.name,
+      description: row.description,
+      type: row.type,
+      status: row.status,
+      channelIds: (row.channelIds as string[] | null) ?? [],
+      platforms: (row.platforms as string[] | null) ?? [],
+      schedule,
+      contentSource: row.contentSource,
+      aiConfig: row.aiConfig,
+      libraryTemplateIds: (row.libraryTemplateIds as string[] | null) ?? [],
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      launchedAt: row.launchedAt ? row.launchedAt.toISOString() : null,
+      categories,
+      upNext: [],
+    };
+  }
+
+  private toCategoryDto(
+    cat: EvergreenCategory,
+    posts: EvergreenPost[],
+    nextRunAt: Date | null,
+  ): EvergreenCategoryDto {
+    return {
+      id: cat.id,
+      campaignId: cat.campaignId,
+      name: cat.name,
+      color: cat.color,
+      schedule: cat.schedule,
+      channelIds: (cat.channelIds as string[] | null) ?? [],
+      seasonal: cat.seasonal,
+      isActive: cat.isActive,
+      rotationCursor: cat.rotationCursor,
+      sortOrder: cat.sortOrder,
+      createdAt: cat.createdAt.toISOString(),
+      updatedAt: cat.updatedAt.toISOString(),
+      posts: posts.map((p) => this.toPostDto(p)),
+      nextRunAt: nextRunAt ? nextRunAt.toISOString() : null,
+    };
+  }
+
+  private toPostDto(post: EvergreenPost): EvergreenPostDto {
+    return {
+      id: post.id,
+      campaignId: post.campaignId,
+      categoryId: post.categoryId,
+      content: post.content,
+      variations: post.variations,
+      recyclePolicy: post.recyclePolicy as RecyclePolicyJson,
+      minGapHours: post.minGapHours,
+      recycledCount: post.recycledCount,
+      lastPublishedAt: post.lastPublishedAt ? post.lastPublishedAt.toISOString() : null,
+      performanceScore: post.performanceScore,
+      isStale: post.isStale,
+      staleReason: post.staleReason,
+      status: post.status,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt.toISOString(),
+    };
+  }
+
+  // ========================================================================
+  // Campaign
+  // ========================================================================
+
+  /** Creates an evergreen campaign as a draft with no categories yet. The
+   *  campaign-level schedule carries the shared timezone/blackout/loop
+   *  settings; `weekdays`/`times` are always empty at this level since each
+   *  category owns its own weekday/time schedule. */
+  async createCampaign(
+    workspaceId: string,
+    userId: string,
+    dto: CreateEvergreenCampaignDto,
+  ): Promise<EvergreenCampaignDto> {
+    const schedule: CampaignScheduleEvergreenJson = {
+      type: 'evergreen',
+      startDate: dto.startDate,
+      weekdays: [],
+      times: [],
+      timezone: dto.timezone,
+      blackoutDates: dto.blackoutDates ?? [],
+      loop: dto.loop ?? true,
+    };
+
+    const [row] = await db
+      .insert(campaigns)
+      .values({
+        workspaceId,
+        createdById: userId,
+        name: dto.name,
+        description: dto.description?.trim() ? dto.description.trim() : null,
+        type: 'evergreen',
+        status: 'draft',
+        schedule,
+        contentSource: 'manual',
+        aiConfig: null,
+        libraryTemplateIds: [],
+        channelIds: dto.channelIds,
+        platforms: [],
+      })
+      .returning();
+
+    return this.assembleEvergreen(row.id);
+  }
+
+  /** Scopes a campaign id to its workspace, 404ing otherwise. Returns the
+   *  raw row (not the assembled DTO) since write methods only need it to
+   *  validate ownership before touching category/post rows. */
+  private async loadOwnedCampaign(workspaceId: string, campaignId: string): Promise<Campaign> {
+    const [row] = await db
+      .select()
+      .from(campaigns)
+      .where(and(eq(campaigns.id, campaignId), eq(campaigns.workspaceId, workspaceId)));
+
+    if (!row) {
+      throw new NotFoundException('Campaign not found');
+    }
+    return row;
+  }
+
+  // ========================================================================
+  // Categories
+  // ========================================================================
+
+  async addCategory(
+    workspaceId: string,
+    campaignId: string,
+    dto: CreateEvergreenCategoryDto,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+
+    await db.insert(evergreenCategories).values({
+      campaignId,
+      name: dto.name,
+      color: dto.color,
+      schedule: dto.schedule,
+      channelIds: dto.channelIds,
+      seasonal: dto.seasonal ?? null,
+    });
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  async updateCategory(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    dto: UpdateEvergreenCategoryDto,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+
+    const [existing] = await db
+      .select()
+      .from(evergreenCategories)
+      .where(
+        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+      );
+    if (!existing) {
+      throw new NotFoundException('Category not found');
+    }
+
+    const updates: Partial<EvergreenCategory> = { updatedAt: new Date() };
+    if (dto.name !== undefined) updates.name = dto.name;
+    if (dto.color !== undefined) updates.color = dto.color;
+    if (dto.schedule !== undefined) updates.schedule = dto.schedule;
+    if (dto.channelIds !== undefined) updates.channelIds = dto.channelIds;
+    if (dto.seasonal !== undefined) updates.seasonal = dto.seasonal;
+
+    await db.update(evergreenCategories).set(updates).where(eq(evergreenCategories.id, categoryId));
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  async setCategoryActive(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    isActive: boolean,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+
+    const [existing] = await db
+      .select({ id: evergreenCategories.id })
+      .from(evergreenCategories)
+      .where(
+        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+      );
+    if (!existing) {
+      throw new NotFoundException('Category not found');
+    }
+
+    await db
+      .update(evergreenCategories)
+      .set({ isActive, updatedAt: new Date() })
+      .where(eq(evergreenCategories.id, categoryId));
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  /** Removes a category and cascades its pool posts. The schema's FK already
+   *  carries `onDelete: 'cascade'`, but we delete posts explicitly first so
+   *  the behaviour doesn't depend on cascade support in every environment
+   *  (and so the fake-DB test harness can assert on it directly). */
+  async removeCategory(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+
+    await db.delete(evergreenPosts).where(eq(evergreenPosts.categoryId, categoryId));
+    await db
+      .delete(evergreenCategories)
+      .where(
+        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+      );
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  // ========================================================================
+  // Pool posts
+  // ========================================================================
+
+  private async loadOwnedCategory(campaignId: string, categoryId: string): Promise<void> {
+    const [existing] = await db
+      .select({ id: evergreenCategories.id })
+      .from(evergreenCategories)
+      .where(
+        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+      );
+    if (!existing) {
+      throw new NotFoundException('Category not found');
+    }
+  }
+
+  async addPost(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    dto: CreateEvergreenPostDto,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+
+    const recyclePolicy: RecyclePolicyJson = dto.recyclePolicy ?? { mode: 'forever' };
+
+    await db.insert(evergreenPosts).values({
+      campaignId,
+      categoryId,
+      content: dto.content,
+      variations: [],
+      recyclePolicy,
+      minGapHours: dto.minGapHours ?? 0,
+      status: 'active',
+    });
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  async updatePost(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+    dto: UpdateEvergreenPostDto,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+
+    const [existing] = await db
+      .select({ id: evergreenPosts.id })
+      .from(evergreenPosts)
+      .where(and(eq(evergreenPosts.id, postId), eq(evergreenPosts.categoryId, categoryId)));
+    if (!existing) {
+      throw new NotFoundException('Post not found');
+    }
+
+    const updates: Partial<EvergreenPost> = { updatedAt: new Date() };
+    if (dto.content !== undefined) updates.content = dto.content;
+    if (dto.recyclePolicy !== undefined) updates.recyclePolicy = dto.recyclePolicy;
+    if (dto.minGapHours !== undefined) updates.minGapHours = dto.minGapHours;
+
+    await db.update(evergreenPosts).set(updates).where(eq(evergreenPosts.id, postId));
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  async removePost(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+
+    await db
+      .delete(evergreenPosts)
+      .where(and(eq(evergreenPosts.id, postId), eq(evergreenPosts.categoryId, categoryId)));
+
+    return this.assembleEvergreen(campaignId);
+  }
+}

--- a/src/campaigns/evergreen.service.ts
+++ b/src/campaigns/evergreen.service.ts
@@ -1,19 +1,30 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../drizzle/db';
 import {
   campaigns,
   type Campaign,
+  type ChannelDayContentJson,
   type CampaignScheduleEvergreenJson,
 } from '../drizzle/schema/campaigns.schema';
+import { socialMediaChannels } from '../drizzle/schema/channels.schema';
 import {
   evergreenCategories,
+  evergreenOccurrences,
   evergreenPosts,
   type EvergreenCategory,
   type EvergreenPost,
   type RecyclePolicyJson,
 } from '../drizzle/schema/evergreen.schema';
-import { computeNextCategoryFire } from './evergreen-rotation.util';
+import {
+  computeNextCategoryFire,
+  pickNextPost,
+  selectVariation,
+} from './evergreen-rotation.util';
+import { CampaignPublishingService } from './campaign-publishing.service';
+import { QUEUES } from '../queue/queue.module';
 import type {
   CreateEvergreenCampaignDto,
   CreateEvergreenCategoryDto,
@@ -72,6 +83,14 @@ export interface EvergreenCategoryDto {
   nextRunAt: string | null;
 }
 
+export interface EvergreenUpNextDto {
+  occurrenceId: string;
+  categoryId: string;
+  scheduledAt: string;
+  channelId: string;
+  postIdRef: string;
+}
+
 export interface EvergreenCampaignDto {
   id: string;
   workspaceId: string;
@@ -89,14 +108,22 @@ export interface EvergreenCampaignDto {
   updatedAt: string;
   launchedAt: string | null;
   categories: EvergreenCategoryDto[];
-  /** Upcoming occurrences across all categories. Deliberately empty here —
-   *  populated once the occurrences table + rotation land (Task 6). */
-  upNext: unknown[];
+  /** Next scheduled occurrences across all categories, soonest first. */
+  upNext: EvergreenUpNextDto[];
 }
+
+/** How many upcoming occurrences `assembleEvergreen` surfaces in `upNext`. */
+const UP_NEXT_LIMIT = 10;
 
 @Injectable()
 export class EvergreenService {
-  constructor() {}
+  private readonly logger = new Logger(EvergreenService.name);
+
+  constructor(
+    private readonly publishing: CampaignPublishingService,
+    @InjectQueue(QUEUES.EVERGREEN_ROTATION)
+    private readonly rotationQueue: Queue,
+  ) {}
 
   // ========================================================================
   // Assembly
@@ -105,11 +132,15 @@ export class EvergreenService {
   /**
    * Loads a campaign row + its categories + each category's pool posts and
    * assembles the nested `EvergreenCampaignDto`, computing each category's
-   * `nextRunAt`. `upNext` is always `[]` — Task 6 fills it once occurrences
-   * exist. Throws `NotFoundException` if the campaign id doesn't exist.
+   * `nextRunAt` and the campaign's `upNext` (next scheduled occurrences
+   * across all categories). Throws `NotFoundException` if the campaign id
+   * doesn't exist.
    */
   async assembleEvergreen(campaignId: string): Promise<EvergreenCampaignDto> {
-    const [row] = await db.select().from(campaigns).where(eq(campaigns.id, campaignId));
+    const [row] = await db
+      .select()
+      .from(campaigns)
+      .where(eq(campaigns.id, campaignId));
     if (!row) {
       throw new NotFoundException('Campaign not found');
     }
@@ -142,6 +173,8 @@ export class EvergreenService {
       }),
     );
 
+    const upNext = await this.loadUpNext(row.id);
+
     return {
       id: row.id,
       workspaceId: row.workspaceId,
@@ -154,13 +187,40 @@ export class EvergreenService {
       schedule,
       contentSource: row.contentSource,
       aiConfig: row.aiConfig,
-      libraryTemplateIds: (row.libraryTemplateIds as string[] | null) ?? [],
+      libraryTemplateIds: row.libraryTemplateIds ?? [],
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),
       launchedAt: row.launchedAt ? row.launchedAt.toISOString() : null,
       categories,
-      upNext: [],
+      upNext,
     };
+  }
+
+  /** Next `UP_NEXT_LIMIT` still-`scheduled`, not-yet-due-or-future occurrences
+   *  across all of the campaign's categories, soonest first. Filtering to
+   *  `scheduledAt >= now` and re-sorting client-side (rather than trusting
+   *  DB order) keeps this correct against the fake-DB test harness, which
+   *  doesn't implement `orderBy`/`gte` — and is cheap at this row count. */
+  private async loadUpNext(campaignId: string): Promise<EvergreenUpNextDto[]> {
+    const rows = await db
+      .select()
+      .from(evergreenOccurrences)
+      .where(eq(evergreenOccurrences.campaignId, campaignId));
+
+    const now = Date.now();
+    return rows
+      .filter(
+        (r) => r.slotStatus === 'scheduled' && r.scheduledAt.getTime() >= now,
+      )
+      .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime())
+      .slice(0, UP_NEXT_LIMIT)
+      .map((r) => ({
+        occurrenceId: r.id,
+        categoryId: r.categoryId,
+        scheduledAt: r.scheduledAt.toISOString(),
+        channelId: r.channelId,
+        postIdRef: r.postIdRef,
+      }));
   }
 
   private toCategoryDto(
@@ -193,10 +253,12 @@ export class EvergreenService {
       categoryId: post.categoryId,
       content: post.content,
       variations: post.variations,
-      recyclePolicy: post.recyclePolicy as RecyclePolicyJson,
+      recyclePolicy: post.recyclePolicy,
       minGapHours: post.minGapHours,
       recycledCount: post.recycledCount,
-      lastPublishedAt: post.lastPublishedAt ? post.lastPublishedAt.toISOString() : null,
+      lastPublishedAt: post.lastPublishedAt
+        ? post.lastPublishedAt.toISOString()
+        : null,
       performanceScore: post.performanceScore,
       isStale: post.isStale,
       staleReason: post.staleReason,
@@ -253,11 +315,19 @@ export class EvergreenService {
   /** Scopes a campaign id to its workspace, 404ing otherwise. Returns the
    *  raw row (not the assembled DTO) since write methods only need it to
    *  validate ownership before touching category/post rows. */
-  private async loadOwnedCampaign(workspaceId: string, campaignId: string): Promise<Campaign> {
+  private async loadOwnedCampaign(
+    workspaceId: string,
+    campaignId: string,
+  ): Promise<Campaign> {
     const [row] = await db
       .select()
       .from(campaigns)
-      .where(and(eq(campaigns.id, campaignId), eq(campaigns.workspaceId, workspaceId)));
+      .where(
+        and(
+          eq(campaigns.id, campaignId),
+          eq(campaigns.workspaceId, workspaceId),
+        ),
+      );
 
     if (!row) {
       throw new NotFoundException('Campaign not found');
@@ -300,7 +370,10 @@ export class EvergreenService {
       .select()
       .from(evergreenCategories)
       .where(
-        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+        and(
+          eq(evergreenCategories.id, categoryId),
+          eq(evergreenCategories.campaignId, campaignId),
+        ),
       );
     if (!existing) {
       throw new NotFoundException('Category not found');
@@ -313,7 +386,10 @@ export class EvergreenService {
     if (dto.channelIds !== undefined) updates.channelIds = dto.channelIds;
     if (dto.seasonal !== undefined) updates.seasonal = dto.seasonal;
 
-    await db.update(evergreenCategories).set(updates).where(eq(evergreenCategories.id, categoryId));
+    await db
+      .update(evergreenCategories)
+      .set(updates)
+      .where(eq(evergreenCategories.id, categoryId));
 
     return this.assembleEvergreen(campaignId);
   }
@@ -330,7 +406,10 @@ export class EvergreenService {
       .select({ id: evergreenCategories.id })
       .from(evergreenCategories)
       .where(
-        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+        and(
+          eq(evergreenCategories.id, categoryId),
+          eq(evergreenCategories.campaignId, campaignId),
+        ),
       );
     if (!existing) {
       throw new NotFoundException('Category not found');
@@ -355,11 +434,16 @@ export class EvergreenService {
   ): Promise<EvergreenCampaignDto> {
     await this.loadOwnedCampaign(workspaceId, campaignId);
 
-    await db.delete(evergreenPosts).where(eq(evergreenPosts.categoryId, categoryId));
+    await db
+      .delete(evergreenPosts)
+      .where(eq(evergreenPosts.categoryId, categoryId));
     await db
       .delete(evergreenCategories)
       .where(
-        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+        and(
+          eq(evergreenCategories.id, categoryId),
+          eq(evergreenCategories.campaignId, campaignId),
+        ),
       );
 
     return this.assembleEvergreen(campaignId);
@@ -369,12 +453,18 @@ export class EvergreenService {
   // Pool posts
   // ========================================================================
 
-  private async loadOwnedCategory(campaignId: string, categoryId: string): Promise<void> {
+  private async loadOwnedCategory(
+    campaignId: string,
+    categoryId: string,
+  ): Promise<void> {
     const [existing] = await db
       .select({ id: evergreenCategories.id })
       .from(evergreenCategories)
       .where(
-        and(eq(evergreenCategories.id, categoryId), eq(evergreenCategories.campaignId, campaignId)),
+        and(
+          eq(evergreenCategories.id, categoryId),
+          eq(evergreenCategories.campaignId, campaignId),
+        ),
       );
     if (!existing) {
       throw new NotFoundException('Category not found');
@@ -390,7 +480,9 @@ export class EvergreenService {
     await this.loadOwnedCampaign(workspaceId, campaignId);
     await this.loadOwnedCategory(campaignId, categoryId);
 
-    const recyclePolicy: RecyclePolicyJson = dto.recyclePolicy ?? { mode: 'forever' };
+    const recyclePolicy: RecyclePolicyJson = dto.recyclePolicy ?? {
+      mode: 'forever',
+    };
 
     await db.insert(evergreenPosts).values({
       campaignId,
@@ -418,17 +510,26 @@ export class EvergreenService {
     const [existing] = await db
       .select({ id: evergreenPosts.id })
       .from(evergreenPosts)
-      .where(and(eq(evergreenPosts.id, postId), eq(evergreenPosts.categoryId, categoryId)));
+      .where(
+        and(
+          eq(evergreenPosts.id, postId),
+          eq(evergreenPosts.categoryId, categoryId),
+        ),
+      );
     if (!existing) {
       throw new NotFoundException('Post not found');
     }
 
     const updates: Partial<EvergreenPost> = { updatedAt: new Date() };
     if (dto.content !== undefined) updates.content = dto.content;
-    if (dto.recyclePolicy !== undefined) updates.recyclePolicy = dto.recyclePolicy;
+    if (dto.recyclePolicy !== undefined)
+      updates.recyclePolicy = dto.recyclePolicy;
     if (dto.minGapHours !== undefined) updates.minGapHours = dto.minGapHours;
 
-    await db.update(evergreenPosts).set(updates).where(eq(evergreenPosts.id, postId));
+    await db
+      .update(evergreenPosts)
+      .set(updates)
+      .where(eq(evergreenPosts.id, postId));
 
     return this.assembleEvergreen(campaignId);
   }
@@ -444,8 +545,291 @@ export class EvergreenService {
 
     await db
       .delete(evergreenPosts)
-      .where(and(eq(evergreenPosts.id, postId), eq(evergreenPosts.categoryId, categoryId)));
+      .where(
+        and(
+          eq(evergreenPosts.id, postId),
+          eq(evergreenPosts.categoryId, categoryId),
+        ),
+      );
 
     return this.assembleEvergreen(campaignId);
   }
+
+  // ========================================================================
+  // Rotation engine — per-fire re-enqueue chain (Task 6)
+  //
+  // Design choice (postIdRef arm-time-vs-fire-time): `evergreenOccurrences
+  // .postIdRef` is NOT NULL (Task 1's schema), so an occurrence row cannot
+  // exist without a post already chosen. We pick the post at ARM time via
+  // `pickNextPost` and store it — this satisfies the FK immediately and lets
+  // `assembleEvergreen`'s `upNext` show a concrete "what fires next" post
+  // without waiting for fire time. At FIRE time we re-validate eligibility
+  // (re-run `pickNextPost` against current state) rather than trusting the
+  // stored pick blindly — a post can go stale/retired/exhaust its recycle
+  // policy in the gap between arm and fire (the gap can be long: fires are
+  // scheduled up to MAX_SCAN_DAYS out). If the stored post is no longer
+  // eligible, we re-pick from the currently-eligible pool instead of
+  // failing the fire.
+  // ========================================================================
+
+  /**
+   * Computes the category's next fire instant and arms it: inserts a
+   * `scheduled` `evergreenOccurrences` row (picking the post to fire via
+   * `pickNextPost`, and a channel from the category's `channelIds`) and
+   * enqueues a delayed `evergreen-rotation` job `{ occurrenceId }` with a
+   * deterministic `jobId = evg-<occurrenceId>`. Does nothing (just logs) when
+   * the category has no weekdays/times configured (no next fire) or has no
+   * channel/eligible post to arm against — the chain simply stays dormant
+   * until the category is edited into a fireable state.
+   */
+  async armCategory(
+    category: EvergreenCategory,
+    campaign: Campaign,
+    now: Date,
+  ): Promise<void> {
+    const schedule = campaign.schedule as CampaignScheduleEvergreenJson;
+
+    const nextFire = computeNextCategoryFire(
+      category.schedule,
+      schedule.timezone,
+      schedule.blackoutDates ?? [],
+      now,
+    );
+    if (!nextFire) {
+      this.logger.log(
+        `armCategory(${category.id}): no next fire (no weekdays/times configured) — not arming.`,
+      );
+      return;
+    }
+
+    const channelIds = (category.channelIds as string[] | null) ?? [];
+    const channelId = channelIds[0];
+    if (!channelId) {
+      this.logger.warn(
+        `armCategory(${category.id}): no channelIds configured — not arming.`,
+      );
+      return;
+    }
+
+    const postRows = await db
+      .select()
+      .from(evergreenPosts)
+      .where(eq(evergreenPosts.categoryId, category.id));
+
+    const picked = pickNextPost(postRows, category, now);
+    if (!picked) {
+      this.logger.log(
+        `armCategory(${category.id}): no eligible post to arm — not arming.`,
+      );
+      return;
+    }
+
+    const [occurrence] = await db
+      .insert(evergreenOccurrences)
+      .values({
+        campaignId: category.campaignId,
+        categoryId: category.id,
+        postIdRef: picked.id,
+        variationId: null,
+        channelId,
+        scheduledAt: nextFire,
+        slotStatus: 'scheduled',
+      })
+      .returning();
+
+    const jobId = `evg-${occurrence.id}`;
+    const delay = Math.max(0, nextFire.getTime() - now.getTime());
+
+    await this.rotationQueue.add(
+      'evergreen-fire',
+      { occurrenceId: occurrence.id },
+      {
+        delay,
+        jobId,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+      },
+    );
+
+    await db
+      .update(evergreenOccurrences)
+      .set({ jobId })
+      .where(eq(evergreenOccurrences.id, occurrence.id));
+  }
+
+  /**
+   * Fires one occurrence: re-validates eligibility, publishes via
+   * `CampaignPublishingService.materializeAndEnqueue`, bumps the post, and
+   * ALWAYS arms the category's next fire in a `finally` block — even if the
+   * publish call throws, or no post is eligible — so the rotation chain is
+   * self-healing and never dies on a single bad fire.
+   */
+  async fireOccurrence(occurrenceId: string): Promise<void> {
+    const [occurrence] = await db
+      .select()
+      .from(evergreenOccurrences)
+      .where(eq(evergreenOccurrences.id, occurrenceId));
+    if (!occurrence) {
+      this.logger.warn(
+        `fireOccurrence(${occurrenceId}): occurrence not found — nothing to do.`,
+      );
+      return;
+    }
+
+    const [category] = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.id, occurrence.categoryId));
+    if (!category) {
+      this.logger.warn(
+        `fireOccurrence(${occurrenceId}): category ${occurrence.categoryId} not found — cannot fire or re-arm.`,
+      );
+      return;
+    }
+
+    const [campaign] = await db
+      .select()
+      .from(campaigns)
+      .where(eq(campaigns.id, occurrence.campaignId));
+    if (!campaign) {
+      this.logger.warn(
+        `fireOccurrence(${occurrenceId}): campaign ${occurrence.campaignId} not found — cannot fire or re-arm.`,
+      );
+      return;
+    }
+
+    const now = new Date();
+
+    try {
+      const postRows = await db
+        .select()
+        .from(evergreenPosts)
+        .where(eq(evergreenPosts.categoryId, category.id));
+
+      // Re-validate at fire time — the arm-time pick may have gone stale
+      // (retired, recycle policy exhausted, min-gap not yet satisfied vs. a
+      // more recent fire, etc.) in the gap between arm and fire.
+      const picked = pickNextPost(postRows, category, now);
+
+      if (!picked) {
+        await db
+          .update(evergreenOccurrences)
+          .set({
+            slotStatus: 'skipped',
+            lastError: 'No eligible post at fire time',
+          })
+          .where(eq(evergreenOccurrences.id, occurrenceId));
+        return;
+      }
+
+      const variation = selectVariation(picked);
+
+      const [channelRow] = await db
+        .select()
+        .from(socialMediaChannels)
+        .where(eq(socialMediaChannels.id, Number(occurrence.channelId)));
+      if (!channelRow) {
+        await db
+          .update(evergreenOccurrences)
+          .set({ slotStatus: 'skipped', lastError: 'Channel unavailable' })
+          .where(eq(evergreenOccurrences.id, occurrenceId));
+        return;
+      }
+
+      const { date, time } = formatInTimeZone(
+        occurrence.scheduledAt,
+        (campaign.schedule as CampaignScheduleEvergreenJson).timezone,
+      );
+
+      const content: ChannelDayContentJson = {
+        ...picked.content,
+        caption: variation.caption,
+      };
+
+      const { postId, jobId } = await this.publishing.materializeAndEnqueue({
+        workspaceId: campaign.workspaceId,
+        createdById: campaign.createdById,
+        campaignId: campaign.id,
+        date,
+        channelId: occurrence.channelId,
+        time,
+        content,
+        platform: channelRow.platform,
+        scheduledAt: now,
+        destination: content.destination,
+      });
+
+      await db
+        .update(evergreenOccurrences)
+        .set({
+          postIdRef: picked.id,
+          variationId: variation.variationId,
+          postsRowId: postId,
+          jobId,
+          slotStatus: 'published',
+          publishedAt: now,
+        })
+        .where(eq(evergreenOccurrences.id, occurrenceId));
+
+      await db
+        .update(evergreenPosts)
+        .set({
+          recycledCount: picked.recycledCount + 1,
+          lastPublishedAt: now,
+          updatedAt: now,
+        })
+        .where(eq(evergreenPosts.id, picked.id));
+    } finally {
+      if (category.isActive) {
+        await this.armCategory(category, campaign, now);
+      } else {
+        this.logger.log(
+          `fireOccurrence(${occurrenceId}): category is inactive — not re-arming.`,
+        );
+      }
+    }
+  }
+}
+
+// ==========================================================================
+// Timezone formatting helper
+// ==========================================================================
+
+/** Format a UTC instant as wall-clock `{ date: yyyy-MM-dd, time: HH:mm }` in
+ *  `timeZone`, using the same `Intl.DateTimeFormat` trick as the rotation
+ *  util's `zoneOffsetMinutes` (kept local/simple rather than importing a
+ *  private helper). Falls back gracefully to UTC formatting if `timeZone`
+ *  is invalid. */
+function formatInTimeZone(
+  at: Date,
+  timeZone: string,
+): { date: string; time: string } {
+  let dtf: Intl.DateTimeFormat;
+  try {
+    dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'UTC',
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+  const parts = dtf.formatToParts(at);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '00';
+  return {
+    date: `${get('year')}-${get('month')}-${get('day')}`,
+    time: `${get('hour')}:${get('minute')}`,
+  };
 }

--- a/src/campaigns/evergreen.service.ts
+++ b/src/campaigns/evergreen.service.ts
@@ -940,6 +940,30 @@ export class EvergreenService {
     const now = new Date();
 
     try {
+      // Idempotency guard (m1): a BullMQ retry (attempts:3) re-runs this
+      // whole method from scratch. If a PRIOR attempt already got as far as
+      // `materializeAndEnqueue` (postsRowId written) but threw before the
+      // status-flip update below landed, re-materializing here would insert
+      // a SECOND orphan `posts` row for the same occurrence. postsRowId
+      // being set is proof the publish was already created, so treat this
+      // as already-fired: skip straight to making the occurrence row
+      // consistent (published) and fall through to the `finally` re-arm —
+      // never call materializeAndEnqueue a second time for one occurrence.
+      if (occurrence.postsRowId) {
+        this.logger.warn(
+          `fireOccurrence(${occurrenceId}): postsRowId already set (${occurrence.postsRowId}) — ` +
+            'treating as already-fired (retry after a post-materialize crash), not re-materializing.',
+        );
+        await db
+          .update(evergreenOccurrences)
+          .set({
+            slotStatus: 'published',
+            publishedAt: occurrence.publishedAt ?? now,
+          })
+          .where(eq(evergreenOccurrences.id, occurrenceId));
+        return;
+      }
+
       const postRows = await db
         .select()
         .from(evergreenPosts)

--- a/src/campaigns/evergreen.service.ts
+++ b/src/campaigns/evergreen.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { and, eq } from 'drizzle-orm';
@@ -31,12 +32,15 @@ import {
 } from './evergreen-rotation.util';
 import { CampaignPublishingService } from './campaign-publishing.service';
 import { QUEUES } from '../queue/queue.module';
+import { GroqService, type Platform } from '../ai/groq.service';
+import { AiTokenService } from '../ai/services/ai-token.service';
 import type {
   CreateEvergreenCampaignDto,
   CreateEvergreenCategoryDto,
   UpdateEvergreenCategoryDto,
   CreateEvergreenPostDto,
   UpdateEvergreenPostDto,
+  AddVariationDto,
 } from './dto/evergreen.dto';
 
 // ==========================================================================
@@ -129,6 +133,8 @@ export class EvergreenService {
     private readonly publishing: CampaignPublishingService,
     @InjectQueue(QUEUES.EVERGREEN_ROTATION)
     private readonly rotationQueue: Queue,
+    private readonly groq: GroqService,
+    private readonly aiTokens: AiTokenService,
   ) {}
 
   // ========================================================================
@@ -557,6 +563,187 @@ export class EvergreenService {
           eq(evergreenPosts.categoryId, categoryId),
         ),
       );
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  /** Scopes a pool post id to its category (ownership-guarded like
+   *  `updatePost`/`removePost` above), 404ing if it doesn't exist. Returns
+   *  the raw row so callers can read `content.caption` / `variations`
+   *  before deciding what to write. */
+  private async loadOwnedPost(
+    categoryId: string,
+    postId: string,
+  ): Promise<EvergreenPost> {
+    const [existing] = await db
+      .select()
+      .from(evergreenPosts)
+      .where(
+        and(
+          eq(evergreenPosts.id, postId),
+          eq(evergreenPosts.categoryId, categoryId),
+        ),
+      );
+    if (!existing) {
+      throw new NotFoundException('Post not found');
+    }
+    return existing;
+  }
+
+  /**
+   * Generates `count` AI variations of a pool post's base caption via
+   * `GroqService.generateVariations`, metered through
+   * `AiTokenService.executeWithTokens` (mirrors `ai.controller.ts`'s
+   * wrapping — token-check, deduct-on-success, log-on-failure). Platform is
+   * derived from the post's category's first configured channel (same
+   * `socialMediaChannels` lookup `fireOccurrence` uses to resolve a
+   * publish-time platform), falling back to the campaign's first
+   * `platforms` entry if the category has no channels configured yet.
+   *
+   * GRACEFUL DEGRADATION: the Groq call + token metering happen BEFORE any
+   * DB write. If either throws (Groq API failure, insufficient tokens,
+   * `executeWithTokens`'s own token-check rejection), the exception
+   * propagates to the caller untouched and this method returns without
+   * touching `evergreenPosts.variations` at all — no partial write, no
+   * corrupted array. The post is only persisted once generation has fully
+   * succeeded and the new variation objects are assembled.
+   */
+  async generateVariations(
+    workspaceId: string,
+    userId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+    count = 3,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+    const post = await this.loadOwnedPost(categoryId, postId);
+
+    const platform = await this.resolvePlatform(categoryId, campaignId);
+    const caption = post.content.caption;
+
+    const { result: variationCaptions } = await this.aiTokens.executeWithTokens(
+      workspaceId,
+      userId,
+      'generate_variations',
+      platform,
+      `Variations of: ${caption.substring(0, 100)}`,
+      async () => {
+        const variations = await this.groq.generateVariations(
+          caption,
+          platform as Platform,
+          count,
+        );
+        return { result: variations, outputLength: variations.join('').length };
+      },
+    );
+
+    // Only reachable once generation fully succeeded — assemble the new
+    // variation objects and persist in one write, appended after whatever
+    // already existed.
+    const newVariations = variationCaptions.map((text) => ({
+      id: randomUUID(),
+      caption: text,
+      source: 'ai' as const,
+    }));
+
+    await db
+      .update(evergreenPosts)
+      .set({
+        variations: [...post.variations, ...newVariations],
+        updatedAt: new Date(),
+      })
+      .where(eq(evergreenPosts.id, postId));
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  /** Best-effort platform resolution for AI generation: the category's
+   *  first configured channel's platform (same `socialMediaChannels`
+   *  lookup `fireOccurrence` uses at publish time), falling back to the
+   *  campaign's first `platforms` entry, then to `'facebook'` if neither is
+   *  configured yet (a brand-new category/campaign with no channels
+   *  attached — generation should still work, just without a
+   *  platform-tuned prompt). */
+  private async resolvePlatform(
+    categoryId: string,
+    campaignId: string,
+  ): Promise<string> {
+    const [category] = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.id, categoryId));
+    const channelIds = (category?.channelIds as string[] | null) ?? [];
+
+    if (channelIds.length > 0) {
+      const [channelRow] = await db
+        .select()
+        .from(socialMediaChannels)
+        .where(eq(socialMediaChannels.id, Number(channelIds[0])));
+      if (channelRow) {
+        return channelRow.platform;
+      }
+    }
+
+    const [campaign] = await db
+      .select()
+      .from(campaigns)
+      .where(eq(campaigns.id, campaignId));
+    const platforms = (campaign?.platforms as string[] | null) ?? [];
+    return platforms[0] ?? 'facebook';
+  }
+
+  /** Appends a manually-authored variation (`source: 'manual'`) to the
+   *  post's variations array. */
+  async addVariation(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+    dto: AddVariationDto,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+    const post = await this.loadOwnedPost(categoryId, postId);
+
+    const newVariation = {
+      id: randomUUID(),
+      caption: dto.caption,
+      media: dto.media,
+      source: 'manual' as const,
+    };
+
+    await db
+      .update(evergreenPosts)
+      .set({
+        variations: [...post.variations, newVariation],
+        updatedAt: new Date(),
+      })
+      .where(eq(evergreenPosts.id, postId));
+
+    return this.assembleEvergreen(campaignId);
+  }
+
+  /** Removes one variation by id, leaving the rest untouched. */
+  async removeVariation(
+    workspaceId: string,
+    campaignId: string,
+    categoryId: string,
+    postId: string,
+    variationId: string,
+  ): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, campaignId);
+    await this.loadOwnedCategory(campaignId, categoryId);
+    const post = await this.loadOwnedPost(categoryId, postId);
+
+    await db
+      .update(evergreenPosts)
+      .set({
+        variations: post.variations.filter((v) => v.id !== variationId),
+        updatedAt: new Date(),
+      })
+      .where(eq(evergreenPosts.id, postId));
 
     return this.assembleEvergreen(campaignId);
   }

--- a/src/campaigns/evergreen.service.ts
+++ b/src/campaigns/evergreen.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { and, eq } from 'drizzle-orm';
@@ -10,6 +15,7 @@ import {
   type CampaignScheduleEvergreenJson,
 } from '../drizzle/schema/campaigns.schema';
 import { socialMediaChannels } from '../drizzle/schema/channels.schema';
+import { posts } from '../drizzle/schema/posts.schema';
 import {
   evergreenCategories,
   evergreenOccurrences,
@@ -573,12 +579,17 @@ export class EvergreenService {
   // ========================================================================
 
   /**
-   * Computes the category's next fire instant and arms it: inserts a
-   * `scheduled` `evergreenOccurrences` row (picking the post to fire via
-   * `pickNextPost`, and a channel from the category's `channelIds`) and
-   * enqueues a delayed `evergreen-rotation` job `{ occurrenceId }` with a
-   * deterministic `jobId = evg-<occurrenceId>`. Does nothing (just logs) when
-   * the category has no weekdays/times configured (no next fire) or has no
+   * Computes the category's next fire instant and arms it: inserts ONE
+   * `scheduled` `evergreenOccurrences` row PER `channelId` in the category's
+   * `channelIds` (each its own occurrence → own post → own BullMQ job), all
+   * at the SAME fire instant. The post to fire is picked ONCE via
+   * `pickNextPost` and shared across every channel's occurrence for this
+   * fire instant (rather than re-picked per channel) — simpler, and keeps
+   * "what's firing right now" a single coherent answer across a category's
+   * channels rather than a per-channel roulette. Each occurrence gets its
+   * own deterministic `jobId = evg-<occurrenceId>`, so multiple channels
+   * never collide on one BullMQ job id. Does nothing (just logs) when the
+   * category has no weekdays/times configured (no next fire) or has no
    * channel/eligible post to arm against — the chain simply stays dormant
    * until the category is edited into a fireable state.
    */
@@ -586,6 +597,7 @@ export class EvergreenService {
     category: EvergreenCategory,
     campaign: Campaign,
     now: Date,
+    excludeOccurrenceId?: string,
   ): Promise<void> {
     const schedule = campaign.schedule as CampaignScheduleEvergreenJson;
 
@@ -603,8 +615,7 @@ export class EvergreenService {
     }
 
     const channelIds = (category.channelIds as string[] | null) ?? [];
-    const channelId = channelIds[0];
-    if (!channelId) {
+    if (channelIds.length === 0) {
       this.logger.warn(
         `armCategory(${category.id}): no channelIds configured — not arming.`,
       );
@@ -624,37 +635,78 @@ export class EvergreenService {
       return;
     }
 
-    const [occurrence] = await db
-      .insert(evergreenOccurrences)
-      .values({
-        campaignId: category.campaignId,
-        categoryId: category.id,
-        postIdRef: picked.id,
-        variationId: null,
-        channelId,
-        scheduledAt: nextFire,
-        slotStatus: 'scheduled',
-      })
-      .returning();
-
-    const jobId = `evg-${occurrence.id}`;
-    const delay = Math.max(0, nextFire.getTime() - now.getTime());
-
-    await this.rotationQueue.add(
-      'evergreen-fire',
-      { occurrenceId: occurrence.id },
-      {
-        delay,
-        jobId,
-        attempts: 3,
-        backoff: { type: 'exponential', delay: 5000 },
-      },
+    // Idempotency guard: skip any channel that already has a future
+    // `scheduled` occurrence. Without this, calling `armCategory` again on a
+    // category that's only PARTIALLY missing coverage (e.g. `reconcile`
+    // finds channel B uncovered but channel A is still healthy) would insert
+    // a SECOND live occurrence for channel A — a genuine duplicate/double-fire,
+    // since each occurrence gets a fresh UUID and thus a distinct
+    // deterministic jobId (the "deterministic jobId prevents double-fire"
+    // guarantee only holds per-occurrence, not across re-arms). Filtering
+    // here makes `armCategory` safe to call repeatedly against a category
+    // that's already fully or partially armed — by `resume` after a
+    // no-op-should-be pause, or by `reconcile`'s belt-and-suspenders sweep.
+    // `excludeOccurrenceId` (set only by `fireOccurrence`'s re-arm-in-finally
+    // call) excludes the occurrence currently being fired from this check —
+    // it's still nominally `scheduled` in the DB if the fire threw before
+    // reaching its own status-flip write, but it must NOT count as live
+    // coverage for its own channel or the chain dies on the first failure.
+    const existingOccurrences = await db
+      .select()
+      .from(evergreenOccurrences)
+      .where(eq(evergreenOccurrences.categoryId, category.id));
+    const coveredChannels = new Set(
+      existingOccurrences
+        .filter(
+          (o) =>
+            o.id !== excludeOccurrenceId &&
+            o.slotStatus === 'scheduled' &&
+            o.scheduledAt.getTime() >= now.getTime(),
+        )
+        .map((o) => o.channelId),
     );
+    const channelsToArm = channelIds.filter((c) => !coveredChannels.has(c));
 
-    await db
-      .update(evergreenOccurrences)
-      .set({ jobId })
-      .where(eq(evergreenOccurrences.id, occurrence.id));
+    if (channelsToArm.length === 0) {
+      this.logger.log(
+        `armCategory(${category.id}): every channel already has a future scheduled occurrence — nothing to arm.`,
+      );
+      return;
+    }
+
+    for (const channelId of channelsToArm) {
+      const [occurrence] = await db
+        .insert(evergreenOccurrences)
+        .values({
+          campaignId: category.campaignId,
+          categoryId: category.id,
+          postIdRef: picked.id,
+          variationId: null,
+          channelId,
+          scheduledAt: nextFire,
+          slotStatus: 'scheduled',
+        })
+        .returning();
+
+      const jobId = `evg-${occurrence.id}`;
+      const delay = Math.max(0, nextFire.getTime() - now.getTime());
+
+      await this.rotationQueue.add(
+        'evergreen-fire',
+        { occurrenceId: occurrence.id },
+        {
+          delay,
+          jobId,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+        },
+      );
+
+      await db
+        .update(evergreenOccurrences)
+        .set({ jobId })
+        .where(eq(evergreenOccurrences.id, occurrence.id));
+    }
   }
 
   /**
@@ -781,11 +833,224 @@ export class EvergreenService {
         .where(eq(evergreenPosts.id, picked.id));
     } finally {
       if (category.isActive) {
-        await this.armCategory(category, campaign, now);
+        // Exclude this occurrence from armCategory's own-channel coverage
+        // check — on the success paths above its slotStatus already flipped
+        // away from 'scheduled' (published/skipped) so this is only load-
+        // bearing on the exception path, where the status-flip write never
+        // ran and the row is still nominally 'scheduled'.
+        await this.armCategory(category, campaign, now, occurrenceId);
       } else {
         this.logger.log(
           `fireOccurrence(${occurrenceId}): category is inactive — not re-arming.`,
         );
+      }
+    }
+  }
+
+  // ========================================================================
+  // Lifecycle — launch / pause / resume / reconcile
+  //
+  // Delegated into from `CampaignsService` when `campaign.type ===
+  // 'evergreen'` (one-directional dependency: THIS service never imports or
+  // injects `CampaignsService`, so there's no circular-dep risk — see
+  // task-7-brief's CIRCULAR-DEP ruling).
+  // ========================================================================
+
+  /** True when at least one pool post under `categoryId` is eligible to fire
+   *  right now against `category`. Used by `launch`'s preflight (does ANY
+   *  active category have publishable content) without needing to actually
+   *  arm anything yet. */
+  private async categoryHasEligiblePost(
+    category: EvergreenCategory,
+    now: Date,
+  ): Promise<boolean> {
+    const postRows = await db
+      .select()
+      .from(evergreenPosts)
+      .where(eq(evergreenPosts.categoryId, category.id));
+    return pickNextPost(postRows, category, now) !== null;
+  }
+
+  /**
+   * Validates the campaign has at least one active category with at least
+   * one eligible pool post (mirrors `CampaignsService.launch`'s preflight —
+   * throws a clear `BadRequestException` rather than silently launching an
+   * empty campaign), arms (fan-out) every active category, then flips the
+   * campaign to `active` with `launchedAt` set. A category that individually
+   * has zero eligible posts is simply skipped by `armCategory` (it no-ops
+   * and logs) — the launch as a whole still succeeds as long as AT LEAST ONE
+   * active category could arm.
+   */
+  async launch(workspaceId: string, id: string): Promise<EvergreenCampaignDto> {
+    const campaign = await this.loadOwnedCampaign(workspaceId, id);
+
+    const categoryRows = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.campaignId, id));
+
+    const activeCategories = categoryRows.filter((c) => c.isActive);
+    const now = new Date();
+
+    const eligibleFlags = await Promise.all(
+      activeCategories.map((c) => this.categoryHasEligiblePost(c, now)),
+    );
+    const hasAnyEligible = eligibleFlags.some(Boolean);
+
+    if (activeCategories.length === 0 || !hasAnyEligible) {
+      throw new BadRequestException(
+        'This campaign has no publishable content. Add at least one active category with an eligible post before launching.',
+      );
+    }
+
+    for (const category of activeCategories) {
+      await this.armCategory(category, campaign, now);
+    }
+
+    await db
+      .update(campaigns)
+      .set({ status: 'active', launchedAt: now, updatedAt: now })
+      .where(eq(campaigns.id, id));
+
+    return this.assembleEvergreen(id);
+  }
+
+  /**
+   * Pulls back every future `scheduled` occurrence: cancels its enqueued
+   * BullMQ job and deletes its not-yet-published `posts` row (guarded on
+   * `posts.status = 'scheduled'`, same race-safety pattern as
+   * `CampaignsService.cancelAndClearSlotPost` — a post that's already
+   * flipped to `publishing` is left alone rather than yanked mid-flight),
+   * then removes the occurrence row itself so `reconcile`/`resume` see a
+   * clean slate to re-arm from. Already-`published`/`skipped` occurrences
+   * are left untouched — pause only pulls back work that hasn't fired yet.
+   * The pool + categories themselves are untouched; only in-flight
+   * scheduling state is torn down.
+   */
+  async pause(workspaceId: string, id: string): Promise<EvergreenCampaignDto> {
+    await this.loadOwnedCampaign(workspaceId, id);
+
+    const occurrenceRows = await db
+      .select()
+      .from(evergreenOccurrences)
+      .where(eq(evergreenOccurrences.campaignId, id));
+
+    const now = Date.now();
+    const futureScheduled = occurrenceRows.filter(
+      (o) => o.slotStatus === 'scheduled' && o.scheduledAt.getTime() >= now,
+    );
+
+    for (const occurrence of futureScheduled) {
+      if (occurrence.jobId) {
+        await this.publishing.cancelSlotJob(occurrence.jobId);
+      }
+      if (occurrence.postsRowId) {
+        await db
+          .delete(posts)
+          .where(
+            and(
+              eq(posts.id, occurrence.postsRowId),
+              eq(posts.status, 'scheduled'),
+            ),
+          );
+      }
+      await db
+        .delete(evergreenOccurrences)
+        .where(eq(evergreenOccurrences.id, occurrence.id));
+    }
+
+    await db
+      .update(campaigns)
+      .set({ status: 'paused', updatedAt: new Date() })
+      .where(eq(campaigns.id, id));
+
+    return this.assembleEvergreen(id);
+  }
+
+  /**
+   * Re-arms (fan-out) every active category and flips the campaign back to
+   * `active`. Mirrors `launch` minus the preflight validation — a campaign
+   * that was launched once already proved it has publishable content, and a
+   * category with zero eligible posts today simply arms nothing (same
+   * graceful no-op `armCategory` already applies elsewhere) rather than
+   * blocking the resume.
+   */
+  async resume(workspaceId: string, id: string): Promise<EvergreenCampaignDto> {
+    const campaign = await this.loadOwnedCampaign(workspaceId, id);
+
+    const categoryRows = await db
+      .select()
+      .from(evergreenCategories)
+      .where(eq(evergreenCategories.campaignId, id));
+
+    const now = new Date();
+    for (const category of categoryRows.filter((c) => c.isActive)) {
+      await this.armCategory(category, campaign, now);
+    }
+
+    await db
+      .update(campaigns)
+      .set({ status: 'active', updatedAt: now })
+      .where(eq(campaigns.id, id));
+
+    return this.assembleEvergreen(id);
+  }
+
+  /**
+   * Belt-and-suspenders sweep against a dead rotation chain: for every
+   * ACTIVE evergreen campaign's ACTIVE category, checks each configured
+   * channel individually — if that channel has no future `scheduled`
+   * occurrence, re-arms the category (fan-out inserts one occurrence PER
+   * channel, so a channel that's already covered doesn't need re-arming;
+   * only the campaign-wide gap matters). Idempotent: `armCategory`'s
+   * deterministic `jobId = evg-<occurrenceId>` means even if this runs
+   * against a chain that's actually still healthy, no double-fire can occur
+   * — BullMQ rejects/no-ops a duplicate job id, and each occurrence row is
+   * freshly inserted so there's no update collision either. Intended to run
+   * on a daily cron (`EvergreenReconcileCron`); safe to call ad hoc too.
+   */
+  async reconcile(): Promise<void> {
+    const activeCampaigns = (
+      await db.select().from(campaigns)
+    ).filter((c) => c.type === 'evergreen' && c.status === 'active');
+
+    const now = new Date();
+
+    for (const campaign of activeCampaigns) {
+      const categoryRows = await db
+        .select()
+        .from(evergreenCategories)
+        .where(eq(evergreenCategories.campaignId, campaign.id));
+
+      for (const category of categoryRows.filter((c) => c.isActive)) {
+        const channelIds = (category.channelIds as string[] | null) ?? [];
+        if (channelIds.length === 0) continue;
+
+        const occurrenceRows = await db
+          .select()
+          .from(evergreenOccurrences)
+          .where(eq(evergreenOccurrences.categoryId, category.id));
+
+        const coveredChannels = new Set(
+          occurrenceRows
+            .filter(
+              (o) =>
+                o.slotStatus === 'scheduled' &&
+                o.scheduledAt.getTime() >= now.getTime(),
+            )
+            .map((o) => o.channelId),
+        );
+
+        const missingAChannel = channelIds.some(
+          (channelId) => !coveredChannels.has(channelId),
+        );
+
+        if (missingAChannel) {
+          this.logger.log(
+            `reconcile(): category ${category.id} has a channel with no future scheduled occurrence — re-arming.`,
+          );
+          await this.armCategory(category, campaign, now);
+        }
       }
     }
   }

--- a/src/campaigns/processors/evergreen-fire.processor.ts
+++ b/src/campaigns/processors/evergreen-fire.processor.ts
@@ -1,0 +1,54 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { QUEUES } from '../../queue/queue.module';
+import { EvergreenService } from '../evergreen.service';
+
+interface EvergreenFireJobData {
+  occurrenceId: string;
+}
+
+/**
+ * Consumes the `evergreen-rotation` queue. Each job fires exactly one
+ * `evergreenOccurrences` row: `EvergreenService.fireOccurrence` publishes the
+ * picked post and — in its own `finally` — arms the category's next fire, so
+ * the chain is self-perpetuating from here on. Mirrors
+ * `src/posts/processors/post-publish.processor.ts`'s shape.
+ */
+@Processor(QUEUES.EVERGREEN_ROTATION, {
+  concurrency: 5,
+})
+export class EvergreenFireProcessor extends WorkerHost {
+  private readonly logger = new Logger(EvergreenFireProcessor.name);
+
+  constructor(private readonly evergreen: EvergreenService) {
+    super();
+  }
+
+  async process(job: Job<EvergreenFireJobData>): Promise<void> {
+    const { occurrenceId } = job.data;
+    this.logger.log(`Firing evergreen occurrence: ${occurrenceId}`);
+    await this.evergreen.fireOccurrence(occurrenceId);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<EvergreenFireJobData>) {
+    this.logger.log(
+      `Job ${job.id} completed for occurrence ${job.data.occurrenceId}`,
+    );
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<EvergreenFireJobData> | undefined, error: Error) {
+    if (job) {
+      this.logger.error(
+        `Job ${job.id} failed for occurrence ${job.data.occurrenceId} after ${job.attemptsMade} attempts: ${error.message}`,
+      );
+    }
+  }
+
+  @OnWorkerEvent('stalled')
+  onStalled(jobId: string) {
+    this.logger.warn(`Job ${jobId} stalled`);
+  }
+}

--- a/src/drizzle/schema/evergreen.schema.spec.ts
+++ b/src/drizzle/schema/evergreen.schema.spec.ts
@@ -1,0 +1,48 @@
+import {
+  evergreenCategories,
+  evergreenPosts,
+  evergreenOccurrences,
+  EVERGREEN_POST_STATUSES,
+} from './evergreen.schema';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+
+describe('evergreen schema', () => {
+  it('defines the three evergreen tables with correct names', () => {
+    expect(getTableConfig(evergreenCategories).name).toBe(
+      'campaign_evergreen_categories',
+    );
+    expect(getTableConfig(evergreenPosts).name).toBe(
+      'campaign_evergreen_posts',
+    );
+    expect(getTableConfig(evergreenOccurrences).name).toBe(
+      'campaign_evergreen_occurrences',
+    );
+  });
+
+  it('categories table has a unique (campaign_id, name) index', () => {
+    const idx = getTableConfig(evergreenCategories).indexes.map(
+      (i) => i.config.name,
+    );
+    expect(idx).toContain('evergreen_categories_campaign_name_uq');
+  });
+
+  it('exports the post status enum', () => {
+    expect(EVERGREEN_POST_STATUSES).toEqual(['active', 'paused', 'retired']);
+  });
+
+  it('posts table has category_id and campaign_id columns', () => {
+    const cols = getTableConfig(evergreenPosts).columns.map((c) => c.name);
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'category_id',
+        'campaign_id',
+        'content',
+        'variations',
+        'recycle_policy',
+        'performance_score',
+        'is_stale',
+        'status',
+      ]),
+    );
+  });
+});

--- a/src/drizzle/schema/evergreen.schema.ts
+++ b/src/drizzle/schema/evergreen.schema.ts
@@ -1,0 +1,123 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  varchar,
+  boolean,
+  jsonb,
+  integer,
+  real,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { campaigns, CampaignSlotStatus, ChannelDayContentJson } from './campaigns.schema';
+
+export const EVERGREEN_POST_STATUSES = ['active', 'paused', 'retired'] as const;
+export type EvergreenPostStatus = (typeof EVERGREEN_POST_STATUSES)[number];
+
+export interface EvergreenCategoryScheduleJson {
+  weekdays: number[]; // 0=Sun..6=Sat
+  times: string[];    // HH:mm
+}
+export interface EvergreenSeasonalJson {
+  startDate: string; // yyyy-MM-dd
+  endDate: string;
+}
+export interface EvergreenVariationJson {
+  id: string;
+  caption: string;
+  media?: { id: string; filename: string; kind: 'image' | 'video'; url?: string }[];
+  source: 'ai' | 'manual';
+}
+export interface RecyclePolicyJson {
+  mode: 'forever' | 'maxCount' | 'expiry';
+  maxCount?: number;
+  expiryDate?: string; // yyyy-MM-dd
+}
+
+export const evergreenCategories = pgTable(
+  'campaign_evergreen_categories',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 120 }).notNull(),
+    color: varchar('color', { length: 20 }).notNull(),
+    schedule: jsonb('schedule').$type<EvergreenCategoryScheduleJson>().notNull(),
+    channelIds: jsonb('channel_ids').$type<string[]>().default([]).notNull(),
+    seasonal: jsonb('seasonal').$type<EvergreenSeasonalJson | null>(),
+    isActive: boolean('is_active').default(true).notNull(),
+    rotationCursor: integer('rotation_cursor').default(0).notNull(),
+    sortOrder: integer('sort_order').default(0).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    uqCampaignName: uniqueIndex('evergreen_categories_campaign_name_uq').on(t.campaignId, t.name),
+  }),
+);
+
+export const evergreenPosts = pgTable(
+  'campaign_evergreen_posts',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    categoryId: uuid('category_id').notNull().references(() => evergreenCategories.id, { onDelete: 'cascade' }),
+    content: jsonb('content').$type<ChannelDayContentJson>().notNull(),
+    variations: jsonb('variations').$type<EvergreenVariationJson[]>().default([]).notNull(),
+    recyclePolicy: jsonb('recycle_policy').$type<RecyclePolicyJson>().notNull(),
+    minGapHours: integer('min_gap_hours').default(0).notNull(),
+    recycledCount: integer('recycled_count').default(0).notNull(),
+    lastPublishedAt: timestamp('last_published_at', { withTimezone: true }),
+    performanceScore: real('performance_score'),
+    isStale: boolean('is_stale').default(false).notNull(),
+    staleReason: text('stale_reason'),
+    status: varchar('status', { length: 20 }).$type<EvergreenPostStatus>().default('active').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    idxCategoryStatus: index('evergreen_posts_category_status_idx').on(t.categoryId, t.status),
+    idxCampaign: index('evergreen_posts_campaign_idx').on(t.campaignId),
+  }),
+);
+
+export const evergreenOccurrences = pgTable(
+  'campaign_evergreen_occurrences',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    campaignId: uuid('campaign_id').notNull().references(() => campaigns.id, { onDelete: 'cascade' }),
+    categoryId: uuid('category_id').notNull().references(() => evergreenCategories.id, { onDelete: 'cascade' }),
+    postIdRef: uuid('post_id_ref').notNull().references(() => evergreenPosts.id, { onDelete: 'cascade' }),
+    variationId: varchar('variation_id', { length: 64 }),
+    channelId: varchar('channel_id', { length: 255 }).notNull(),
+    scheduledAt: timestamp('scheduled_at', { withTimezone: true }).notNull(),
+    slotStatus: varchar('slot_status', { length: 20 }).$type<CampaignSlotStatus>().default('scheduled').notNull(),
+    postsRowId: uuid('posts_row_id'),
+    jobId: varchar('job_id', { length: 160 }),
+    publishedAt: timestamp('published_at', { withTimezone: true }),
+    lastError: text('last_error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    idxCampaignScheduled: index('evergreen_occurrences_campaign_scheduled_idx').on(t.campaignId, t.scheduledAt),
+    idxPostRef: index('evergreen_occurrences_post_ref_idx').on(t.postIdRef),
+    idxJob: index('evergreen_occurrences_job_idx').on(t.jobId),
+  }),
+);
+
+export const evergreenCategoriesRelations = relations(evergreenCategories, ({ one, many }) => ({
+  campaign: one(campaigns, { fields: [evergreenCategories.campaignId], references: [campaigns.id] }),
+  posts: many(evergreenPosts),
+}));
+export const evergreenPostsRelations = relations(evergreenPosts, ({ one }) => ({
+  category: one(evergreenCategories, { fields: [evergreenPosts.categoryId], references: [evergreenCategories.id] }),
+}));
+
+export type EvergreenCategory = typeof evergreenCategories.$inferSelect;
+export type NewEvergreenCategory = typeof evergreenCategories.$inferInsert;
+export type EvergreenPost = typeof evergreenPosts.$inferSelect;
+export type NewEvergreenPost = typeof evergreenPosts.$inferInsert;
+export type EvergreenOccurrence = typeof evergreenOccurrences.$inferSelect;
+export type NewEvergreenOccurrence = typeof evergreenOccurrences.$inferInsert;

--- a/src/drizzle/schema/index.ts
+++ b/src/drizzle/schema/index.ts
@@ -25,3 +25,4 @@ export * from './canva.schema';
 export * from './calendar-sync.schema';
 export * from './admin-login-challenge.schema';
 export * from './campaigns.schema';
+export * from './evergreen.schema';

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -19,6 +19,7 @@ export const QUEUES = {
   DISCORD_INGEST: 'discord-ingest',
   WHATSAPP_INGEST: 'whatsapp-ingest',
   MAESTRO_BRIDGE: 'maestro-bridge',
+  EVERGREEN_ROTATION: 'evergreen-rotation',
 } as const;
 
 @Module({
@@ -72,6 +73,7 @@ export const QUEUES = {
       { name: QUEUES.DISCORD_INGEST },
       { name: QUEUES.WHATSAPP_INGEST },
       { name: QUEUES.MAESTRO_BRIDGE },
+      { name: QUEUES.EVERGREEN_ROTATION },
     ),
   ],
   providers: [RateLimiterService],


### PR DESCRIPTION
## What

A 4th campaign type: **Evergreen Recycling** — auto-rotates a pool of categorized posts on a repeating schedule, **forever until paused** (unlike bulk/drip which are finite).

Category buckets (each with its own schedule + rotating post pool) → per-fire re-enqueue rotation engine → reuses the existing `post-publishing` publish path.

## Architecture

- **3 new tables** (additive): `campaign_evergreen_categories`, `campaign_evergreen_posts`, `campaign_evergreen_occurrences`. Parent `campaigns` row reused (`type='evergreen'`).
- **Rotation engine** (genuinely new — no prior engine re-fires after publish): `armCategory` picks a post + inserts one occurrence per channel → delayed BullMQ job on a new `evergreen-rotation` queue. `fireOccurrence` re-validates at fire time, materializes via the existing `materializeAndEnqueue`, then `try/finally` **always re-arms the next fire** (self-healing chain). Daily reconcile `@Cron` re-arms dead chains.
- **4 differentiators, all graceful-degrade:** D1 AI variations (Groq), D2 performance-aware picker (post_metric_snapshots; null score = neutral, never sinks), D3 freshness guard (Groq; on error → not flagged), D4 messaging channels (free via `PostTarget.destination`).
- **Lifecycle** (launch/pause/resume) branches from `CampaignsService` — bulk/drip byte-for-byte unchanged (regression-guarded).

## Migration

⚠️ The 3 tables are applied via a hand-written idempotent SQL script (`drizzle/manual/2026-08-18-evergreen-recycling-tables.sql`), NOT `db:generate` — the repo's migration journal has pre-existing drift (see precedent 2cf7946). **Already applied to prod** via the Railway psql console (verified: 3 tables present).

## Testing

- 213/213 campaigns tests, `nest build` clean.
- Whole-branch review (opus) — rotation engine adversarially clean (self-heal, tz/DST, D2 null-neutrality, no DI cycle, bulk isolation, pause cleanup). Found + fixed: read-path not branched (getOne → assembleEvergreen), an IDOR in checkFreshness (workspace guard added), fire-retry orphan-row guard.

Built via full spec → plan → subagent-driven TDD. Spec: `docs/superpowers/specs/2026-08-17-evergreen-recycling-design.md`.

Paired with the frontend PR (asad00712/schedura-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)