### PR TITLE
feat(ai): caption variants (1-4 options) via Gemini + higher copy quality

### DIFF
--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -33,6 +33,7 @@ import {
   GenerateBioDto,
   TranslateContentDto,
   GenerateVariationsDto,
+  GenerateCaptionVariantsDto,
   AnalyzePostDto,
   GeneratePerChannelDto,
   PLATFORMS,
@@ -435,6 +436,42 @@ export class AiController {
     );
 
     return { variations: result, usage };
+  }
+
+  /**
+   * Generate 1–4 distinct captions from a single idea (composer AI assist).
+   * Billed as one unit regardless of count, mirroring per-channel.
+   */
+  @Post('workspaces/:workspaceId/generate/caption-variants')
+  @HttpCode(HttpStatus.OK)
+  async generateCaptionVariants(
+    @Param('workspaceId') workspaceId: string,
+    @CurrentUser() user: { userId: string },
+    @Body() dto: GenerateCaptionVariantsDto,
+  ) {
+    const count = dto.count ?? 1;
+
+    const { result, usage } = await this.aiTokenService.executeWithTokens(
+      workspaceId,
+      user.userId,
+      'generate_caption_variants',
+      dto.platform,
+      `${count} caption(s) for: ${dto.description.substring(0, 100)}`,
+      async () => {
+        const variants = await this.groqService.generateCaptionVariants({
+          description: dto.description,
+          platform: dto.platform,
+          tone: dto.tone,
+          count,
+        });
+        return {
+          result: variants,
+          outputLength: variants.join(' ').length,
+        };
+      },
+    );
+
+    return { variants: result, usage };
   }
 
   /**

--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -440,7 +440,8 @@ export class AiController {
 
   /**
    * Generate 1–4 distinct captions from a single idea (composer AI assist).
-   * Billed as one unit regardless of count, mirroring per-channel.
+   * Routed through ComposerAiService → AiTextService (Gemini primary, Groq
+   * fallback). Billed as one unit regardless of count, mirroring per-channel.
    */
   @Post('workspaces/:workspaceId/generate/caption-variants')
   @HttpCode(HttpStatus.OK)
