### PR TITLE
fix(auth): close launch-gate bypass for users still in onboarding

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -215,6 +215,9 @@ export class AuthController {
   @Post('onboarding/complete')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  // Pre-launch setup route: a non-allowlisted user must be able to finish
+  // onboarding on their own account even though the launch gate blocks the app.
+  @SkipLaunchGate()
   async completeOnboarding(
     @CurrentUser() user: { userId: string; email: string },
   ) {

--- a/src/auth/guards/allowlist.guard.spec.ts
+++ b/src/auth/guards/allowlist.guard.spec.ts
@@ -97,7 +97,11 @@ describe('AllowlistGuard', () => {
     });
   });
 
-  it('passes an unlisted user still in onboarding (onboardingCompletedAt null)', async () => {
+  it('blocks an unlisted user still in onboarding (no onboarding pass-through)', async () => {
+    // Pre-fix hole: a non-allowlisted user with onboardingCompletedAt === null
+    // passed through and could connect channels + post. The gate now blocks
+    // regardless of onboarding state; the genuine setup routes are opened via
+    // @SkipLaunchGate instead.
     process.env.ALLOWLIST_EMAILS = 'a@x.com';
     const g = make({
       verify: () => ({ sub: 'u1', email: 'c@z.com' }),
@@ -106,7 +110,7 @@ describe('AllowlistGuard', () => {
     });
     await expect(
       g.canActivate(ctx({ authorization: 'Bearer t' })),
-    ).resolves.toBe(true);
+    ).rejects.toMatchObject({ response: { code: 'NOT_LAUNCHED' } });
   });
 
   it('blocks an unlisted user once onboarding is complete', async () => {

--- a/src/auth/guards/allowlist.guard.ts
+++ b/src/auth/guards/allowlist.guard.ts
@@ -16,6 +16,14 @@ import { SKIP_LAUNCH_GATE } from '../decorators/skip-launch-gate.decorator';
  * admins) may reach the app; everyone else gets 403 NOT_LAUNCHED. The gate is
  * OFF (pass-through) when ALLOWLIST_EMAILS is empty/unset.
  *
+ * A non-allowlisted user is blocked from the whole app regardless of onboarding
+ * state. The few pre-launch routes a signed-up user still needs — auth,
+ * profile, create-workspace, complete-onboarding — opt out via @SkipLaunchGate,
+ * so a non-allowlisted user can sign up and set up an account but cannot connect
+ * channels or publish. (An earlier version instead passed through any user with
+ * onboardingCompletedAt === null, which let random sign-ups connect channels and
+ * post during onboarding — a live bypass this closes.)
+ *
  * JwtAuthGuard is per-controller, not global, so this global guard cannot rely
  * on req.user. It verifies the bearer token itself (best-effort): no/invalid
  * token → pass (the route's own auth guard, if any, will reject). It is an
@@ -55,33 +63,27 @@ export class AllowlistGuard implements CanActivate {
       return true; // invalid/expired token → let JwtAuthGuard 401 it
     }
 
-    // Need the role to honor "super admin always passes", and the onboarding
-    // flag so we only block AFTER onboarding is finished (below).
+    // Need the role to honor "super admin always passes". A failed lookup
+    // fails SAFE (role undefined → not a super admin → blocked below).
     let role: string | undefined;
-    let onboardingCompletedAt: Date | string | null | undefined;
     try {
       const user = await this.usersService.findOneWithSuspension(
         payload.sub as string,
       );
       role = user?.role;
-      onboardingCompletedAt = user?.onboardingCompletedAt;
     } catch {
       role = undefined;
-      onboardingCompletedAt = undefined;
     }
 
     if (isEmailAllowlisted(payload.email, role)) return true;
 
-    // Not allowlisted — but let the full pre-launch signup flow complete first:
-    // signup, email verification, workspace creation, and the rest of
-    // onboarding all run for everyone. We only lock the app itself, which a
-    // user reaches once onboarding is marked complete. So a not-yet-onboarded
-    // user (onboardingCompletedAt strictly null) passes through; the block
-    // engages only once they finish onboarding (a real timestamp). A failed
-    // lookup (undefined) fails SAFE and blocks — an unknown state on a
-    // non-allowlisted token must not open the app.
-    if (onboardingCompletedAt === null) return true;
-
+    // Not allowlisted → blocked from the whole app, regardless of onboarding
+    // state. The genuine pre-launch setup routes a signed-up user still needs
+    // (auth, profile, create-workspace, complete-onboarding) are opened
+    // individually via @SkipLaunchGate — see those handlers. This deliberately
+    // does NOT wait for onboarding to complete: an earlier version passed
+    // through any user with onboardingCompletedAt === null, which let random
+    // sign-ups connect channels and publish during onboarding (a live bypass).
     throw new ForbiddenException({
       statusCode: 403,
       error: 'Forbidden',

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -18,6 +18,7 @@ import { CreateWorkspaceDto } from './dto/create-workspace.dto';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { UpdateWorkspaceDto } from './dto/update-workspace.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { SkipLaunchGate } from 'src/auth/decorators/skip-launch-gate.decorator';
 
 @Controller('workspace')
 export class WorkspaceController {
@@ -25,6 +26,9 @@ export class WorkspaceController {
 
   @Post()
   @UseGuards(JwtAuthGuard)
+  // Pre-launch setup route: a non-allowlisted user creates their workspace
+  // during onboarding even though the launch gate blocks the rest of the app.
+  @SkipLaunchGate()
   async create(
     @Body() dto: CreateWorkspaceDto,
     @CurrentUser() user: { userId: string; email: string },


### PR DESCRIPTION
**Security fix.** The launch gate let any non-allowlisted user through while their `onboardingCompletedAt` was null (assuming they couldn't reach the app yet). But channel-connect (`/channels/.../oauth/initiate`) and publish are reachable during onboarding, so random sign-ups who never finished onboarding could connect TikTok and post. A user who *completed* onboarding was correctly blocked — which is why the gate appeared to work.

**Fix:** block non-allowlisted users regardless of onboarding state; open only the genuine pre-launch setup routes via `@SkipLaunchGate` — `POST /workspace` and `POST /auth/onboarding/complete`. Non-allowlisted users can sign up + set up an account but cannot connect channels or publish.

- Removes the `onboardingCompletedAt === null → return true` pass-through and the now-unused onboarding lookup.
- Flips the guard test that asserted the old pass-through; all 34 auth tests pass; `nest build` clean.

**Ops:** the 2 random users + their TikTok posts should be removed/suspended in prod manually (data cleanup, separate from this code fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)