### PR TITLE
feat(auth): capture country/region at signup

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -107,10 +107,11 @@ export class AuthController {
   @HttpCode(HttpStatus.CREATED)
   async register(
     @Body() createUserDto: CreateUserDto,
+    @Ip() ip: string,
     @Res({ passthrough: true }) response: Response,
   ) {
     const { accessToken, user, message } =
-      await this.authService.register(createUserDto);
+      await this.authService.register(createUserDto, ip);
 
     const refreshToken = await this.authService.generateRefreshToken(
       user.id,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -89,7 +89,10 @@ export class AuthService {
     private loginActivityService: LoginActivityService,
   ) {}
 
-  async register(registerDto: CreateUserDto): Promise<AuthResponse> {
+  async register(
+    registerDto: CreateUserDto,
+    ip?: string,
+  ): Promise<AuthResponse> {
     // Signup always produces a plain user. Role is never derived from the
     // address someone typed into a public form — SUPER_ADMIN_EMAILS used to do
     // exactly that, which meant anyone who learned a listed address could grant
@@ -99,6 +102,13 @@ export class AuthService {
 
     // Generate verification token and send email
     await this.sendVerificationEmailInternal(user.id, user.email, user.name);
+
+    // Stamp signup-time last-seen and region from the request IP. Awaited
+    // (recordSync) so the country is persisted before we return — a signup
+    // should have its region the moment the account exists, not only after a
+    // first login. Fault-tolerant: a geo miss leaves country null and never
+    // blocks the registration.
+    await this.loginActivityService.recordSync(user.id, ip);
 
     const accessToken = await this.generateAccessToken(user.id, user.email);
 

--- a/src/auth/services/login-activity.service.ts
+++ b/src/auth/services/login-activity.service.ts
@@ -49,6 +49,38 @@ export class LoginActivityService {
     void this.resolveCountry(userId, cleanIp);
   }
 
+  /**
+   * Like {@link record}, but waits for the country lookup instead of firing it
+   * detached. Use this where the region must be persisted before the request
+   * returns — signup, where the account is created once and its country is
+   * wanted the moment it exists, rather than only after a first login. The
+   * geo lookup is still fault-tolerant (a failure leaves country null and
+   * never throws), so the caller is delayed at most by the lookup's own 2s
+   * timeout and is never broken by it. Login and refresh keep using the
+   * fire-and-forget {@link record} — they are far too frequent to await on a
+   * network call every time.
+   */
+  async recordSync(userId: string, ip: string | undefined | null): Promise<void> {
+    const now = new Date();
+    const cleanIp = ip?.split(',')[0].trim() || null;
+
+    try {
+      await this.db
+        .update(users)
+        .set({ lastLoginAt: now, lastLoginIp: cleanIp, updatedAt: now })
+        .where(eq(users.id, userId));
+    } catch (error) {
+      // Recording activity must not break auth — log and carry on.
+      this.logger.warn(
+        `Failed to record signup activity for ${userId}: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    // Awaited so the country is in the row before the caller returns.
+    await this.resolveCountry(userId, cleanIp);
+  }
+
   private async resolveCountry(
     userId: string,
     ip: string | null,


### PR DESCRIPTION
## What

Capture the user's country/region at **signup** — previously it was only set on the first **login/refresh**, so freshly-registered accounts showed a blank region in the admin Users table until they signed in again.

## How

- `register(dto, ip?)` now stamps last-seen + resolves country from the signup request IP.
- New `LoginActivityService.recordSync()` — same as the existing `record()` but **awaits** the geo lookup so the region is persisted **before the response returns** (guaranteed at signup, not fire-and-forget).
- Login/refresh keep using the async `record()` — they are far too frequent to await a network call every time.
- Controller `register()` gains `@Ip() ip` (mirrors `login`/`refresh`).

## Not changed

- **No schema change / no migration** — `country`, `countryCode`, `lastLoginIp` already exist on `users` (from the user-region-tracking work, already applied on prod).
- No frontend change. No timezone (out of scope per request).

## Safety

Fault-tolerant: a GeoIP miss/timeout leaves `country` null and **never blocks registration** (worst case ~2s delay). Signup is a rare event, so the added latency is acceptable.

## Verify

- `nest build` clean ✅
- 34/34 auth tests pass ✅
- Post-deploy: register a new account → admin Users table shows its country + last-seen immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)