### PR TITLE
fix(ai): replace decommissioned Groq llama models + handle gpt-oss reasoning

### DIFF
--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -65,7 +65,7 @@ export class AiController {
       message: this.groqService.isReady()
         ? 'AI service is configured and ready'
         : 'AI service is not configured - check GROQ_API_KEY environment variable',
-      model: 'llama-3.3-70b-versatile',
+      model: 'openai/gpt-oss-120b',
       sttProvider: 'ElevenLabs Scribe',
     };
   }

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -90,7 +90,9 @@ export interface ContentIdea {
 export class GroqService {
   private readonly logger = new Logger(GroqService.name);
   private client: Groq | null = null;
-  private readonly defaultModel = 'llama-3.3-70b-versatile';
+  // Groq decommissioned llama-3.3-70b-versatile (404s). gpt-oss-120b is the
+  // current strong general model on Groq (131k ctx). Overridable per-call.
+  private readonly defaultModel = 'openai/gpt-oss-120b';
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GROQ_API_KEY');
@@ -134,6 +136,12 @@ export class GroqService {
     } = options || {};
 
     try {
+      // Groq's gpt-oss models are reasoning models: without reasoning_effort
+      // they spend the whole max_tokens budget on hidden reasoning and return
+      // empty content (breaking small-budget calls like a 24-token title).
+      // 'low' keeps reasoning minimal so short completions still yield real
+      // text. (Ignored by non-reasoning models.) The field isn't in the SDK's
+      // typed params yet, so extend the non-streaming param type locally.
       const completion = await this.client.chat.completions.create({
         model,
         messages: [
@@ -142,6 +150,9 @@ export class GroqService {
         ],
         temperature,
         max_tokens: maxTokens,
+        // reasoning_effort isn't in the SDK's typed params yet; cast the extra
+        // field only, so the create() return stays a non-streaming completion.
+        ...({ reasoning_effort: 'low' } as { reasoning_effort: 'low' }),
       });
 
       const content = completion.choices[0]?.message?.content;
@@ -186,7 +197,9 @@ export class GroqService {
 
     const raw = await this.generateCompletion(system, user, {
       temperature: 0.3,
-      maxTokens: 24,
+      // gpt-oss (reasoning model) needs a little headroom even at low effort;
+      // a 24-token budget returns empty. 128 is ample for a short title.
+      maxTokens: 128,
     });
 
     return raw
@@ -592,7 +605,8 @@ Provide ${count} variations, numbered 1 through ${count}. Each should be complet
 
     const raw = await this.generateCompletion(system, user, {
       temperature: 0.2,
-      maxTokens: 100,
+      // gpt-oss (reasoning model) headroom — 100 can come back empty.
+      maxTokens: 128,
     });
 
     try {

--- a/src/ai/services/drip-content-generator.service.ts
+++ b/src/ai/services/drip-content-generator.service.ts
@@ -98,7 +98,9 @@ const PLATFORM_CONFIG: Record<
 export class DripContentGeneratorService {
   private readonly logger = new Logger(DripContentGeneratorService.name);
   private groqClient: Groq | null = null;
-  private readonly defaultModel = 'llama-3.3-70b-versatile';
+  // Groq decommissioned llama-3.3-70b-versatile (404s). gpt-oss-120b is the
+  // current strong general model on Groq (131k ctx).
+  private readonly defaultModel = 'openai/gpt-oss-120b';
 
   constructor(
     private readonly configService: ConfigService,
@@ -272,6 +274,8 @@ IMPORTANT:
 Respond with ONLY the post content (including hashtags). No explanations or meta-text.`;
 
     try {
+      // gpt-oss is a reasoning model; without 'low' it can spend the whole
+      // budget on hidden reasoning and return empty content.
       const completion = await this.groqClient.chat.completions.create({
         model: this.defaultModel,
         messages: [
@@ -280,6 +284,9 @@ Respond with ONLY the post content (including hashtags). No explanations or meta
         ],
         temperature: 0.8,
         max_tokens: 500,
+        // reasoning_effort isn't in the SDK's typed params yet; cast the extra
+        // field only, so the create() return stays a non-streaming completion.
+        ...({ reasoning_effort: 'low' } as { reasoning_effort: 'low' }),
       });
 
       let text = completion.choices[0]?.message?.content?.trim() || '';

--- a/src/chatbot/llm/groq.provider.ts
+++ b/src/chatbot/llm/groq.provider.ts
@@ -20,11 +20,9 @@ export class GroqChatProvider extends BaseLLMProvider {
   private activeClientIndex = 0;
 
   readonly name = 'groq';
-  readonly models = [
-    'openai/gpt-oss-120b',
-    'llama-3.3-70b-versatile',
-    'llama-3.1-8b-instant',
-  ];
+  // Groq decommissioned the llama-3.x models (404). Current Groq general
+  // models: gpt-oss-120b (strong) + gpt-oss-20b (smaller/faster).
+  readonly models = ['openai/gpt-oss-120b', 'openai/gpt-oss-20b'];
 
   private readonly defaultModel = 'openai/gpt-oss-120b';
 

--- a/src/chatbot/llm/llm-router.service.ts
+++ b/src/chatbot/llm/llm-router.service.ts
@@ -49,14 +49,15 @@ export class LLMRouterService {
 
   /**
    * Get the best model for the task type.
-   * GPT-OSS-120B for tool calling & complex reasoning, Llama 3.1 8B for simple tasks.
+   * GPT-OSS-120B for tool calling & complex reasoning, GPT-OSS-20B for simple
+   * tasks. (Groq decommissioned the llama-3.x models — 404.)
    */
   getModelForTask(
     taskType: 'simple' | 'complex' | 'tool_calling' = 'complex',
   ): string {
     switch (taskType) {
       case 'simple':
-        return 'llama-3.1-8b-instant';
+        return 'openai/gpt-oss-20b';
       case 'complex':
       case 'tool_calling':
       default:

--- a/src/chatbot/services/agent.service.ts
+++ b/src/chatbot/services/agent.service.ts
@@ -78,8 +78,9 @@ export interface AgentResult {
 
 const MAX_ITERATIONS = 10;
 
-/** Fallback model when the primary hits rate limits. */
-const FALLBACK_MODEL = 'llama-3.3-70b-versatile';
+/** Fallback model when the primary hits rate limits.
+ *  (Groq decommissioned llama-3.3-70b-versatile — 404s.) */
+const FALLBACK_MODEL = 'openai/gpt-oss-20b';
 
 /**
  * Trim conversation history to keep token counts manageable.


### PR DESCRIPTION
## Problem

Live "Failed to generate content" 400 on AI generation. Root cause: **Groq decommissioned `llama-3.3-70b-versatile` and `llama-3.1-8b-instant`** — both now 404. Every Groq-backed generation was broken: the inline AI-assist fallback path, all `/ai/*` endpoints, evergreen, drip, and the chatbot rate-limit fallback.

(This surfaced now because inline AI-assist calls Groq via the fallback path while `GOOGLE_AI_API_KEY` isn't set yet — but the dead model was a latent break for all Groq features.)

## Fix
- Repoint all Groq model defaults/fallbacks to **`openai/gpt-oss-120b`** (+ `gpt-oss-20b` for simple/fallback tiers) — the current active Groq general models. 5 references across `src/ai/` + `src/chatbot/`.
- **`gpt-oss` are reasoning models** — without `reasoning_effort: 'low'` they spend the entire `max_tokens` budget on hidden reasoning and return empty `content` (a second, subtler "No content generated" 400). Added `reasoning_effort: 'low'` to the Groq completion calls.
- Raised two tiny `max_tokens` (24/100 → 128) that returned empty even at low effort (conversation title, freshness check).

## Verified
Live end-to-end through the real `GroqService`: `generateCaption`, `generateHashtags`, and `generateConversationTitle` all return real content. `nest build` clean; AI + chatbot Jest suites green (9/9).

Gemini remains **primary** for inline once `GOOGLE_AI_API_KEY` is set on Railway; this fix makes the Groq **fallback** (and all other Groq features) actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)