### PR TITLE
feat(auth): gate the app only after onboarding, not during signup

### DIFF
--- a/src/auth/guards/allowlist.guard.spec.ts
+++ b/src/auth/guards/allowlist.guard.spec.ts
@@ -18,6 +18,12 @@ function make(opts: {
   skip?: boolean;
   verify?: (t: string) => { sub: string; email: string };
   role?: string;
+  // Onboarding state of the looked-up user. Default: a real timestamp, i.e.
+  // ONBOARDED — so the "block unlisted" tests exercise the post-onboarding
+  // lock. Pass `null` to simulate a user still in onboarding; pass a custom
+  // resolver via `user` to simulate a failed lookup.
+  onboardingCompletedAt?: Date | string | null;
+  user?: unknown;
 }) {
   const jwtService = {
     verify: jest.fn((t: string) =>
@@ -25,10 +31,18 @@ function make(opts: {
     ),
   };
   const config = { get: jest.fn().mockReturnValue('secret') };
+  const resolvedUser =
+    'user' in opts
+      ? opts.user
+      : {
+          role: opts.role ?? 'USER',
+          onboardingCompletedAt:
+            opts.onboardingCompletedAt === undefined
+              ? new Date('2026-01-01T00:00:00Z')
+              : opts.onboardingCompletedAt,
+        };
   const usersService = {
-    findOneWithSuspension: jest
-      .fn()
-      .mockResolvedValue({ role: opts.role ?? 'USER' }),
+    findOneWithSuspension: jest.fn().mockResolvedValue(resolvedUser),
   };
   return new AllowlistGuard(
     reflector(!!opts.skip),
@@ -81,6 +95,42 @@ describe('AllowlistGuard', () => {
     ).rejects.toMatchObject({
       response: { code: 'NOT_LAUNCHED' },
     });
+  });
+
+  it('passes an unlisted user still in onboarding (onboardingCompletedAt null)', async () => {
+    process.env.ALLOWLIST_EMAILS = 'a@x.com';
+    const g = make({
+      verify: () => ({ sub: 'u1', email: 'c@z.com' }),
+      role: 'USER',
+      onboardingCompletedAt: null,
+    });
+    await expect(
+      g.canActivate(ctx({ authorization: 'Bearer t' })),
+    ).resolves.toBe(true);
+  });
+
+  it('blocks an unlisted user once onboarding is complete', async () => {
+    process.env.ALLOWLIST_EMAILS = 'a@x.com';
+    const g = make({
+      verify: () => ({ sub: 'u1', email: 'c@z.com' }),
+      role: 'USER',
+      onboardingCompletedAt: new Date('2026-02-01T00:00:00Z'),
+    });
+    await expect(
+      g.canActivate(ctx({ authorization: 'Bearer t' })),
+    ).rejects.toMatchObject({ response: { code: 'NOT_LAUNCHED' } });
+  });
+
+  it('blocks (fail-safe) an unlisted user when the user lookup fails', async () => {
+    process.env.ALLOWLIST_EMAILS = 'a@x.com';
+    // Lookup returns nothing → onboardingCompletedAt undefined → must NOT open.
+    const g = make({
+      verify: () => ({ sub: 'u1', email: 'c@z.com' }),
+      user: undefined,
+    });
+    await expect(
+      g.canActivate(ctx({ authorization: 'Bearer t' })),
+    ).rejects.toMatchObject({ response: { code: 'NOT_LAUNCHED' } });
   });
 
   it('passes a listed user', async () => {

--- a/src/auth/guards/allowlist.guard.ts
+++ b/src/auth/guards/allowlist.guard.ts
@@ -55,18 +55,32 @@ export class AllowlistGuard implements CanActivate {
       return true; // invalid/expired token → let JwtAuthGuard 401 it
     }
 
-    // Need the role to honor "super admin always passes".
+    // Need the role to honor "super admin always passes", and the onboarding
+    // flag so we only block AFTER onboarding is finished (below).
     let role: string | undefined;
+    let onboardingCompletedAt: Date | string | null | undefined;
     try {
       const user = await this.usersService.findOneWithSuspension(
         payload.sub as string,
       );
       role = user?.role;
+      onboardingCompletedAt = user?.onboardingCompletedAt;
     } catch {
       role = undefined;
+      onboardingCompletedAt = undefined;
     }
 
     if (isEmailAllowlisted(payload.email, role)) return true;
+
+    // Not allowlisted — but let the full pre-launch signup flow complete first:
+    // signup, email verification, workspace creation, and the rest of
+    // onboarding all run for everyone. We only lock the app itself, which a
+    // user reaches once onboarding is marked complete. So a not-yet-onboarded
+    // user (onboardingCompletedAt strictly null) passes through; the block
+    // engages only once they finish onboarding (a real timestamp). A failed
+    // lookup (undefined) fails SAFE and blocks — an unknown state on a
+    // non-allowlisted token must not open the app.
+    if (onboardingCompletedAt === null) return true;
 
     throw new ForbiddenException({
       statusCode: 403,


### PR DESCRIPTION
## What

Changes *when* the pre-launch allowlist gate blocks a non-allowlisted user. Previously the gate 403'd every authenticated request, so signup finished but workspace creation and onboarding failed. Now the full pre-launch flow runs — signup → email verification → workspace creation → all onboarding steps — and the app locks only once onboarding is marked complete.

## How

`AllowlistGuard` now reads `onboardingCompletedAt` (already selected by `findOneWithSuspension`, no query change) alongside role:
- allowlisted / super admin → pass (unchanged)
- not allowlisted + `onboardingCompletedAt === null` (still onboarding) → **pass**
- not allowlisted + real timestamp (onboarded) → **403 NOT_LAUNCHED**
- not allowlisted + failed lookup (`undefined`) → **block, fail-safe**

The `/auth/onboarding/complete` call itself sees `null` at call time (it *sets* the timestamp), so it passes and the block engages on the next request — no chicken-and-egg.

Pairs with the frontend PR (moves `LaunchGate` off the onboarding route tree + refines the Under-development copy).

## Testing

9/9 guard tests (added: mid-onboarding passes, onboarded blocks, failed-lookup fails safe), `nest build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)