### PR TITLE
feat(ai): inbox AI reply-assist endpoint

### DIFF
--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -21,6 +21,7 @@ import {
 } from './services/ai-token.service';
 import { ElevenLabsSttService } from './services/elevenlabs-stt.service';
 import { ComposerAiService } from './composer-ai.service';
+import { InboxAiService } from './inbox-ai.service';
 import {
   GeneratePostDto,
   GenerateCaptionDto,
@@ -36,6 +37,7 @@ import {
   GenerateCaptionVariantsDto,
   AnalyzePostDto,
   GeneratePerChannelDto,
+  SuggestReplyDto,
   PLATFORMS,
   TONES,
 } from './dto/ai.dto';
@@ -48,6 +50,7 @@ export class AiController {
     private readonly aiTokenService: AiTokenService,
     private readonly sttService: ElevenLabsSttService,
     private readonly composerAiService: ComposerAiService,
+    private readonly inboxAiService: InboxAiService,
   ) {}
 
   // ==========================================================================
@@ -479,6 +482,25 @@ export class AiController {
       user.userId,
       dto,
     );
+  }
+
+  /**
+   * Draft a reply for an inbox conversation (comments/DMs). Single unit,
+   * Gemini-primary via InboxAiService.
+   */
+  @Post('workspaces/:workspaceId/inbox/suggest-reply')
+  @HttpCode(HttpStatus.OK)
+  async suggestReply(
+    @Param('workspaceId') workspaceId: string,
+    @CurrentUser() user: { userId: string },
+    @Body() dto: SuggestReplyDto,
+  ) {
+    return this.inboxAiService.suggestReply(workspaceId, user.userId, {
+      platform: dto.platform,
+      messages: dto.messages,
+      instruction: dto.instruction ?? 'suggest',
+      draft: dto.draft,
+    });
   }
 
   /**

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -8,6 +8,7 @@ import { DripContentGeneratorService } from './services/drip-content-generator.s
 import { AiTokenService } from './services/ai-token.service';
 import { ElevenLabsSttService } from './services/elevenlabs-stt.service';
 import { ComposerAiService } from './composer-ai.service';
+import { InboxAiService } from './inbox-ai.service';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
 
@@ -29,6 +30,7 @@ import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
     AiTokenService,
     ElevenLabsSttService,
     ComposerAiService,
+    InboxAiService,
   ],
   exports: [
     GroqService,
@@ -38,6 +40,7 @@ import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
     AiTokenService,
     ElevenLabsSttService,
     ComposerAiService,
+    InboxAiService,
   ],
 })
 export class AiModule {}

--- a/src/ai/dto/ai.dto.ts
+++ b/src/ai/dto/ai.dto.ts
@@ -8,11 +8,14 @@ import {
   IsBoolean,
   IsNotEmpty,
   ArrayMinSize,
+  ArrayMaxSize,
+  ValidateNested,
   Min,
   Max,
   MinLength,
   MaxLength,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 
 // Platform and tone enums
 export const PLATFORMS = [
@@ -318,6 +321,39 @@ export class GeneratePerChannelDto {
   @IsBoolean()
   @IsOptional()
   includeHashtags?: boolean;
+}
+
+// =============================================================================
+// Suggest Reply DTO (inbox AI reply-assist)
+// =============================================================================
+
+export class SuggestReplyMessageDto {
+  @IsIn(['me', 'customer'])
+  author: 'me' | 'customer';
+
+  @IsString()
+  @MaxLength(2000)
+  text: string;
+}
+
+export class SuggestReplyDto {
+  @IsString()
+  platform: string;
+
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => SuggestReplyMessageDto)
+  messages: SuggestReplyMessageDto[];
+
+  @IsOptional()
+  @IsIn(['suggest', 'rephrase', 'shorten', 'friendly'])
+  instruction?: 'suggest' | 'rephrase' | 'shorten' | 'friendly';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  draft?: string;
 }
 
 // =============================================================================

--- a/src/ai/dto/ai.dto.ts
+++ b/src/ai/dto/ai.dto.ts
@@ -338,9 +338,11 @@ export class SuggestReplyMessageDto {
 
 export class SuggestReplyDto {
   @IsString()
+  @IsNotEmpty()
   platform: string;
 
   @IsArray()
+  @ArrayMinSize(1)
   @ArrayMaxSize(20)
   @ValidateNested({ each: true })
   @Type(() => SuggestReplyMessageDto)

--- a/src/ai/inbox-ai.service.spec.ts
+++ b/src/ai/inbox-ai.service.spec.ts
@@ -1,0 +1,38 @@
+import { InboxAiService } from './inbox-ai.service';
+
+describe('InboxAiService.suggestReply', () => {
+  it('builds a prompt from the conversation and returns the reply + usage', async () => {
+    const aiText = {
+      complete: jest.fn().mockResolvedValue('Thanks for reaching out! ...'),
+    } as any;
+    const aiTokens = {
+      executeWithTokens: jest.fn(
+        async (
+          _ws: string,
+          _u: string,
+          _op: string,
+          _p: string | undefined,
+          _s: string,
+          fn: () => Promise<{ result: unknown; outputLength?: number }>,
+        ) => {
+          const { result } = await fn();
+          return { result, usage: { tokensDeducted: 5, tokensRemaining: 95 } };
+        },
+      ),
+    } as any;
+
+    const service = new InboxAiService(aiText, aiTokens);
+    const out = await service.suggestReply('ws-1', 'user-1', {
+      platform: 'instagram',
+      messages: [{ author: 'customer', text: 'Do you ship to the US?' }],
+      instruction: 'suggest',
+    });
+
+    expect(out.reply).toContain('Thanks for reaching out');
+    expect(out.usage.tokensDeducted).toBe(5);
+    // The prompt handed to the model includes the conversation + platform.
+    const [, userPrompt] = aiText.complete.mock.calls[0];
+    expect(userPrompt).toContain('Do you ship to the US?');
+    expect(userPrompt).toContain('instagram');
+  });
+});

--- a/src/ai/inbox-ai.service.ts
+++ b/src/ai/inbox-ai.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { AiTextService } from './ai-text.service';
+import { AiTokenService, TokenDeductResult } from './services/ai-token.service';
+import { SYSTEM_PROMPTS, USER_PROMPTS } from './prompts';
+
+export interface SuggestReplyInput {
+  platform: string;
+  messages: { author: 'me' | 'customer'; text: string }[];
+  instruction?: 'suggest' | 'rephrase' | 'shorten' | 'friendly';
+  draft?: string;
+}
+
+export interface SuggestReplyResult {
+  reply: string;
+  usage: TokenDeductResult;
+}
+
+/**
+ * Single-shot inbox reply drafting. Reuses AiTextService (Gemini primary,
+ * Groq fallback) and is metered as one `suggest_reply` unit. Stateless — it
+ * uses the messages passed in, never re-fetches the thread.
+ */
+@Injectable()
+export class InboxAiService {
+  constructor(
+    private readonly aiText: AiTextService,
+    private readonly aiTokens: AiTokenService,
+  ) {}
+
+  async suggestReply(
+    workspaceId: string,
+    userId: string,
+    input: SuggestReplyInput,
+  ): Promise<SuggestReplyResult> {
+    const { platform, messages, instruction = 'suggest', draft } = input;
+
+    const { result, usage } = await this.aiTokens.executeWithTokens(
+      workspaceId,
+      userId,
+      'suggest_reply',
+      platform,
+      `Inbox reply (${instruction}) on ${platform}`,
+      async () => {
+        const user = USER_PROMPTS.suggestReply(
+          platform,
+          messages,
+          instruction,
+          draft,
+        );
+        const reply = await this.aiText.complete(
+          SYSTEM_PROMPTS.inboxReply,
+          user,
+        );
+        return { result: { reply }, outputLength: reply.length };
+      },
+    );
+
+    return { ...result, usage };
+  }
+}

