### PR TITLE
feat(ai): composer AI assist — inline caption + per-channel generation (Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,16 @@ WHATSAPP_ES_CONFIG_ID=
 THREADS_CLIENT_ID=
 THREADS_CLIENT_SECRET=
 
+# --- Inline AI assist (composer caption/hashtags/per-channel) ---
+# Gemini is the primary provider for inline generation (best multilingual +
+# reliability). If GOOGLE_AI_API_KEY is unset, the app silently falls back to
+# GROQ_API_KEY — no breakage, lower copy quality. (Maestro/agentic AI uses
+# Anthropic separately and is unaffected by these keys.)
+# Gemini: https://aistudio.google.com/app/apikey
+GOOGLE_AI_API_KEY=
+# Groq (fallback for inline; also used by evergreen/other /ai endpoints): https://console.groq.com/keys
+GROQ_API_KEY=
+
 # --- Composer stock-media providers (free API keys) ---
 # Each source in the composer's Add-media dialog needs its own key. Without a
 # key, that source shows a clean "try later" empty state; others keep working.

--- a/src/ai/ai-text.service.spec.ts
+++ b/src/ai/ai-text.service.spec.ts
@@ -1,0 +1,59 @@
+import { AiTextService } from './ai-text.service';
+
+describe('AiTextService', () => {
+  it('uses Gemini when it succeeds', async () => {
+    const gemini = {
+      isAvailable: () => true,
+      generateText: jest.fn().mockResolvedValue('G'),
+    } as any;
+    const groq = { isReady: () => true, completeRaw: jest.fn() } as any;
+    const svc = new AiTextService(gemini, groq);
+    await expect(svc.complete('s', 'u')).resolves.toBe('G');
+    expect(groq.completeRaw).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Groq when Gemini throws', async () => {
+    const gemini = {
+      isAvailable: () => true,
+      generateText: jest.fn().mockRejectedValue(new Error('rl')),
+    } as any;
+    const groq = {
+      isReady: () => true,
+      completeRaw: jest.fn().mockResolvedValue('Q'),
+    } as any;
+    const svc = new AiTextService(gemini, groq);
+    await expect(svc.complete('s', 'u')).resolves.toBe('Q');
+  });
+
+  it('rejects when both Gemini and Groq are unavailable', async () => {
+    const gemini = {
+      isAvailable: () => false,
+      generateText: jest.fn(),
+    } as any;
+    const groq = { isReady: () => false, completeRaw: jest.fn() } as any;
+    const svc = new AiTextService(gemini, groq);
+    await expect(svc.complete('s', 'u')).rejects.toThrow();
+    expect(gemini.generateText).not.toHaveBeenCalled();
+    expect(groq.completeRaw).not.toHaveBeenCalled();
+  });
+
+  describe('isReady', () => {
+    it('is true when Gemini is available', () => {
+      const gemini = { isAvailable: () => true } as any;
+      const groq = { isReady: () => false } as any;
+      expect(new AiTextService(gemini, groq).isReady()).toBe(true);
+    });
+
+    it('is true when Groq is ready', () => {
+      const gemini = { isAvailable: () => false } as any;
+      const groq = { isReady: () => true } as any;
+      expect(new AiTextService(gemini, groq).isReady()).toBe(true);
+    });
+
+    it('is false when neither is available', () => {
+      const gemini = { isAvailable: () => false } as any;
+      const groq = { isReady: () => false } as any;
+      expect(new AiTextService(gemini, groq).isReady()).toBe(false);
+    });
+  });
+});

--- a/src/ai/ai-text.service.ts
+++ b/src/ai/ai-text.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
+import { GroqService } from './groq.service';
+
+/**
+ * Single-shot LLM completion with Gemini as the primary provider and Groq
+ * as the fallback. Not chat/tool-calling — for that, use ChatbotModule's
+ * LLMRouterService. This is the low-level text-completion primitive shared
+ * by AI-assist features (e.g. per-channel composer suggestions).
+ */
+@Injectable()
+export class AiTextService {
+  private readonly logger = new Logger(AiTextService.name);
+
+  constructor(
+    private readonly gemini: GeminiChatProvider,
+    private readonly groq: GroqService,
+  ) {}
+
+  isReady(): boolean {
+    return this.gemini.isAvailable() || this.groq.isReady();
+  }
+
+  async complete(
+    systemPrompt: string,
+    userPrompt: string,
+    opts?: { temperature?: number; maxTokens?: number },
+  ): Promise<string> {
+    if (this.gemini.isAvailable()) {
+      try {
+        return await this.gemini.generateText(systemPrompt, userPrompt, opts);
+      } catch (err) {
+        this.logger.warn(
+          `Gemini failed, falling back to Groq: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    if (this.groq.isReady()) {
+      return this.groq.completeRaw(systemPrompt, userPrompt, opts);
+    }
+
+    throw new BadRequestException('AI is not configured');
+  }
+}

--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -20,6 +20,7 @@ import {
   AI_OPERATION_COSTS,
 } from './services/ai-token.service';
 import { ElevenLabsSttService } from './services/elevenlabs-stt.service';
+import { ComposerAiService } from './composer-ai.service';
 import {
   GeneratePostDto,
   GenerateCaptionDto,
@@ -33,6 +34,7 @@ import {
   TranslateContentDto,
   GenerateVariationsDto,
   AnalyzePostDto,
+  GeneratePerChannelDto,
   PLATFORMS,
   TONES,
 } from './dto/ai.dto';
@@ -44,6 +46,7 @@ export class AiController {
     private readonly groqService: GroqService,
     private readonly aiTokenService: AiTokenService,
     private readonly sttService: ElevenLabsSttService,
+    private readonly composerAiService: ComposerAiService,
   ) {}
 
   // ==========================================================================
@@ -432,6 +435,25 @@ export class AiController {
     );
 
     return { variations: result, usage };
+  }
+
+  /**
+   * Generate one tailored caption per platform (composer AI assist).
+   * Metered as a single billable unit regardless of how many platforms
+   * are requested.
+   */
+  @Post('workspaces/:workspaceId/generate/per-channel')
+  @HttpCode(HttpStatus.OK)
+  generatePerChannel(
+    @Param('workspaceId') workspaceId: string,
+    @Body() dto: GeneratePerChannelDto,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return this.composerAiService.generatePerChannel(
+      workspaceId,
+      user.userId,
+      dto,
+    );
   }
 
   /**

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -2,17 +2,27 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AiController } from './ai.controller';
 import { GroqService } from './groq.service';
+import { AiTextService } from './ai-text.service';
 import { TavilyService } from './services/tavily.service';
 import { DripContentGeneratorService } from './services/drip-content-generator.service';
 import { AiTokenService } from './services/ai-token.service';
 import { ElevenLabsSttService } from './services/elevenlabs-stt.service';
 import { DrizzleModule } from '../drizzle/drizzle.module';
+import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
 
+// GeminiChatProvider is provided here directly (not imported from
+// ChatbotModule) to avoid a circular module dependency: ChatbotModule
+// already imports AiModule, so AiModule importing ChatbotModule back would
+// cycle. GeminiChatProvider's constructor only depends on ConfigService
+// (already available via ConfigModule here), so instantiating a second,
+// AiModule-scoped copy is cheap and side-effect-free.
 @Module({
   imports: [ConfigModule, DrizzleModule],
   controllers: [AiController],
   providers: [
     GroqService,
+    GeminiChatProvider,
+    AiTextService,
     TavilyService,
     DripContentGeneratorService,
     AiTokenService,
@@ -20,6 +30,7 @@ import { DrizzleModule } from '../drizzle/drizzle.module';
   ],
   exports: [
     GroqService,
+    AiTextService,
     TavilyService,
     DripContentGeneratorService,
     AiTokenService,

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -7,6 +7,7 @@ import { TavilyService } from './services/tavily.service';
 import { DripContentGeneratorService } from './services/drip-content-generator.service';
 import { AiTokenService } from './services/ai-token.service';
 import { ElevenLabsSttService } from './services/elevenlabs-stt.service';
+import { ComposerAiService } from './composer-ai.service';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
 
@@ -27,6 +28,7 @@ import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
     DripContentGeneratorService,
     AiTokenService,
     ElevenLabsSttService,
+    ComposerAiService,
   ],
   exports: [
     GroqService,
@@ -35,6 +37,7 @@ import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
     DripContentGeneratorService,
     AiTokenService,
     ElevenLabsSttService,
+    ComposerAiService,
   ],
 })
 export class AiModule {}

--- a/src/ai/composer-ai.service.spec.ts
+++ b/src/ai/composer-ai.service.spec.ts
@@ -1,0 +1,71 @@
+import { ComposerAiService } from './composer-ai.service';
+
+describe('ComposerAiService', () => {
+  describe('generatePerChannel', () => {
+    it('generates one tailored caption per platform as a single billable unit', async () => {
+      const groq = {
+        buildCaptionPrompt: jest.fn((opts: any) => ({
+          system: `system:${opts.platform}`,
+          user: `user:${opts.platform}:${opts.tone ?? 'none'}`,
+        })),
+      } as any;
+
+      const aiText = {
+        complete: jest.fn((system: string) =>
+          Promise.resolve(`caption-for-${system.replace('system:', '')}`),
+        ),
+      } as any;
+
+      const aiTokens = {
+        executeWithTokens: jest.fn(
+          async (
+            _workspaceId: string,
+            _userId: string,
+            _operation: string,
+            _platform: string | undefined,
+            _inputSummary: string,
+            fn: () => Promise<{ result: unknown; outputLength?: number }>,
+          ) => {
+            const { result } = await fn();
+            return { result, usage: { tokensDeducted: 8, tokensRemaining: 92 } };
+          },
+        ),
+      } as any;
+
+      const service = new ComposerAiService(groq, aiText, aiTokens);
+
+      const output = await service.generatePerChannel('ws-1', 'user-1', {
+        description: 'New product launch',
+        platforms: ['twitter', 'linkedin', 'instagram'],
+        tone: 'promotional',
+        includeHashtags: true,
+      });
+
+      expect(output.variations).toEqual([
+        { platform: 'twitter', text: 'caption-for-twitter' },
+        { platform: 'linkedin', text: 'caption-for-linkedin' },
+        { platform: 'instagram', text: 'caption-for-instagram' },
+      ]);
+      expect(output.usage).toEqual({ tokensDeducted: 8, tokensRemaining: 92 });
+
+      // Tone threaded into every prompt build call.
+      expect(groq.buildCaptionPrompt).toHaveBeenCalledTimes(3);
+      for (const call of groq.buildCaptionPrompt.mock.calls) {
+        expect(call[0]).toMatchObject({
+          description: 'New product launch',
+          tone: 'promotional',
+          includeHashtags: true,
+          includeCta: true,
+        });
+      }
+
+      // Exactly one billable unit for the whole fan-out.
+      expect(aiTokens.executeWithTokens).toHaveBeenCalledTimes(1);
+      expect(aiTokens.executeWithTokens.mock.calls[0][2]).toBe(
+        'generate_per_channel',
+      );
+      expect(aiTokens.executeWithTokens.mock.calls[0][0]).toBe('ws-1');
+      expect(aiTokens.executeWithTokens.mock.calls[0][1]).toBe('user-1');
+    });
+  });
+});

--- a/src/ai/composer-ai.service.ts
+++ b/src/ai/composer-ai.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { GroqService } from './groq.service';
+import { AiTextService } from './ai-text.service';
+import { AiTokenService, TokenDeductResult } from './services/ai-token.service';
+import type { Platform, Tone } from './dto/ai.dto';
+
+export interface GeneratePerChannelInput {
+  description: string;
+  platforms: Platform[];
+  tone?: Tone;
+  includeHashtags?: boolean;
+}
+
+export interface PerChannelVariation {
+  platform: Platform;
+  text: string;
+}
+
+export interface GeneratePerChannelResult {
+  variations: PerChannelVariation[];
+  usage: TokenDeductResult;
+}
+
+/**
+ * Orchestrates per-channel caption generation for the composer: one tailored
+ * caption per platform, fanned out in parallel but metered as a SINGLE
+ * billable AI operation (see AI_OPERATION_COSTS.generate_per_channel).
+ */
+@Injectable()
+export class ComposerAiService {
+  constructor(
+    private readonly groq: GroqService,
+    private readonly aiText: AiTextService,
+    private readonly aiTokens: AiTokenService,
+  ) {}
+
+  async generatePerChannel(
+    workspaceId: string,
+    userId: string,
+    input: GeneratePerChannelInput,
+  ): Promise<GeneratePerChannelResult> {
+    const { description, platforms, tone, includeHashtags } = input;
+
+    const { result, usage } = await this.aiTokens.executeWithTokens(
+      workspaceId,
+      userId,
+      'generate_per_channel',
+      platforms.join(','),
+      `Per-channel: ${description.substring(0, 80)}`,
+      async () => {
+        const variations = await Promise.all(
+          platforms.map(async (platform) => {
+            const { system, user } = this.groq.buildCaptionPrompt({
+              description,
+              platform,
+              tone,
+              includeHashtags: !!includeHashtags,
+              includeCta: true,
+            });
+            const text = await this.aiText.complete(system, user);
+            return { platform, text };
+          }),
+        );
+        return {
+          result: { variations },
+          outputLength: variations.map((v) => v.text).join('').length,
+        };
+      },
+    );
+
+    return { ...result, usage };
+  }
+}

--- a/src/ai/dto/ai.dto.ts
+++ b/src/ai/dto/ai.dto.ts
@@ -4,6 +4,10 @@ import {
   IsEnum,
   IsArray,
   IsNumber,
+  IsIn,
+  IsBoolean,
+  IsNotEmpty,
+  ArrayMinSize,
   Min,
   Max,
   MinLength,
@@ -274,6 +278,29 @@ export class AnalyzePostDto {
 }
 
 // =============================================================================
+// Generate Per-Channel DTO (composer AI assist)
+// =============================================================================
+
+export class GeneratePerChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsIn(PLATFORMS, { each: true })
+  platforms: Platform[];
+
+  @IsIn(TONES)
+  @IsOptional()
+  tone?: Tone;
+
+  @IsBoolean()
+  @IsOptional()
+  includeHashtags?: boolean;
+}
+
+// =============================================================================
 // Response DTOs
 // =============================================================================
 
@@ -314,6 +341,16 @@ export class PostAnalysisResponseDto {
   strengths: string[];
   improvements: string[];
   suggestions: string;
+}
+
+export class PerChannelVariationResponseDto {
+  platform: Platform;
+  text: string;
+  hashtags?: string[];
+}
+
+export class GeneratedPerChannelResponseDto {
+  variations: PerChannelVariationResponseDto[];
 }
 
 export class AiStatusResponseDto {

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -160,6 +160,19 @@ export class GroqService {
   }
 
   /**
+   * Thin public passthrough onto the private raw completion runner, for
+   * callers (e.g. AiTextService) that need a raw Groq completion as a
+   * fallback rather than one of the typed prompt-building methods below.
+   */
+  async completeRaw(
+    systemPrompt: string,
+    userPrompt: string,
+    opts?: { temperature?: number; maxTokens?: number; model?: string },
+  ): Promise<string> {
+    return this.generateCompletion(systemPrompt, userPrompt, opts);
+  }
+
+  /**
    * Generate a short, descriptive title for a chat conversation from the
    * user's first message. Cheap + fast (small token budget). Returns a cleaned
    * 3-6 word Title-Case string.

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -214,13 +214,18 @@ export class GroqService {
   }
 
   /**
-   * Generate a caption for media content
+   * Build the system+user prompt pair for generateCaption without running
+   * it. Exposed so provider-agnostic callers (e.g. AiTextService via the
+   * controller layer) can reuse the exact same prompt through any provider.
    */
-  async generateCaption(options: GenerateCaptionOptions): Promise<string> {
+  buildCaptionPrompt(options: GenerateCaptionOptions): {
+    system: string;
+    user: string;
+  } {
     const { description, platform, tone, includeHashtags, includeCta } =
       options;
 
-    const userPrompt = USER_PROMPTS.generateCaption(
+    const user = USER_PROMPTS.generateCaption(
       description,
       platform,
       tone,
@@ -228,21 +233,40 @@ export class GroqService {
       includeCta,
     );
 
-    return this.generateCompletion(SYSTEM_PROMPTS.captionWriter, userPrompt);
+    return { system: SYSTEM_PROMPTS.captionWriter, user };
+  }
+
+  /**
+   * Generate a caption for media content
+   */
+  async generateCaption(options: GenerateCaptionOptions): Promise<string> {
+    const { system, user } = this.buildCaptionPrompt(options);
+
+    return this.generateCompletion(system, user);
+  }
+
+  /**
+   * Build the system+user prompt pair for generateHashtags without running
+   * it. See buildCaptionPrompt for why this exists.
+   */
+  buildHashtagsPrompt(options: GenerateHashtagsOptions): {
+    system: string;
+    user: string;
+  } {
+    const { topic, platform, count } = options;
+
+    const user = USER_PROMPTS.generateHashtags(topic, platform, count);
+
+    return { system: SYSTEM_PROMPTS.hashtagGenerator, user };
   }
 
   /**
    * Generate hashtags for a topic
    */
   async generateHashtags(options: GenerateHashtagsOptions): Promise<string[]> {
-    const { topic, platform, count } = options;
+    const { system, user } = this.buildHashtagsPrompt(options);
 
-    const userPrompt = USER_PROMPTS.generateHashtags(topic, platform, count);
-
-    const result = await this.generateCompletion(
-      SYSTEM_PROMPTS.hashtagGenerator,
-      userPrompt,
-    );
+    const result = await this.generateCompletion(system, user);
 
     // Parse hashtags from the response
     const hashtags = result
@@ -374,18 +398,31 @@ export class GroqService {
   }
 
   /**
-   * Improve an existing post
+   * Build the system+user prompt pair for improvePost without running it.
+   * See buildCaptionPrompt for why this exists.
    */
-  async improvePost(options: ImprovePostOptions): Promise<string> {
+  buildImprovePrompt(options: ImprovePostOptions): {
+    system: string;
+    user: string;
+  } {
     const { originalPost, platform, improvementFocus } = options;
 
-    const userPrompt = USER_PROMPTS.improvePost(
+    const user = USER_PROMPTS.improvePost(
       originalPost,
       platform,
       improvementFocus,
     );
 
-    return this.generateCompletion(SYSTEM_PROMPTS.contentGenerator, userPrompt);
+    return { system: SYSTEM_PROMPTS.contentGenerator, user };
+  }
+
+  /**
+   * Improve an existing post
+   */
+  async improvePost(options: ImprovePostOptions): Promise<string> {
+    const { system, user } = this.buildImprovePrompt(options);
+
+    return this.generateCompletion(system, user);
   }
 
   /**
@@ -469,6 +506,25 @@ export class GroqService {
   }
 
   /**
+   * Build the system+user prompt pair for generateVariations without
+   * running it. See buildCaptionPrompt for why this exists.
+   */
+  buildVariationsPrompt(
+    content: string,
+    platform: Platform,
+    count: number = 3,
+  ): { system: string; user: string } {
+    const user = `Create ${count} different variations of this ${platform} post. Each should convey the same message but with different wording, structure, or approach.
+
+Original post:
+${content}
+
+Provide ${count} variations, numbered 1 through ${count}. Each should be complete and ready to publish.`;
+
+    return { system: SYSTEM_PROMPTS.contentGenerator, user };
+  }
+
+  /**
    * Generate multiple variations of a post
    */
   async generateVariations(
@@ -476,20 +532,15 @@ export class GroqService {
     platform: Platform,
     count: number = 3,
   ): Promise<string[]> {
-    const prompt = `Create ${count} different variations of this ${platform} post. Each should convey the same message but with different wording, structure, or approach.
-
-Original post:
-${content}
-
-Provide ${count} variations, numbered 1 through ${count}. Each should be complete and ready to publish.`;
-
-    const result = await this.generateCompletion(
-      SYSTEM_PROMPTS.contentGenerator,
-      prompt,
-      {
-        maxTokens: 2048,
-      },
+    const { system, user } = this.buildVariationsPrompt(
+      content,
+      platform,
+      count,
     );
+
+    const result = await this.generateCompletion(system, user, {
+      maxTokens: 2048,
+    });
 
     // Parse variations
     const variations: string[] = [];

--- a/src/ai/services/ai-token.service.ts
+++ b/src/ai/services/ai-token.service.ts
@@ -33,6 +33,7 @@ export const AI_OPERATION_COSTS: Record<string, number> = {
   generate_youtube_metadata: 8,
   generate_variations: 8,
   analyze_post: 8,
+  generate_per_channel: 8,
   // Tier 4 - Complex (10 tokens)
   generate_thread: 10,
   // Tier 5 - Premium (15 tokens per platform)

--- a/src/chatbot/llm/gemini.provider.ts
+++ b/src/chatbot/llm/gemini.provider.ts
@@ -46,6 +46,29 @@ export class GeminiChatProvider extends BaseLLMProvider {
     return this.genAI !== null;
   }
 
+  /**
+   * Single-shot, non-chat completion. Throws if the provider isn't
+   * configured (no GOOGLE_AI_API_KEY) — callers should check
+   * `isAvailable()` first when they want to fall back instead of throwing.
+   */
+  async generateText(
+    systemPrompt: string,
+    userPrompt: string,
+    opts?: { temperature?: number; maxTokens?: number },
+  ): Promise<string> {
+    const genAI = this.ensureGenAI();
+    const model = genAI.getGenerativeModel({
+      model: this.defaultModel,
+      generationConfig: {
+        temperature: opts?.temperature ?? 0.7,
+        maxOutputTokens: opts?.maxTokens ?? 1024,
+      },
+      systemInstruction: systemPrompt,
+    });
+    const result = await model.generateContent(userPrompt);
+    return result.response.text();
+  }
+
   private ensureGenAI(): GoogleGenerativeAI {
     if (!this.genAI) {
       throw new Error('Google AI API is not configured');


### PR DESCRIPTION
## What

Phase 1 of the inline AI-assist layer: a "generate-fills-fields" experience in the post composer (distinct from the paid agentic Maestro). One prompt + tone → a single caption or per-channel tailored captions, written into the composer's real draft fields. Metered as free-quota → paid.

## Backend
- **`AiTextService`** — single-shot completion with **Gemini Flash primary + Groq fallback** (multilingual + reliability for international; silent Groq fallback if `GOOGLE_AI_API_KEY` unset — no breakage).
- **`ComposerAiService.generatePerChannel`** + **`POST /ai/workspaces/:id/generate/per-channel`** — fan-out over selected platforms, one tailored caption each (LinkedIn formal, Twitter short, IG emoji-heavy), billed as **ONE** metered unit (`generate_per_channel: 8`).
- `GroqService` prompt-builders extracted (provider-agnostic) — existing `/ai/*` endpoints + EvergreenService behavior **byte-for-byte unchanged**.
- `.env.example`: documented `GOOGLE_AI_API_KEY` (+ `GROQ_API_KEY`).

## Metering / billing
- Reuses `AiTokenService.executeWithTokens` — deducts only on success; a failed/partial fan-out charges nothing. FREE plan (0 tokens) → 403; paid-exhausted → 400 "Insufficient tokens" — the FE treats both as quota-exhausted → upsell.

## Testing
- New Jest specs: `AiTextService` (Gemini-primary/Groq-fallback/both-down), `ComposerAiService` (fan-out + one metering unit). BE build clean; AI suites green.
- Whole-branch review (opus): SHIP after one CRITICAL fix (see below), re-reviewed clean.

## Scope
Composer only. Inbox reply-suggest + media alt-text are separate future branches; the backend path is kept generic so they reuse it. Maestro/Anthropic untouched.

**FE PR:** asad00712/schedura-frontend (same branch).
**Deploy note:** set `GOOGLE_AI_API_KEY` on Railway to enable Gemini (else Groq fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)