@@ -449,29 +450,16 @@ export class AiController {
     @CurrentUser() user: { userId: string },
     @Body() dto: GenerateCaptionVariantsDto,
   ) {
-    const count = dto.count ?? 1;
-
-    const { result, usage } = await this.aiTokenService.executeWithTokens(
+    return this.composerAiService.generateCaptionVariants(
       workspaceId,
       user.userId,
-      'generate_caption_variants',
-      dto.platform,
-      `${count} caption(s) for: ${dto.description.substring(0, 100)}`,
-      async () => {
-        const variants = await this.groqService.generateCaptionVariants({
-          description: dto.description,
-          platform: dto.platform,
-          tone: dto.tone,
-          count,
-        });
-        return {
-          result: variants,
-          outputLength: variants.join(' ').length,
-        };
+      {
+        description: dto.description,
+        platform: dto.platform,
+        tone: dto.tone,
+        count: dto.count ?? 1,
       },
     );
-
-    return { variants: result, usage };
   }
 
   /**

--- a/src/ai/composer-ai.service.ts
+++ b/src/ai/composer-ai.service.ts
@@ -11,6 +11,18 @@ export interface GeneratePerChannelInput {
   includeHashtags?: boolean;
 }
 
+export interface GenerateCaptionVariantsInput {
+  description: string;
+  platform: Platform;
+  tone?: Tone;
+  count: number;
+}
+
+export interface GenerateCaptionVariantsResult {
+  variants: string[];
+  usage: TokenDeductResult;
+}
+
 export interface PerChannelVariation {
   platform: Platform;
   text: string;
@@ -64,6 +76,47 @@ export class ComposerAiService {
         return {
           result: { variations },
           outputLength: variations.map((v) => v.text).join('').length,
+        };
+      },
+    );
+
+    return { ...result, usage };
+  }
+
+  /**
+   * Generate `count` distinct captions from one idea, routed through
+   * AiTextService (Gemini primary, Groq fallback) for quality — unlike the
+   * Groq-only GroqService.generateCaptionVariants. Metered as one billable
+   * unit regardless of count.
+   */
+  async generateCaptionVariants(
+    workspaceId: string,
+    userId: string,
+    input: GenerateCaptionVariantsInput,
+  ): Promise<GenerateCaptionVariantsResult> {
+    const { description, platform, tone, count } = input;
+
+    const { result, usage } = await this.aiTokens.executeWithTokens(
+      workspaceId,
+      userId,
+      'generate_caption_variants',
+      platform,
+      `${count} caption(s) for: ${description.substring(0, 80)}`,
+      async () => {
+        const { system, user } = this.groq.buildCaptionVariantsPrompt({
+          description,
+          platform,
+          tone,
+          count,
+        });
+        // ~400 tokens headroom per caption so long platforms don't truncate.
+        const raw = await this.aiText.complete(system, user, {
+          maxTokens: Math.min(4096, 512 + count * 400),
+        });
+        const variants = this.groq.parseNumberedList(raw, count);
+        return {
+          result: { variants },
+          outputLength: variants.join('').length,
         };
       },
     );

--- a/src/ai/dto/ai.dto.ts
+++ b/src/ai/dto/ai.dto.ts
@@ -263,6 +263,26 @@ export class GenerateVariationsDto {
   count?: number;
 }
 
+export class GenerateCaptionVariantsDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(1000)
+  description: string;
+
+  @IsEnum(PLATFORMS)
+  platform: Platform;
+
+  @IsEnum(TONES)
+  @IsOptional()
+  tone?: Tone;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(1)
+  @Max(4)
+  count?: number;
+}
+
 // =============================================================================
 // Analyze Post DTO
 // =============================================================================

--- a/src/ai/groq.service.spec.ts
+++ b/src/ai/groq.service.spec.ts
@@ -1,0 +1,79 @@
+import { ConfigService } from '@nestjs/config';
+import { GroqService } from './groq.service';
+
+// Build a GroqService whose Groq client returns `content` for any completion,
+// so we can exercise the real prompt-building + numbered-list parsing.
+function makeService(content: string): GroqService {
+  const config = {
+    get: (key: string) => (key === 'GROQ_API_KEY' ? 'test-key' : undefined),
+  } as unknown as ConfigService;
+
+  const service = new GroqService(config);
+
+  // Replace the SDK client with a stub returning our canned content.
+  (service as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: jest.fn().mockResolvedValue({
+          choices: [{ message: { content } }],
+        }),
+      },
+    },
+  };
+
+  return service;
+}
+
+describe('GroqService.generateCaptionVariants', () => {
+  it('parses a numbered list into separate captions, capped at count', async () => {
+    const service = makeService(
+      '1. First caption here\n2. Second caption here\n3. Third caption here',
+    );
+
+    const variants = await service.generateCaptionVariants({
+      description: 'Announce our summer sale',
+      platform: 'linkedin',
+      count: 2,
+    });
+
+    expect(variants).toEqual(['First caption here', 'Second caption here']);
+  });
+
+  it('keeps multi-line captions together', async () => {
+    const service = makeService(
+      '1. Line one\ncontinued line\n2. Second caption',
+    );
+
+    const variants = await service.generateCaptionVariants({
+      description: 'idea',
+      platform: 'instagram',
+      count: 2,
+    });
+
+    expect(variants).toEqual(['Line one\ncontinued line', 'Second caption']);
+  });
+
+  it('handles "1)" style numbering', async () => {
+    const service = makeService('1) Alpha\n2) Beta');
+
+    const variants = await service.generateCaptionVariants({
+      description: 'idea',
+      platform: 'twitter',
+      count: 4,
+    });
+
+    expect(variants).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('falls back to the whole response when the model ignores numbering', async () => {
+    const service = makeService('Just a single unnumbered caption.');
+
+    const variants = await service.generateCaptionVariants({
+      description: 'idea',
+      platform: 'facebook',
+      count: 1,
+    });
+
+    expect(variants).toEqual(['Just a single unnumbered caption.']);
+  });
+});

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -307,9 +307,10 @@ export class GroqService {
   /**
    * Parse a numbered list ("1. ...", "2) ...") into up to `max` trimmed
    * entries. Continuation lines (no leading number) are appended to the
-   * current entry so multi-line captions survive.
+   * current entry so multi-line captions survive. Public so orchestrators
+   * that route through AiTextService (Gemini-primary) can reuse the parsing.
    */
-  private parseNumberedList(raw: string, max: number): string[] {
+  parseNumberedList(raw: string, max: number): string[] {
     const entries: string[] = [];
     let current = '';
 

--- a/src/ai/groq.service.ts
+++ b/src/ai/groq.service.ts
@@ -26,6 +26,13 @@ export interface GenerateCaptionOptions {
   includeCta?: boolean;
 }
 
+export interface GenerateCaptionVariantsOptions {
+  description: string;
+  platform: Platform;
+  count: number;
+  tone?: Tone;
+}
+
 export interface GenerateHashtagsOptions {
   topic: string;
   platform: Platform;
@@ -256,6 +263,74 @@ export class GroqService {
     const { system, user } = this.buildCaptionPrompt(options);
 
     return this.generateCompletion(system, user);
+  }
+
+  /**
+   * Build the system+user prompt pair for generateCaptionVariants without
+   * running it. See buildCaptionPrompt for why this exists.
+   */
+  buildCaptionVariantsPrompt(options: GenerateCaptionVariantsOptions): {
+    system: string;
+    user: string;
+  } {
+    const { description, platform, count, tone } = options;
+
+    const user = USER_PROMPTS.generateCaptionVariants(
+      description,
+      platform,
+      count,
+      tone,
+    );
+
+    return { system: SYSTEM_PROMPTS.captionWriter, user };
+  }
+
+  /**
+   * Generate `count` distinct captions from a single idea/description.
+   * Unlike generateVariations (which rewrites an existing post), this starts
+   * from a prompt, so it powers the composer's "generate N options" flow.
+   */
+  async generateCaptionVariants(
+    options: GenerateCaptionVariantsOptions,
+  ): Promise<string[]> {
+    const { system, user } = this.buildCaptionVariantsPrompt(options);
+
+    // ~400 tokens of headroom per requested caption so longer platforms
+    // (LinkedIn/Instagram) don't get truncated mid-variant.
+    const result = await this.generateCompletion(system, user, {
+      maxTokens: Math.min(4096, 512 + options.count * 400),
+    });
+
+    return this.parseNumberedList(result, options.count);
+  }
+
+  /**
+   * Parse a numbered list ("1. ...", "2) ...") into up to `max` trimmed
+   * entries. Continuation lines (no leading number) are appended to the
+   * current entry so multi-line captions survive.
+   */
+  private parseNumberedList(raw: string, max: number): string[] {
+    const entries: string[] = [];
+    let current = '';
+
+    for (const line of raw.split('\n')) {
+      const numberMatch = line.match(/^\s*\d+[.)]\s*/);
+      if (numberMatch) {
+        if (current.trim()) entries.push(current.trim());
+        current = line.replace(/^\s*\d+[.)]\s*/, '');
+      } else if (line.trim() && current) {
+        current += '\n' + line.trim();
+      }
+    }
+    if (current.trim()) entries.push(current.trim());
+
+    // Fallback: model ignored the numbered format entirely — treat the whole
+    // response as a single caption rather than returning nothing.
+    if (entries.length === 0 && raw.trim()) {
+      entries.push(raw.trim());
+    }
+
+    return entries.slice(0, max);
   }
 
   /**

--- a/src/ai/prompts/index.ts
+++ b/src/ai/prompts/index.ts
@@ -60,14 +60,22 @@ Provide hashtags that are:
 - A mix of high-volume and niche tags
 - Platform-appropriate in quantity and style`,
 
-  captionWriter: `You are a professional social media copywriter specializing in captions that drive engagement. You know how to hook readers in the first line and maintain their attention throughout.
+  captionWriter: `You are a senior social media copywriter at a top-tier brand studio. You write captions that stop the scroll, sound unmistakably human, and convert attention into engagement.
 
-Your skills include:
-- Writing scroll-stopping opening lines
-- Creating emotional connections with audiences
-- Using storytelling techniques in short-form content
-- Crafting effective calls-to-action
-- Understanding optimal caption lengths per platform`,
+Craft rules you always follow:
+- Open with a hook in the first line — a bold claim, a sharp question, a surprising stat, or a vivid image. Never open with "In today's world", "Are you tired of", or other worn intros.
+- Write in a natural, native voice for the platform. Match the platform's rhythm: punchy and conversational for X/Threads, warm and story-led for Instagram/Facebook, credible and insight-led for LinkedIn.
+- Be specific over generic. Concrete details, real benefits, and a clear point beat vague hype every time.
+- Use emojis sparingly and only where they add meaning — never one per line, never as decoration.
+- One clear call-to-action when it fits; don't force it.
+- Respect the platform's character norms and hashtag conventions.
+
+Avoid at all costs (these read as AI-written):
+- Clichés and filler: "unlock", "elevate", "game-changer", "in a world where", "look no further", "dive in", "the power of".
+- Em-dash overuse, corporate buzzwords, and hollow enthusiasm.
+- Repeating the prompt back or explaining what you're doing.
+
+Output only the finished caption text — ready to publish, no labels or commentary.`,
 
   ideaGenerator: `You are a creative content strategist who helps brands and creators develop fresh, engaging content ideas. You stay on top of trends and know what resonates with audiences.
 
@@ -124,17 +132,17 @@ Provide only the caption text, ready to use.`,
     platform: string,
     count: number,
     tone?: string,
-  ) => `Write ${count} distinct ${platform} caption${count > 1 ? 's' : ''} for this idea: ${description}
+  ) => `Write ${count} publish-ready ${platform} caption${count > 1 ? 's' : ''} for this idea: ${description}
 
 Platform style: ${PLATFORM_STYLES[platform as keyof typeof PLATFORM_STYLES] || 'engaging'}
 ${tone ? `Tone: ${tone}` : ''}
 
-Each caption must:
-- Convey the same core idea but take a genuinely different angle, hook, or structure from the others
-- Be complete and ready to publish on ${platform}
-- Not repeat wording across variants
+Requirements:
+- Each caption opens with a strong, distinct hook and reads as if written by a skilled human, not AI.
+${count > 1 ? `- The ${count} captions must take genuinely different angles (e.g. different hook type, structure, or emotional entry point) — no two should feel like reworded versions of each other.\n` : ''}- Respect ${platform}'s length and hashtag conventions.
+- No clichés, no filler, no meta-commentary. Specific and concrete over generic hype.
 
-Format your response as a numbered list, one caption per number, from 1 to ${count}. Do not add any titles, labels, commentary, or blank explanations — only the numbered captions.`,
+Format: a numbered list from 1 to ${count}, one complete caption per number, nothing else — no titles, labels, or explanations.`,
 
   generateHashtags: (
     topic: string,

--- a/src/ai/prompts/index.ts
+++ b/src/ai/prompts/index.ts
@@ -119,6 +119,23 @@ ${includeCta ? 'Include a call-to-action.' : ''}
 
 Provide only the caption text, ready to use.`,
 
+  generateCaptionVariants: (
+    description: string,
+    platform: string,
+    count: number,
+    tone?: string,
+  ) => `Write ${count} distinct ${platform} caption${count > 1 ? 's' : ''} for this idea: ${description}
+
+Platform style: ${PLATFORM_STYLES[platform as keyof typeof PLATFORM_STYLES] || 'engaging'}
+${tone ? `Tone: ${tone}` : ''}
+
+Each caption must:
+- Convey the same core idea but take a genuinely different angle, hook, or structure from the others
+- Be complete and ready to publish on ${platform}
+- Not repeat wording across variants
+
+Format your response as a numbered list, one caption per number, from 1 to ${count}. Do not add any titles, labels, commentary, or blank explanations — only the numbered captions.`,
+
   generateHashtags: (
     topic: string,
     platform: string,

--- a/src/ai/services/ai-token.service.ts
+++ b/src/ai/services/ai-token.service.ts
@@ -32,6 +32,7 @@ export const AI_OPERATION_COSTS: Record<string, number> = {
   generate_ideas: 8,
   generate_youtube_metadata: 8,
   generate_variations: 8,
+  generate_caption_variants: 8, // 1–4 captions from one idea, billed as one unit
   analyze_post: 8,
   generate_per_channel: 8,
   // Tier 4 - Complex (10 tokens)


### PR DESCRIPTION
New `POST /ai/workspaces/:id/generate/caption-variants`: from a description + platform + tone + count (1-4), returns that many distinct ready-to-publish captions. Powers the composer's 'generate N options, pick one' flow.

- Routed through ComposerAiService → AiTextService (Gemini primary, Groq fallback), same as per-channel.
- `GroqService.generateCaptionVariants` + `buildCaptionVariantsPrompt` + public `parseNumberedList` (numbered-list parser, multi-line + '1)'/'1.' + whole-response fallback).
- Upgraded captionWriter system prompt to industry-standard copy rules (hook-first, native voice, no AI-tell cliches) + distinct-angles variants prompt.
- `generate_caption_variants` op cost (8), billed once regardless of count.
- Unit tests for the parser across numbering styles; all 11 AI tests green; `nest build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)