--- a/src/ai/prompts/index.ts
+++ b/src/ai/prompts/index.ts
@@ -94,6 +94,16 @@ Your expertise:
 - Converting video scripts to text posts
 - Maintaining brand voice across transformations
 - Optimizing content for each platform's unique requirements`,
+
+  inboxReply: `You are a professional social media community manager replying to a customer on behalf of a brand. You write replies that are warm, helpful, concise, and on-brand, matching the tone and register of the platform.
+
+Rules:
+- Reply as the brand ("me"), addressing the latest customer message in context.
+- Be genuinely helpful and human — acknowledge the customer, answer or move things forward.
+- Never invent facts, prices, policies, dates, or promises you weren't given. If you can't answer, offer a helpful next step.
+- Match the platform's norms (short and casual for X/Instagram DMs, a little fuller for Facebook/LinkedIn).
+- Reply in the same language the customer used.
+- Output only the reply text — no quotes, labels, or commentary.`,
 };
 
 // User prompt templates
@@ -271,6 +281,33 @@ Maintain:
 - Cultural appropriateness
 
 Provide only the translated content.`,
+
+  suggestReply: (
+    platform: string,
+    messages: { author: 'me' | 'customer'; text: string }[],
+    instruction: 'suggest' | 'rephrase' | 'shorten' | 'friendly',
+    draft?: string,
+  ) => {
+    const transcript = messages
+      .map((m) => `${m.author === 'me' ? 'me' : 'customer'}: ${m.text}`)
+      .join('\n');
+
+    const task =
+      instruction === 'suggest'
+        ? 'Write the next reply from me.'
+        : instruction === 'rephrase'
+          ? `Here is my current draft reply:\n${draft ?? ''}\n\nRewrite it to be clearer and better, keeping the same meaning.`
+          : instruction === 'shorten'
+            ? `Here is my current draft reply:\n${draft ?? ''}\n\nRewrite it to be shorter and punchier, keeping the key point.`
+            : `Here is my current draft reply:\n${draft ?? ''}\n\nRewrite it to be warmer and friendlier, keeping the meaning.`;
+
+    return `Platform: ${platform}
+
+Conversation so far:
+${transcript}
+
+${task}`;
+  },
 };
 
 // Tone options for users to select

--- a/src/ai/services/ai-token.service.ts
+++ b/src/ai/services/ai-token.service.ts
@@ -28,6 +28,7 @@ export const AI_OPERATION_COSTS: Record<string, number> = {
   repurpose_content: 5,
   translate_content: 5,
   speech_to_text: 5, // Voice input transcription
+  suggest_reply: 5, // one inbox reply draft
   // Tier 3 - Advanced (8 tokens)
   generate_ideas: 8,
   generate_youtube_metadata: 8,


### PR DESCRIPTION
New `POST /ai/workspaces/:workspaceId/inbox/suggest-reply` — drafts a reply for an inbox conversation (comments/DMs). Powers the frontend's ✨ reply popover.

- `InboxAiService` routes through `AiTextService` (Gemini primary, Groq fallback), metered as one `suggest_reply` unit (cost 5). Stateless — uses the messages in the request, never re-fetches the thread.
- `SuggestReplyDto`: `platform` (free-form — inbox has more platforms than the 7 AI-composer ones), `messages[{author:'me'|'customer', text}]` (1–20), `instruction?` (suggest/rephrase/shorten/friendly), `draft?`. Returns `{ reply, usage }`.
- New `SYSTEM_PROMPTS.inboxReply` (community-manager voice, no invented facts) + `USER_PROMPTS.suggestReply`.
- Unit test asserts prompt content + usage; `nest build` clean, 12 AI tests pass.

Phase 2 of the inline 'AI everywhere' plan — distinct from Maestro. Frontend PR wires the ✨ button in the comment + DM composers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)