### PR TITLE
feat(maestro): API-key auth by default + per-workspace BYOK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,18 @@ GIPHY_API_KEY=
 COVERR_API_KEY=
 # Flickr (Creative-Commons photos): https://www.flickr.com/services/apps/create/apply/
 FLICKR_API_KEY=
+
+# --- Maestro (the in-app AI agent, Claude Agent SDK) ---
+# Maestro is a paid, multi-tenant product, so every run must bill to an Anthropic
+# API account. In production ANTHROPIC_API_KEY is REQUIRED — without it Maestro
+# refuses to start a turn and users see a "not configured" message.
+# Anthropic console: https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=
+# Auth mode. Default (unset) = apikey, which is what production must use.
+# Set to `subscription` ONLY for local development, to bill an interactive
+# Claude Code (Max plan) OAuth session instead of the API key. It is REFUSED
+# when NODE_ENV=production — a container has no interactive session, and one
+# personal subscription is not a commercial multi-tenant billing path.
+# MAESTRO_AUTH_MODE=subscription
+# Overrides the default agent model (claude-haiku-4-5).
+# MAESTRO_MODEL=claude-haiku-4-5

--- a/docs/superpowers/plans/2026-08-26-whatsapp-templates.md
+++ b/docs/superpowers/plans/2026-08-26-whatsapp-templates.md
@@ -1,0 +1,1680 @@
+# WhatsApp Message Templates — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mirror the customer's WhatsApp message templates from Meta into the Library with a live approval badge, and replace the inbox's closed-window dead end with a picker of approved templates.
+
+**Architecture:** A new `whatsapp_message_templates` table mirrors templates that live on the customer's WABA at Meta. A sync service reconciles them (upsert + prune) on page load; a new webhook parser keeps status live between syncs. The Library reuses `TemplateCardGrid` but renders a distinct card variant so WhatsApp actions stay honest. `media_templates` is not modified — not one column.
+
+**Tech Stack:** NestJS, Drizzle ORM, PostgreSQL, BullMQ, Jest (backend); React 19, TanStack Query v5, shadcn/ui, Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-08-26-whatsapp-templates-design.md`
+
+## Global Constraints
+
+- **Branch:** `feat/whatsapp-templates` in **both** repos. Backend was branched from `origin/main` (`1b9fb9f`), frontend from `main` (`0343eb9`).
+- **Never modify `media_templates`** — no new columns, no shape changes.
+- **Never modify `parseWhatsAppMessages`** — inbox ingest (`whatsapp-ingest.service.ts:20`) and the Maestro bridge (`maestro-bridge.processor.ts:218`) both depend on it. Add a separate function.
+- **Store Meta's returned category**, never the user's requested one — Meta silently overrides `UTILITY` → `MARKETING`, and category drives pricing.
+- **No soft delete** on WhatsApp templates. Meta deletion is permanent; a recycle bin would be a lie.
+- **Only `APPROVED` is sendable.**
+- **Unknown status → neutral badge, never blank.** Meta may add values.
+- **Fan-out from the start:** one WABA can be connected to two workspaces.
+- Graph API version: use the existing `WHATSAPP_GRAPH_BASE` constant in `whatsapp.service.ts`. Do not hardcode a version.
+- Backend tests: Jest, `*.spec.ts` co-located. Frontend tests: Vitest, `*.test.ts`, **pure logic only — no DOM testing is configured**.
+- Commit after every task. Backend and frontend commit separately.
+
+### The 14 status values (verbatim from Meta)
+
+`APPROVED, PENDING, REJECTED, PAUSED, DISABLED, FLAGGED, ARCHIVED, UNARCHIVED, DELETED, IN_APPEAL, LIMIT_EXCEEDED, LOCKED, REINSTATED, PENDING_DELETION`
+
+### The 8 rejection reasons (verbatim from Meta)
+
+`ABUSIVE_CONTENT, CATEGORY_NOT_AVAILABLE, INCORRECT_CATEGORY, INVALID_FORMAT, NONE, PROMOTIONAL, SCAM, TAG_CONTENT_MISMATCH` (or `null`)
+
+---
+
+## File Structure
+
+**Backend (`socialmedia-workspace`)**
+
+| File | Responsibility |
+|---|---|
+| `src/drizzle/schema/whatsapp-templates.schema.ts` | *Create* — table, types, status/category constants |
+| `drizzle/migrations/00XX_whatsapp_templates.sql` | *Create* — hand-written (journal drift; `db:generate` unusable) |
+| `src/channels/services/whatsapp-template.util.ts` | *Create* — pure: webhook parse + Meta-row → DB-row mapping |
+| `src/channels/services/whatsapp-template.util.spec.ts` | *Create* — tests for the above |
+| `src/channels/services/whatsapp.service.ts` | *Modify* — add `listMessageTemplates`, `deleteMessageTemplate`, `sendTemplate` |
+| `src/whatsapp-templates/whatsapp-templates.service.ts` | *Create* — sync reconciliation, status updates, fan-out |
+| `src/whatsapp-templates/whatsapp-templates.controller.ts` | *Create* — list / sync / delete endpoints |
+| `src/whatsapp-templates/whatsapp-templates.module.ts` | *Create* — module wiring |
+| `src/channels/webhooks.controller.ts` | *Modify* — route template events before the maestro/ingest branch |
+| `src/inbox/adapters/whatsapp-dm.adapter.ts` | *Modify* — `sendTemplateDm`; drop the "coming soon" copy |
+
+**Frontend (`socialmedia-frontend`)**
+
+| File | Responsibility |
+|---|---|
+| `src/features/media-library/types/whatsapp-template.ts` | *Create* — types + status tone mapping |
+| `src/features/media-library/types/whatsapp-template.test.ts` | *Create* — tone mapping tests |
+| `src/features/media-library/api/whatsapp-templates.api.ts` | *Create* — typed apiClient wrappers |
+| `src/features/media-library/hooks/use-whatsapp-templates.ts` | *Create* — list query + sync/delete mutations |
+| `src/features/media-library/components/items/whatsapp-template-card.tsx` | *Create* — the WhatsApp card variant |
+| `src/features/media-library/components/items/template-card-grid.tsx` | *Modify* — accept the union, dispatch to the right card |
+| `src/features/media-library/components/type-view/type-view.tsx` | *Modify* — feed WhatsApp templates into the grid |
+| `src/features/inbox/components/whatsapp-template-picker.tsx` | *Create* — approved-template picker |
+
+---
+
+## Task 1: Schema + migration
+
+**Files:**
+- Create: `src/drizzle/schema/whatsapp-templates.schema.ts`
+- Create: `drizzle/migrations/00XX_whatsapp_templates.sql`
+- Modify: `src/drizzle/schema/index.ts` (add the export)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `whatsappMessageTemplates` table; `WHATSAPP_TEMPLATE_STATUS`, `WHATSAPP_TEMPLATE_CATEGORY`, `WHATSAPP_TEMPLATE_REJECTION_REASON` const arrays; types `WhatsAppTemplateStatus`, `WhatsAppTemplateCategory`, `WhatsAppTemplateComponent`, `WhatsAppMessageTemplate`, `NewWhatsAppMessageTemplate`.
+
+- [ ] **Step 1: Read the sibling schema for house style**
+
+Read `src/drizzle/schema/feedback.schema.ts`. Note: `desc` imports from `drizzle-orm`, **not** `drizzle-orm/pg-core`.
+
+- [ ] **Step 2: Write the schema file**
+
+```ts
+import {
+  bigint, index, jsonb, pgTable, timestamp, uniqueIndex, uuid, varchar,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { workspace } from './workspace.schema';
+import { socialMediaChannels } from './channels.schema';
+
+/** Meta's full status set. Stored verbatim — the UI groups these into tones.
+ *  Meta may add values, so consumers must tolerate an unrecognized string. */
+export const WHATSAPP_TEMPLATE_STATUS = [
+  'APPROVED', 'PENDING', 'REJECTED', 'PAUSED', 'DISABLED', 'FLAGGED',
+  'ARCHIVED', 'UNARCHIVED', 'DELETED', 'IN_APPEAL', 'LIMIT_EXCEEDED',
+  'LOCKED', 'REINSTATED', 'PENDING_DELETION',
+] as const;
+export type WhatsAppTemplateStatus = (typeof WHATSAPP_TEMPLATE_STATUS)[number];
+
+export const WHATSAPP_TEMPLATE_CATEGORY = [
+  'MARKETING', 'UTILITY', 'AUTHENTICATION',
+] as const;
+export type WhatsAppTemplateCategory =
+  (typeof WHATSAPP_TEMPLATE_CATEGORY)[number];
+
+export const WHATSAPP_TEMPLATE_REJECTION_REASON = [
+  'ABUSIVE_CONTENT', 'CATEGORY_NOT_AVAILABLE', 'INCORRECT_CATEGORY',
+  'INVALID_FORMAT', 'NONE', 'PROMOTIONAL', 'SCAM', 'TAG_CONTENT_MISMATCH',
+] as const;
+
+/** One HEADER/BODY/FOOTER/BUTTONS block as Meta returns it. Kept loose on
+ *  purpose: Phase 1 only renders these, and Meta's component shape varies by
+ *  format far more than Phase 1 needs to model. */
+export interface WhatsAppTemplateComponent {
+  type: 'HEADER' | 'BODY' | 'FOOTER' | 'BUTTONS';
+  format?: 'TEXT' | 'IMAGE' | 'VIDEO' | 'DOCUMENT' | 'LOCATION';
+  text?: string;
+  buttons?: Array<Record<string, any>>;
+  example?: Record<string, any>;
+}
+
+export const whatsappMessageTemplates = pgTable(
+  'whatsapp_message_templates',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    workspaceId: uuid('workspace_id')
+      .notNull()
+      .references(() => workspace.id, { onDelete: 'cascade' }),
+
+    /** The channel whose token synced this row. `social_media_channels.id` is
+     *  a bigserial, so this is a bigint — NOT a uuid like the other FKs. */
+    channelId: bigint('channel_id', { mode: 'number' })
+      .notNull()
+      .references(() => socialMediaChannels.id, { onDelete: 'cascade' }),
+
+    /** Denormalized from channel.metadata.wabaId so webhook lookups, which
+     *  arrive keyed by WABA, do not have to join through channels. */
+    wabaId: varchar('waba_id', { length: 64 }).notNull(),
+
+    /** Meta's own id. The upsert key. */
+    metaTemplateId: varchar('meta_template_id', { length: 64 }).notNull(),
+
+    name: varchar('name', { length: 512 }).notNull(),
+    language: varchar('language', { length: 32 }).notNull(),
+
+    /** Meta's RETURNED category, never the requested one — Meta silently
+     *  overrides UTILITY to MARKETING, and category drives pricing. */
+    category: varchar('category', { length: 32 })
+      .$type<WhatsAppTemplateCategory>()
+      .notNull(),
+
+    status: varchar('status', { length: 32 })
+      .$type<WhatsAppTemplateStatus>()
+      .notNull(),
+
+    rejectionReason: varchar('rejection_reason', { length: 64 }),
+
+    components: jsonb('components')
+      .$type<WhatsAppTemplateComponent[]>()
+      .notNull()
+      .default([]),
+
+    lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Meta's identity for a template is (name, language) within a WABA.
+    uniqueIndex('whatsapp_templates_channel_name_lang_uq').on(
+      table.channelId, table.name, table.language,
+    ),
+    index('whatsapp_templates_meta_id_idx').on(table.metaTemplateId),
+    index('whatsapp_templates_waba_id_idx').on(table.wabaId),
+    index('whatsapp_templates_workspace_id_idx').on(table.workspaceId),
+    index('whatsapp_templates_channel_id_idx').on(table.channelId),
+  ],
+);
+
+export const whatsappMessageTemplatesRelations = relations(
+  whatsappMessageTemplates,
+  ({ one }) => ({
+    workspace: one(workspace, {
+      fields: [whatsappMessageTemplates.workspaceId],
+      references: [workspace.id],
+    }),
+    channel: one(socialMediaChannels, {
+      fields: [whatsappMessageTemplates.channelId],
+      references: [socialMediaChannels.id],
+    }),
+  }),
+);
+
+export type WhatsAppMessageTemplate =
+  typeof whatsappMessageTemplates.$inferSelect;
+export type NewWhatsAppMessageTemplate =
+  typeof whatsappMessageTemplates.$inferInsert;
+```
+
+**Verified before writing this plan:** `workspace` is `pgTable('workspace', ...)` with a `uuid` PK; `socialMediaChannels` is `pgTable('social_media_channels', ...)` and its PK is `bigserial('id', { mode: 'number' })` — **a bigint, not a uuid**. `channelId` above is typed accordingly. Do not "correct" it to `uuid`: the FK would fail to create.
+
+- [ ] **Step 3: Export from the schema barrel**
+
+Add to `src/drizzle/schema/index.ts` following the existing export style.
+
+- [ ] **Step 4: Write the migration by hand**
+
+The journal has drifted (see the Evergreen and feedback efforts) — `npm run db:generate` is unusable. Find the highest-numbered file in `drizzle/migrations/` and use the next number.
+
+```sql
+CREATE TABLE IF NOT EXISTS "whatsapp_message_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "channel_id" bigint NOT NULL,
+  "waba_id" varchar(64) NOT NULL,
+  "meta_template_id" varchar(64) NOT NULL,
+  "name" varchar(512) NOT NULL,
+  "language" varchar(32) NOT NULL,
+  "category" varchar(32) NOT NULL,
+  "status" varchar(32) NOT NULL,
+  "rejection_reason" varchar(64),
+  "components" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "last_synced_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "whatsapp_message_templates_workspace_id_fk"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspace"("id") ON DELETE CASCADE,
+  CONSTRAINT "whatsapp_message_templates_channel_id_fk"
+    FOREIGN KEY ("channel_id") REFERENCES "social_media_channels"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "whatsapp_templates_channel_name_lang_uq"
+  ON "whatsapp_message_templates" ("channel_id","name","language");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_meta_id_idx"
+  ON "whatsapp_message_templates" ("meta_template_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_waba_id_idx"
+  ON "whatsapp_message_templates" ("waba_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_workspace_id_idx"
+  ON "whatsapp_message_templates" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_channel_id_idx"
+  ON "whatsapp_message_templates" ("channel_id");
+```
+
+Replace both `<...>` markers with the real table name and PK type found in Step 2.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `npm run build`
+Expected: PASS, no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/drizzle/schema/whatsapp-templates.schema.ts src/drizzle/schema/index.ts drizzle/migrations/
+git commit -m "feat(whatsapp): whatsapp_message_templates schema + migration"
+```
+
+---
+
+## Task 2: Pure utilities — webhook parser + Meta row mapper
+
+**Files:**
+- Create: `src/channels/services/whatsapp-template.util.ts`
+- Create: `src/channels/services/whatsapp-template.util.spec.ts`
+
+**Interfaces:**
+- Consumes: `WhatsAppTemplateStatus`, `WhatsAppTemplateCategory`, `WhatsAppTemplateComponent` from Task 1.
+- Produces:
+  - `parseWhatsAppTemplateEvents(payload: any): ParsedTemplateEvent[]`
+  - `interface ParsedTemplateEvent { wabaId: string; metaTemplateId: string; name: string; language: string; status: string; category?: string; reason?: string | null }`
+  - `mapMetaTemplateRow(row: any): MappedMetaTemplate`
+  - `interface MappedMetaTemplate { metaTemplateId: string; name: string; language: string; category: string; status: string; components: WhatsAppTemplateComponent[] }`
+
+This task is pure functions only — no DB, no network. Everything testable in isolation.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import {
+  parseWhatsAppTemplateEvents,
+  mapMetaTemplateRow,
+} from './whatsapp-template.util';
+import { parseWhatsAppMessages } from './whatsapp-webhook.util';
+
+const statusPayload = (event: string, reason: string | null = 'NONE') => ({
+  object: 'whatsapp_business_account',
+  entry: [
+    {
+      id: '102290129340398',
+      time: 1751247548,
+      changes: [
+        {
+          field: 'message_template_status_update',
+          value: {
+            event,
+            message_template_id: 1689556908129832,
+            message_template_name: 'order_confirmation',
+            message_template_language: 'en-US',
+            reason,
+            message_template_category: 'UTILITY',
+          },
+        },
+      ],
+    },
+  ],
+});
+
+describe('parseWhatsAppTemplateEvents', () => {
+  it('parses an APPROVED event', () => {
+    const [ev] = parseWhatsAppTemplateEvents(statusPayload('APPROVED'));
+    expect(ev).toEqual({
+      wabaId: '102290129340398',
+      metaTemplateId: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en-US',
+      status: 'APPROVED',
+      category: 'UTILITY',
+      reason: 'NONE',
+    });
+  });
+
+  it.each([
+    'APPROVED', 'PENDING', 'REJECTED', 'PAUSED', 'DISABLED', 'FLAGGED',
+    'ARCHIVED', 'UNARCHIVED', 'DELETED', 'IN_APPEAL', 'LIMIT_EXCEEDED',
+    'LOCKED', 'REINSTATED', 'PENDING_DELETION',
+  ])('parses the %s event', (event) => {
+    const [ev] = parseWhatsAppTemplateEvents(statusPayload(event));
+    expect(ev.status).toBe(event);
+  });
+
+  it('carries the rejection reason through', () => {
+    const [ev] = parseWhatsAppTemplateEvents(
+      statusPayload('REJECTED', 'INCORRECT_CATEGORY'),
+    );
+    expect(ev.reason).toBe('INCORRECT_CATEGORY');
+  });
+
+  it('tolerates a null reason', () => {
+    const [ev] = parseWhatsAppTemplateEvents(
+      statusPayload('PENDING_DELETION', null),
+    );
+    expect(ev.reason).toBeNull();
+  });
+
+  it('ignores message events', () => {
+    const messagePayload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: 'WABA_ID',
+          changes: [
+            { field: 'messages', value: { messages: [{ id: 'wamid.X' }] } },
+          ],
+        },
+      ],
+    };
+    expect(parseWhatsAppTemplateEvents(messagePayload)).toEqual([]);
+  });
+
+  it.each([
+    [null], [undefined], [{}], [{ object: 'page' }],
+    [{ object: 'whatsapp_business_account' }],
+    [{ object: 'whatsapp_business_account', entry: [{}] }],
+    [{ object: 'whatsapp_business_account', entry: [{ changes: [{}] }] }],
+  ])('returns [] for malformed payload %#', (payload) => {
+    expect(parseWhatsAppTemplateEvents(payload as any)).toEqual([]);
+  });
+
+  it('leaves parseWhatsAppMessages untouched for message payloads', () => {
+    // Regression guard: the two parsers must not interfere. Inbox ingest and
+    // the Maestro bridge both depend on parseWhatsAppMessages.
+    const messagePayload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: 'WABA_ID',
+          changes: [
+            {
+              field: 'messages',
+              value: {
+                metadata: { phone_number_id: '1010' },
+                messages: [
+                  {
+                    from: '15551234567',
+                    id: 'wamid.HBgL',
+                    timestamp: '1719400000',
+                    type: 'text',
+                    text: { body: 'Hi' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(parseWhatsAppMessages(messagePayload)).toHaveLength(1);
+    expect(parseWhatsAppTemplateEvents(messagePayload)).toEqual([]);
+  });
+});
+
+describe('mapMetaTemplateRow', () => {
+  it('maps a Meta list row', () => {
+    const row = {
+      id: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en_US',
+      category: 'UTILITY',
+      status: 'APPROVED',
+      components: [{ type: 'BODY', text: 'Your order {{1}} shipped.' }],
+    };
+    expect(mapMetaTemplateRow(row)).toEqual({
+      metaTemplateId: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en_US',
+      category: 'UTILITY',
+      status: 'APPROVED',
+      components: [{ type: 'BODY', text: 'Your order {{1}} shipped.' }],
+    });
+  });
+
+  it('defaults components to [] when Meta omits them', () => {
+    const row = {
+      id: '1', name: 'n', language: 'en', category: 'MARKETING',
+      status: 'PENDING',
+    };
+    expect(mapMetaTemplateRow(row).components).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest src/channels/services/whatsapp-template.util.spec.ts`
+Expected: FAIL — cannot find module `./whatsapp-template.util`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import type { WhatsAppTemplateComponent } from '../../drizzle/schema/whatsapp-templates.schema';
+
+export interface ParsedTemplateEvent {
+  wabaId: string;
+  metaTemplateId: string;
+  name: string;
+  language: string;
+  status: string;
+  category?: string;
+  reason?: string | null;
+}
+
+/**
+ * Flatten `message_template_status_update` webhooks into status rows.
+ *
+ * Deliberately separate from `parseWhatsAppMessages`: that parser feeds inbox
+ * ingest and the Maestro bridge, and both filter on `field === 'messages'`.
+ * Widening it would put template payloads through message code paths.
+ */
+export function parseWhatsAppTemplateEvents(
+  payload: any,
+): ParsedTemplateEvent[] {
+  const out: ParsedTemplateEvent[] = [];
+  if (payload?.object !== 'whatsapp_business_account') return out;
+  for (const entry of payload?.entry ?? []) {
+    const wabaId = entry?.id;
+    if (!wabaId) continue;
+    for (const change of entry?.changes ?? []) {
+      if (change?.field !== 'message_template_status_update') continue;
+      const v = change.value ?? {};
+      if (!v?.message_template_id || !v?.event) continue;
+      out.push({
+        wabaId: String(wabaId),
+        metaTemplateId: String(v.message_template_id),
+        name: String(v.message_template_name ?? ''),
+        language: String(v.message_template_language ?? ''),
+        status: String(v.event),
+        category: v.message_template_category
+          ? String(v.message_template_category)
+          : undefined,
+        reason: v.reason === undefined ? undefined : v.reason,
+      });
+    }
+  }
+  return out;
+}
+
+export interface MappedMetaTemplate {
+  metaTemplateId: string;
+  name: string;
+  language: string;
+  category: string;
+  status: string;
+  components: WhatsAppTemplateComponent[];
+}
+
+/** Normalize one row of `GET /<waba>/message_templates` into our column shape. */
+export function mapMetaTemplateRow(row: any): MappedMetaTemplate {
+  return {
+    metaTemplateId: String(row?.id ?? ''),
+    name: String(row?.name ?? ''),
+    language: String(row?.language ?? ''),
+    category: String(row?.category ?? ''),
+    status: String(row?.status ?? ''),
+    components: Array.isArray(row?.components) ? row.components : [],
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx jest src/channels/services/whatsapp-template.util.spec.ts`
+Expected: PASS, all tests green.
+
+- [ ] **Step 5: Run the pre-existing webhook util tests**
+
+Run: `npx jest src/channels/services/whatsapp-webhook.util.spec.ts`
+Expected: PASS, unchanged. This proves the existing parser was not disturbed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/channels/services/whatsapp-template.util.ts src/channels/services/whatsapp-template.util.spec.ts
+git commit -m "feat(whatsapp): template webhook parser + Meta row mapper"
+```
+
+---
+
+## Task 3: Meta API calls on WhatsAppService
+
+**Files:**
+- Modify: `src/channels/services/whatsapp.service.ts`
+
+**Interfaces:**
+- Consumes: existing `WHATSAPP_GRAPH_BASE` constant in this file.
+- Produces:
+  - `listMessageTemplates(accessToken: string, wabaId: string): Promise<any[]>`
+  - `deleteMessageTemplate(accessToken, wabaId, name, metaTemplateId): Promise<void>`
+  - `sendTemplate(accessToken, phoneNumberId, toWaId, name, language, components?): Promise<{ messageId: string }>`
+
+Follow the exact shape of the existing `sendText` (read it first): `fetch`, `await res.json().catch(() => ({}))`, throw `data?.error?.message` on `!res.ok`.
+
+- [ ] **Step 1: Add the three methods**
+
+```ts
+  /**
+   * List every template on a WABA. Meta paginates; follow `paging.next` so a
+   * business with more than one page does not silently lose the tail.
+   */
+  async listMessageTemplates(
+    accessToken: string,
+    wabaId: string,
+  ): Promise<any[]> {
+    const out: any[] = [];
+    let url =
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/message_templates` +
+      `?limit=100&fields=id,name,language,category,status,components`;
+    // Bounded so a malformed paging cursor cannot spin forever.
+    for (let page = 0; page < 20 && url; page++) {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg =
+          data?.error?.message ||
+          `WhatsApp template list failed (${res.status})`;
+        throw new Error(msg);
+      }
+      out.push(...(data?.data ?? []));
+      url = data?.paging?.next ?? '';
+    }
+    return out;
+  }
+
+  /**
+   * Delete a template at Meta. Permanent — there is no recycle bin. Deleting
+   * by name removes every language variant, so pass `hsm_id` to scope the
+   * delete to the one row the user actually chose.
+   */
+  async deleteMessageTemplate(
+    accessToken: string,
+    wabaId: string,
+    name: string,
+    metaTemplateId: string,
+  ): Promise<void> {
+    const url =
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/message_templates` +
+      `?name=${encodeURIComponent(name)}` +
+      `&hsm_id=${encodeURIComponent(metaTemplateId)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg =
+        data?.error?.message || `WhatsApp template delete failed (${res.status})`;
+      throw new Error(msg);
+    }
+  }
+
+  /**
+   * Send an approved template. Unlike `sendText`, this is valid *outside* the
+   * 24-hour customer window — that is the whole point of templates.
+   */
+  async sendTemplate(
+    accessToken: string,
+    phoneNumberId: string,
+    toWaId: string,
+    name: string,
+    language: string,
+    components?: Array<Record<string, any>>,
+  ): Promise<{ messageId: string }> {
+    const res = await fetch(`${WHATSAPP_GRAPH_BASE}/${phoneNumberId}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        to: toWaId,
+        type: 'template',
+        template: {
+          name,
+          language: { code: language },
+          ...(components?.length ? { components } : {}),
+        },
+      }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg =
+        data?.error?.message || `WhatsApp template send failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return { messageId: data?.messages?.[0]?.id ?? '' };
+  }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Run the existing WhatsApp service tests**
+
+Run: `npx jest src/channels/services/whatsapp.service.spec.ts`
+Expected: PASS, unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/channels/services/whatsapp.service.ts
+git commit -m "feat(whatsapp): list/delete/send message template Graph calls"
+```
+
+---
+
+## Task 4: Sync service (reconciliation + fan-out)
+
+**Files:**
+- Create: `src/whatsapp-templates/whatsapp-templates.service.ts`
+- Create: `src/whatsapp-templates/whatsapp-templates.service.spec.ts`
+- Create: `src/whatsapp-templates/whatsapp-templates.module.ts`
+
+**Interfaces:**
+- Consumes: `mapMetaTemplateRow` (Task 2), `listMessageTemplates` / `deleteMessageTemplate` (Task 3), `whatsappMessageTemplates` (Task 1).
+- Produces:
+  - `reconcile(existing: ExistingRow[], incoming: MappedMetaTemplate[]): ReconcileResult` — **exported standalone pure function**, not a method
+  - `shouldSyncChannel(lastSyncedAt: Date | null, now: Date, force?: boolean): boolean` — exported pure function
+  - `SYNC_MIN_INTERVAL_MS: number`
+  - `interface ExistingRow { id: string; metaTemplateId: string; status: string }`
+  - `interface ReconcileResult { toInsert: MappedMetaTemplate[]; toUpdate: Array<{ id: string; row: MappedMetaTemplate }>; toDeleteIds: string[] }`
+  - `WhatsAppTemplatesService.syncWorkspace(workspaceId: string, opts?: { force?: boolean }): Promise<{ synced: number }>`
+  - `WhatsAppTemplatesService.applyStatusEvents(events: ParsedTemplateEvent[]): Promise<void>`
+  - `WhatsAppTemplatesService.listForWorkspace(workspaceId: string): Promise<WhatsAppMessageTemplate[]>`
+  - `WhatsAppTemplatesService.deleteTemplate(workspaceId: string, id: string): Promise<void>`
+
+`reconcile` is pure so it can be tested without a database — that is where the real logic risk lives.
+
+- [ ] **Step 1: Write the failing tests for `reconcile`**
+
+```ts
+import {
+  reconcile, shouldSyncChannel, SYNC_MIN_INTERVAL_MS,
+} from './whatsapp-templates.service';
+
+const meta = (id: string, status = 'APPROVED') => ({
+  metaTemplateId: id,
+  name: `t_${id}`,
+  language: 'en_US',
+  category: 'UTILITY',
+  status,
+  components: [],
+});
+
+describe('reconcile', () => {
+  it('inserts templates Meta has and we do not', () => {
+    const r = reconcile([], [meta('1'), meta('2')]);
+    expect(r.toInsert.map((x) => x.metaTemplateId)).toEqual(['1', '2']);
+    expect(r.toUpdate).toEqual([]);
+    expect(r.toDeleteIds).toEqual([]);
+  });
+
+  it('updates templates both sides have', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'PENDING' }];
+    const r = reconcile(existing, [meta('1', 'APPROVED')]);
+    expect(r.toInsert).toEqual([]);
+    expect(r.toUpdate).toHaveLength(1);
+    expect(r.toUpdate[0].id).toBe('row-1');
+    expect(r.toUpdate[0].row.status).toBe('APPROVED');
+    expect(r.toDeleteIds).toEqual([]);
+  });
+
+  it('prunes rows Meta no longer has', () => {
+    const existing = [
+      { id: 'row-1', metaTemplateId: '1', status: 'APPROVED' },
+      { id: 'row-2', metaTemplateId: '2', status: 'APPROVED' },
+    ];
+    const r = reconcile(existing, [meta('1')]);
+    expect(r.toDeleteIds).toEqual(['row-2']);
+  });
+
+  it('handles all three operations at once', () => {
+    const existing = [
+      { id: 'row-1', metaTemplateId: '1', status: 'PENDING' },
+      { id: 'row-gone', metaTemplateId: '99', status: 'APPROVED' },
+    ];
+    const r = reconcile(existing, [meta('1', 'APPROVED'), meta('2')]);
+    expect(r.toInsert.map((x) => x.metaTemplateId)).toEqual(['2']);
+    expect(r.toUpdate.map((x) => x.id)).toEqual(['row-1']);
+    expect(r.toDeleteIds).toEqual(['row-gone']);
+  });
+
+  it('prunes everything when Meta returns nothing', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'APPROVED' }];
+    const r = reconcile(existing, []);
+    expect(r.toDeleteIds).toEqual(['row-1']);
+    expect(r.toInsert).toEqual([]);
+  });
+
+  it('is a no-op when both sides already agree', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'APPROVED' }];
+    const r = reconcile(existing, [meta('1', 'APPROVED')]);
+    expect(r.toInsert).toEqual([]);
+    expect(r.toDeleteIds).toEqual([]);
+    // Still emitted as an update: components or category may have changed even
+    // when status did not, and re-writing is cheaper than diffing every field.
+    expect(r.toUpdate).toHaveLength(1);
+  });
+});
+
+describe('shouldSyncChannel', () => {
+  const now = new Date('2026-08-26T12:00:00Z');
+
+  it('syncs a channel that has never synced', () => {
+    expect(shouldSyncChannel(null, now)).toBe(true);
+  });
+
+  it('skips a channel synced moments ago', () => {
+    const justNow = new Date(now.getTime() - 30_000);
+    expect(shouldSyncChannel(justNow, now)).toBe(false);
+  });
+
+  it('syncs again once the interval has passed', () => {
+    const stale = new Date(now.getTime() - SYNC_MIN_INTERVAL_MS - 1);
+    expect(shouldSyncChannel(stale, now)).toBe(true);
+  });
+
+  it('syncs at exactly the interval boundary', () => {
+    const boundary = new Date(now.getTime() - SYNC_MIN_INTERVAL_MS);
+    expect(shouldSyncChannel(boundary, now)).toBe(true);
+  });
+
+  it('force overrides a fresh sync', () => {
+    const justNow = new Date(now.getTime() - 30_000);
+    expect(shouldSyncChannel(justNow, now, true)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest src/whatsapp-templates/whatsapp-templates.service.spec.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write `reconcile` and the service**
+
+```ts
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../drizzle/db';
+import { whatsappMessageTemplates } from '../drizzle/schema/whatsapp-templates.schema';
+import { WhatsAppService } from '../channels/services/whatsapp.service';
+import { ChannelService } from '../channels/services/channel.service';
+import {
+  mapMetaTemplateRow,
+  type MappedMetaTemplate,
+  type ParsedTemplateEvent,
+} from '../channels/services/whatsapp-template.util';
+
+export interface ExistingRow {
+  id: string;
+  metaTemplateId: string;
+  status: string;
+}
+
+export interface ReconcileResult {
+  toInsert: MappedMetaTemplate[];
+  toUpdate: Array<{ id: string; row: MappedMetaTemplate }>;
+  toDeleteIds: string[];
+}
+
+/**
+ * Diff what we have against what Meta returned.
+ *
+ * Pure and exported so the reconciliation rules — the part with real risk —
+ * are testable without a database. Rows Meta no longer returns are deleted
+ * outright rather than soft-deleted: Meta deletion is permanent, and keeping a
+ * ghost row would offer a restore that cannot work.
+ */
+export function reconcile(
+  existing: ExistingRow[],
+  incoming: MappedMetaTemplate[],
+): ReconcileResult {
+  const byMetaId = new Map(existing.map((e) => [e.metaTemplateId, e]));
+  const seen = new Set<string>();
+  const toInsert: MappedMetaTemplate[] = [];
+  const toUpdate: Array<{ id: string; row: MappedMetaTemplate }> = [];
+
+  for (const row of incoming) {
+    const match = byMetaId.get(row.metaTemplateId);
+    if (match) {
+      seen.add(match.id);
+      toUpdate.push({ id: match.id, row });
+    } else {
+      toInsert.push(row);
+    }
+  }
+
+  const toDeleteIds = existing.filter((e) => !seen.has(e.id)).map((e) => e.id);
+  return { toInsert, toUpdate, toDeleteIds };
+}
+
+@Injectable()
+export class WhatsAppTemplatesService {
+  private readonly logger = new Logger(WhatsAppTemplatesService.name);
+
+  constructor(
+    private readonly whatsapp: WhatsAppService,
+    private readonly channels: ChannelService,
+  ) {}
+
+  // syncWorkspace, applyStatusEvents, listForWorkspace, deleteTemplate below.
+}
+```
+
+Then implement the four methods:
+
+- **`listForWorkspace(workspaceId)`** — select all rows for the workspace, ordered by `name`.
+
+- **`syncWorkspace(workspaceId, opts?: { force?: boolean })`** — find the workspace's active `whatsapp` channels; for each, read `metadata.wabaId` and the decrypted token; call `listMessageTemplates`; `mapMetaTemplateRow` each row; load existing rows for that `channelId`; `reconcile`; then apply inserts/updates/deletes in a transaction, stamping `lastSyncedAt: new Date()`. A channel whose Graph call throws is logged and skipped — one broken channel must not fail the whole sync.
+
+  **Throttle.** The frontend syncs on every mount of the Library templates view, so a user clicking between views would hammer Meta. Skip a channel whose newest `lastSyncedAt` is under `SYNC_MIN_INTERVAL_MS` old unless `force` is set:
+
+```ts
+/** Fetch-on-load is a backstop for missed webhooks, not a live feed — once
+ *  every few minutes per channel is ample, and Meta rate-limits per WABA. */
+export const SYNC_MIN_INTERVAL_MS = 5 * 60 * 1000;
+
+export function shouldSyncChannel(
+  lastSyncedAt: Date | null,
+  now: Date,
+  force = false,
+): boolean {
+  if (force) return true;
+  if (!lastSyncedAt) return true;
+  return now.getTime() - lastSyncedAt.getTime() >= SYNC_MIN_INTERVAL_MS;
+}
+```
+
+  Export `shouldSyncChannel` as a standalone pure function beside `reconcile` so it is testable without a clock. The explicit "Sync" button passes `force: true`; the automatic mount-time sync does not.
+
+- **`applyStatusEvents(events)`** — for each event, update **every** row matching `(wabaId, metaTemplateId)` — plural on purpose: one WABA can be connected to two workspaces, and updating only the first is precisely the fan-out bug shipped before (`findChannelsByPlatformAccount`). Write `status`, `rejectionReason` (`reason === 'NONE' ? null : reason`), `category` when present, and `updatedAt`. An event matching no row is logged at debug and ignored — it may belong to a WABA we do not track.
+
+- **`deleteTemplate(workspaceId, id)`** — load the row scoped to `workspaceId` (404 if absent), resolve the channel token, call `deleteMessageTemplate`, then delete the local row. Meta first: if Meta rejects, the local row must survive so the list does not lie.
+
+Use the existing token-decryption helper on `ChannelService` — read `whatsapp-onboarding.service.ts` for how channels and tokens are resolved. Do not re-implement decryption.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx jest src/whatsapp-templates/whatsapp-templates.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the module**
+
+```ts
+import { Module } from '@nestjs/common';
+import { ChannelsModule } from '../channels/channels.module';
+import { WhatsAppTemplatesService } from './whatsapp-templates.service';
+import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
+
+@Module({
+  imports: [ChannelsModule],
+  controllers: [WhatsAppTemplatesController],
+  providers: [WhatsAppTemplatesService],
+  exports: [WhatsAppTemplatesService],
+})
+export class WhatsAppTemplatesModule {}
+```
+
+The controller arrives in Task 5; create it as an empty class first if needed so this compiles, or write Task 5 before building.
+
+**Watch for circular imports.** A 4-module cycle bit the team-invitations effort on cold boot. If `ChannelsModule` ends up importing this module back, use `forwardRef`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/whatsapp-templates/
+git commit -m "feat(whatsapp): template sync service with reconcile + fan-out"
+```
+
+---
+
+## Task 5: Endpoints
+
+**Files:**
+- Create: `src/whatsapp-templates/whatsapp-templates.controller.ts`
+- Modify: `src/app.module.ts` (register `WhatsAppTemplatesModule`)
+
+**Interfaces:**
+- Consumes: `WhatsAppTemplatesService` (Task 4).
+- Produces:
+  - `GET  /workspaces/:workspaceId/whatsapp-templates` → `WhatsAppMessageTemplate[]`
+  - `POST /workspaces/:workspaceId/whatsapp-templates/sync` → `{ synced: number }`
+  - `DELETE /workspaces/:workspaceId/whatsapp-templates/:id` → 204
+
+- [ ] **Step 1: Read an existing workspace-scoped controller**
+
+Read the WhatsApp routes in `src/channels/channels.controller.ts` (around line 5925) for the exact guard and decorator stack: `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` plus `@RequireCapability(...)`.
+
+- [ ] **Step 2: Write the controller**
+
+```ts
+import {
+  Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { WorkspaceRoleGuard } from '../auth/guards/workspace-role.guard';
+import { RequireCapability } from '../auth/decorators/require-capability.decorator';
+import { WhatsAppTemplatesService } from './whatsapp-templates.service';
+
+@Controller('workspaces/:workspaceId/whatsapp-templates')
+@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)
+export class WhatsAppTemplatesController {
+  constructor(private readonly service: WhatsAppTemplatesService) {}
+
+  @Get()
+  @RequireCapability('channels:view')
+  async list(@Param('workspaceId') workspaceId: string) {
+    return this.service.listForWorkspace(workspaceId);
+  }
+
+  @Post('sync')
+  @RequireCapability('channels:view')
+  @HttpCode(HttpStatus.OK)
+  async sync(@Param('workspaceId') workspaceId: string) {
+    // Explicit user action — bypass the per-channel throttle.
+    return this.service.syncWorkspace(workspaceId, { force: true });
+  }
+
+  @Delete(':id')
+  @RequireCapability('channels:manage')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+  ) {
+    await this.service.deleteTemplate(workspaceId, id);
+  }
+}
+```
+
+Verify `channels:view` and `channels:manage` exist in the capability map — read `src/auth/guards/workspace-role.guard.ts`. Use the real capability names; do not invent them.
+
+**Do not bind a whole DTO object to `@Query()`.** The global `ValidationPipe` runs with `forbidNonWhitelisted: true`, and a whole-bag DTO makes every unlisted query key a 400. This exact bug shipped in the feedback effort. These endpoints take no query params — keep it that way.
+
+- [ ] **Step 3: Register the module**
+
+Add `WhatsAppTemplatesModule` to the `imports` array in `src/app.module.ts`.
+
+- [ ] **Step 4: Verify it compiles and boots**
+
+Run: `npm run build`
+Expected: PASS.
+
+Run: `npm run start:dev`
+Expected: boots with no circular-dependency warning; the three routes appear in the route table. Stop the server after checking.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whatsapp-templates/ src/app.module.ts
+git commit -m "feat(whatsapp): template list/sync/delete endpoints"
+```
+
+---
+
+## Task 6: Webhook routing
+
+**Files:**
+- Modify: `src/channels/webhooks.controller.ts:176-222`
+
+**Interfaces:**
+- Consumes: `parseWhatsAppTemplateEvents` (Task 2), `WhatsAppTemplatesService.applyStatusEvents` (Task 4).
+- Produces: nothing new.
+
+**The ordering matters.** `POST /webhooks/whatsapp` currently checks for Maestro traffic and otherwise enqueues inbox ingest. Template events carry no `messages`, so they would fall through to inbox ingest and be silently dropped. Route them **first**.
+
+- [ ] **Step 1: Add the template branch**
+
+Inside the existing `try` block in `handleWhatsAppWebhook`, immediately after `res.status(200).send('EVENT_RECEIVED')` and **before** the `maestroPnid` check:
+
+```ts
+      // Template status updates carry no `messages`, so they would fall
+      // through to inbox ingest and vanish. Handle them first and return.
+      const templateEvents = parseWhatsAppTemplateEvents(req.body);
+      if (templateEvents.length > 0) {
+        try {
+          await this.whatsappTemplates.applyStatusEvents(templateEvents);
+        } catch (err) {
+          this.logger.error(
+            `WhatsApp template status update failed: ${(err as Error).message}`,
+          );
+        }
+        return;
+      }
+```
+
+Add the import and inject `WhatsAppTemplatesService` into the constructor.
+
+- [ ] **Step 2: Verify it compiles and boots**
+
+Run: `npm run build`
+Expected: PASS.
+
+Run: `npm run start:dev`
+Expected: boots clean. If a circular dependency appears, wrap with `forwardRef`.
+
+- [ ] **Step 3: Run the full backend suite**
+
+Run: `npm test`
+Expected: PASS. Inbox and Maestro tests must be unchanged — this is the guard on the shared webhook route.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/channels/webhooks.controller.ts
+git commit -m "feat(whatsapp): route template status webhooks before inbox ingest"
+```
+
+---
+
+## Task 7: Inbox template send
+
+**Files:**
+- Modify: `src/inbox/adapters/whatsapp-dm.adapter.ts:130-152`
+
+**Interfaces:**
+- Consumes: `sendTemplate` (Task 3).
+- Produces: `WhatsAppDmAdapter.sendTemplateDm(channel, conversationId, name, language, components?): Promise<CreatedDm>`
+
+- [ ] **Step 1: Add the template send method**
+
+Model it on the existing `sendDm` (same file, line 37) — same `phoneNumberId` and `toWaId` derivation:
+
+```ts
+  /**
+   * Send an approved template. Valid outside the 24-hour window — this is what
+   * reopens a conversation the customer has gone quiet on.
+   */
+  async sendTemplateDm(
+    channel: ResolvedChannel,
+    conversationId: string,
+    name: string,
+    language: string,
+    components?: Array<Record<string, any>>,
+  ): Promise<CreatedDm> {
+    const phoneNumberId = String(
+      channel.metadata?.phoneNumberId ?? channel.platformAccountId,
+    );
+    const toWaId = conversationId.slice(conversationId.lastIndexOf(':') + 1);
+    const { messageId } = await this.whatsapp.sendTemplate(
+      channel.accessToken,
+      phoneNumberId,
+      toWaId,
+      name,
+      language,
+      components,
+    );
+    return {
+      conversationId,
+      platformItemId: messageId,
+      text: `[template] ${name}`,
+      platformCreatedAt: new Date(),
+    };
+  }
+```
+
+- [ ] **Step 2: Fix the dead-end copy**
+
+In `getReplyWindowState`, replace:
+
+```ts
+          'The 24-hour reply window has closed. A pre-approved template is required (coming soon).',
+```
+
+with:
+
+```ts
+          'The 24-hour reply window has closed. Send an approved template to reopen the conversation.',
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Run the inbox tests**
+
+Run: `npx jest src/inbox`
+Expected: PASS. If a test asserts the old "coming soon" string, update that assertion — the copy change is intentional.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inbox/adapters/whatsapp-dm.adapter.ts
+git commit -m "feat(whatsapp): send approved templates from the inbox"
+```
+
+---
+
+## Task 8: Frontend types + status tone mapping
+
+**Files:**
+- Create: `src/features/media-library/types/whatsapp-template.ts`
+- Create: `src/features/media-library/types/whatsapp-template.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface WhatsAppTemplate { id: string; workspaceId: string; channelId: number; wabaId: string; metaTemplateId: string; name: string; language: string; category; status: string; rejectionReason: string | null; components; lastSyncedAt: string | null; createdAt: string; updatedAt: string }`
+  - `type WhatsAppTemplateTone = 'approved' | 'pending' | 'blocked' | 'neutral'`
+  - `toneForStatus(status: string): WhatsAppTemplateTone`
+  - `isSendable(status: string): boolean`
+  - `rejectionReasonLabel(reason: string | null): string | null`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import {
+  toneForStatus, isSendable, rejectionReasonLabel,
+} from './whatsapp-template'
+
+describe('toneForStatus', () => {
+  it.each(['APPROVED', 'REINSTATED'])('%s is approved', (s) => {
+    expect(toneForStatus(s)).toBe('approved')
+  })
+
+  it.each(['PENDING', 'IN_APPEAL', 'PENDING_DELETION'])(
+    '%s is pending', (s) => { expect(toneForStatus(s)).toBe('pending') },
+  )
+
+  it.each([
+    'REJECTED', 'DISABLED', 'PAUSED', 'FLAGGED', 'LIMIT_EXCEEDED', 'LOCKED',
+  ])('%s is blocked', (s) => { expect(toneForStatus(s)).toBe('blocked') })
+
+  it.each(['ARCHIVED', 'UNARCHIVED', 'DELETED'])('%s is neutral', (s) => {
+    expect(toneForStatus(s)).toBe('neutral')
+  })
+
+  it('falls back to neutral for a status Meta adds later', () => {
+    // Never blank: an unknown status must still render a badge.
+    expect(toneForStatus('SOME_FUTURE_STATUS')).toBe('neutral')
+    expect(toneForStatus('')).toBe('neutral')
+  })
+
+  it('covers all 14 documented statuses', () => {
+    const all = [
+      'APPROVED', 'PENDING', 'REJECTED', 'PAUSED', 'DISABLED', 'FLAGGED',
+      'ARCHIVED', 'UNARCHIVED', 'DELETED', 'IN_APPEAL', 'LIMIT_EXCEEDED',
+      'LOCKED', 'REINSTATED', 'PENDING_DELETION',
+    ]
+    for (const s of all) {
+      expect(['approved', 'pending', 'blocked', 'neutral'])
+        .toContain(toneForStatus(s))
+    }
+  })
+})
+
+describe('isSendable', () => {
+  it('allows only APPROVED', () => {
+    expect(isSendable('APPROVED')).toBe(true)
+  })
+
+  it.each([
+    'PENDING', 'REJECTED', 'PAUSED', 'DISABLED', 'FLAGGED', 'ARCHIVED',
+    'UNARCHIVED', 'DELETED', 'IN_APPEAL', 'LIMIT_EXCEEDED', 'LOCKED',
+    'REINSTATED', 'PENDING_DELETION', 'SOMETHING_NEW',
+  ])('rejects %s', (s) => { expect(isSendable(s)).toBe(false) })
+})
+
+describe('rejectionReasonLabel', () => {
+  it('humanizes a known reason', () => {
+    expect(rejectionReasonLabel('INCORRECT_CATEGORY'))
+      .toBe('Wrong category for this content')
+  })
+
+  it('returns null for NONE and null', () => {
+    expect(rejectionReasonLabel('NONE')).toBeNull()
+    expect(rejectionReasonLabel(null)).toBeNull()
+  })
+
+  it('falls back to the raw value for an unknown reason', () => {
+    expect(rejectionReasonLabel('BRAND_NEW_REASON')).toBe('BRAND_NEW_REASON')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/features/media-library/types/whatsapp-template.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+export interface WhatsAppTemplateComponent {
+  type: 'HEADER' | 'BODY' | 'FOOTER' | 'BUTTONS'
+  format?: 'TEXT' | 'IMAGE' | 'VIDEO' | 'DOCUMENT' | 'LOCATION'
+  text?: string
+  buttons?: Array<Record<string, unknown>>
+  example?: Record<string, unknown>
+}
+
+export interface WhatsAppTemplate {
+  id: string
+  workspaceId: string
+  /** bigserial on the backend — arrives as a number, not a uuid string. */
+  channelId: number
+  wabaId: string
+  metaTemplateId: string
+  name: string
+  language: string
+  /** Meta's returned category — it can differ from what was requested. */
+  category: 'MARKETING' | 'UTILITY' | 'AUTHENTICATION'
+  status: string
+  rejectionReason: string | null
+  components: WhatsAppTemplateComponent[]
+  lastSyncedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type WhatsAppTemplateTone =
+  | 'approved' | 'pending' | 'blocked' | 'neutral'
+
+const TONE_BY_STATUS: Record<string, WhatsAppTemplateTone> = {
+  APPROVED: 'approved',
+  REINSTATED: 'approved',
+  PENDING: 'pending',
+  IN_APPEAL: 'pending',
+  PENDING_DELETION: 'pending',
+  REJECTED: 'blocked',
+  DISABLED: 'blocked',
+  PAUSED: 'blocked',
+  FLAGGED: 'blocked',
+  LIMIT_EXCEEDED: 'blocked',
+  LOCKED: 'blocked',
+  ARCHIVED: 'neutral',
+  UNARCHIVED: 'neutral',
+  DELETED: 'neutral',
+}
+
+/** Meta documents 14 statuses and may add more, so an unrecognized value
+ *  falls back to neutral rather than rendering an empty badge. */
+export function toneForStatus(status: string): WhatsAppTemplateTone {
+  return TONE_BY_STATUS[status] ?? 'neutral'
+}
+
+/** Only APPROVED templates can actually be sent. */
+export function isSendable(status: string): boolean {
+  return status === 'APPROVED'
+}
+
+const REASON_LABELS: Record<string, string> = {
+  ABUSIVE_CONTENT: 'Content breaks WhatsApp policy',
+  CATEGORY_NOT_AVAILABLE: 'That category is unavailable for this account',
+  INCORRECT_CATEGORY: 'Wrong category for this content',
+  INVALID_FORMAT: 'Formatting or variables are invalid',
+  PROMOTIONAL: 'Too promotional for a utility template',
+  SCAM: 'Flagged as a scam',
+  TAG_CONTENT_MISMATCH: "Content does not match the template's tag",
+}
+
+export function rejectionReasonLabel(reason: string | null): string | null {
+  if (!reason || reason === 'NONE') return null
+  return REASON_LABELS[reason] ?? reason
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/features/media-library/types/whatsapp-template.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/media-library/types/whatsapp-template.ts src/features/media-library/types/whatsapp-template.test.ts
+git commit -m "feat(whatsapp): template types + status tone mapping"
+```
+
+---
+
+## Task 9: Frontend API + hooks
+
+**Files:**
+- Create: `src/features/media-library/api/whatsapp-templates.api.ts`
+- Create: `src/features/media-library/hooks/use-whatsapp-templates.ts`
+
+**Interfaces:**
+- Consumes: `WhatsAppTemplate` (Task 8); backend endpoints (Task 5).
+- Produces:
+  - `whatsappTemplatesApi.list(workspaceId)`, `.sync(workspaceId)`, `.remove(workspaceId, id)`
+  - `useWhatsAppTemplates(workspaceId)` → `{ templates, isLoading, isError }`
+  - `useSyncWhatsAppTemplates(workspaceId)`, `useDeleteWhatsAppTemplate(workspaceId)`
+
+- [ ] **Step 1: Write the API wrapper**
+
+Follow `media-library.api.ts` exactly — same `apiClient` import, same `base()` shape.
+
+```ts
+import { apiClient } from '@/lib/api'
+import type { WhatsAppTemplate } from '../types/whatsapp-template'
+
+function base(workspaceId: string): string {
+  return `/workspaces/${workspaceId}/whatsapp-templates`
+}
+
+export const whatsappTemplatesApi = {
+  list: (workspaceId: string) =>
+    apiClient.get<WhatsAppTemplate[]>(base(workspaceId)),
+
+  /** Pull the latest from Meta. Returns how many templates were reconciled. */
+  sync: (workspaceId: string) =>
+    apiClient.post<{ synced: number }>(`${base(workspaceId)}/sync`),
+
+  /** Permanent at Meta — there is no recycle bin. */
+  remove: (workspaceId: string, id: string) =>
+    apiClient.delete<void>(`${base(workspaceId)}/${id}`),
+}
+```
+
+- [ ] **Step 2: Write the hooks**
+
+Follow `use-template-mutations.ts` — same `LIBRARY_KEY` invalidation style, same toast usage.
+
+```ts
+import { useEffect } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { whatsappTemplatesApi } from '../api/whatsapp-templates.api'
+
+const WA_TEMPLATES_KEY = ['whatsapp-templates'] as const
+
+/**
+ * List the workspace's WhatsApp templates, and reconcile with Meta once on
+ * mount.
+ *
+ * The sync is the backstop, not the primary path: status changes normally
+ * arrive by webhook. Meta's review can take up to 24 hours, so a user who
+ * leaves the page open would otherwise never see PENDING turn APPROVED.
+ */
+export function useWhatsAppTemplates(workspaceId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  const q = useQuery({
+    queryKey: [...WA_TEMPLATES_KEY, workspaceId],
+    queryFn: () => whatsappTemplatesApi.list(workspaceId as string),
+    enabled: !!workspaceId,
+  })
+
+  useEffect(() => {
+    if (!workspaceId) return
+    let cancelled = false
+    whatsappTemplatesApi
+      .sync(workspaceId)
+      .then(() => {
+        if (cancelled) return
+        void queryClient.invalidateQueries({
+          queryKey: [...WA_TEMPLATES_KEY, workspaceId],
+        })
+      })
+      // Silent: the cached list still renders, and a sync failure is not
+      // something the user asked for or can act on.
+      .catch(() => undefined)
+    return () => { cancelled = true }
+  }, [workspaceId, queryClient])
+
+  return {
+    templates: q.data ?? [],
+    isLoading: q.isLoading,
+    isError: q.isError,
+  }
+}
+
+export function useSyncWhatsAppTemplates(workspaceId: string | undefined) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => whatsappTemplatesApi.sync(workspaceId as string),
+    onSuccess: async (res) => {
+      await queryClient.invalidateQueries({
+        queryKey: [...WA_TEMPLATES_KEY, workspaceId],
+      })
+      toast.success(`Synced ${res.synced} template${res.synced === 1 ? '' : 's'}`)
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Could not sync templates')
+    },
+  })
+}
+
+export function useDeleteWhatsAppTemplate(workspaceId: string | undefined) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      whatsappTemplatesApi.remove(workspaceId as string, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...WA_TEMPLATES_KEY, workspaceId],
+      })
+      toast.success('Template deleted from WhatsApp')
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Could not delete the template')
+    },
+  })
+}
+```
+
+Verify `apiClient` exposes `get`/`post`/`delete` with these signatures, and that `sonner`'s `toast` is the toast used in this codebase — read `use-template-mutations.ts` and copy its imports.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/media-library/api/whatsapp-templates.api.ts src/features/media-library/hooks/use-whatsapp-templates.ts
+git commit -m "feat(whatsapp): template API wrappers + query hooks"
+```
+
+---
+
+## Task 10: The WhatsApp card variant
+
+**Files:**
+- Create: `src/features/media-library/components/items/whatsapp-template-card.tsx`
+- Modify: `src/features/media-library/components/items/template-card-grid.tsx`
+
+**Interfaces:**
+- Consumes: `WhatsAppTemplate`, `toneForStatus`, `isSendable`, `rejectionReasonLabel` (Task 8).
+- Produces:
+  - `WhatsAppTemplateCard` component
+  - `TemplateCardGrid` accepting `whatsappTemplates?: WhatsAppTemplate[]` alongside `templates`
+
+**Shadcn rule:** every visual element must come from shadcn. Use the MCP (`mcp__shadcn__*`) before reaching for any component — do not hand-roll a badge or dialog. `Badge`, `AlertDialog`, `DropdownMenu`, and `Button` are the likely set; confirm each is installed (`src/components/ui/`) and install via `mcp__shadcn__get_add_command_for_items` if not.
+
+**Theme tokens only** — no `bg-green-500`. Use `bg-success`, `bg-warning`, `bg-destructive`, `bg-muted` and their `text-*` pairs. Confirm these tokens exist in `src/index.css`; `--warning` was verified during the feedback effort.
+
+- [ ] **Step 1: Write the card**
+
+Requirements:
+- Name, language, and Meta's category
+- Status badge tinted by `toneForStatus`. **Every status renders a badge** — unknown ones show the raw string in the neutral tone
+- A `blocked` card with a `rejectionReason` shows `rejectionReasonLabel(...)` beneath the badge
+- BODY component text as the preview
+- Actions: **View** (dialog), **Send in inbox** (only when `isSendable`), **Delete**
+- No Star, no Duplicate, no Use-in-post — those are meaningless here
+- Delete opens an `AlertDialog` reading: *"Delete "{name}"? This removes it from WhatsApp permanently. It will not go to the recycle bin and cannot be restored."*
+
+- [ ] **Step 2: Widen the grid**
+
+`TemplateCardGrid` keeps its current props and gains one:
+
+```tsx
+interface TemplateCardGridProps {
+  templates: MediaTemplate[]
+  /** WhatsApp templates render as their own card variant: they live on the
+   *  customer's WABA, so starring, duplicating, and "use in post" do not
+   *  apply to them. */
+  whatsappTemplates?: WhatsAppTemplate[]
+  onOpen: (id: string) => void
+  onToggleStar: (id: string) => void
+  onDelete: (id: string) => void
+  onDuplicate?: (id: string) => void
+  onUseInPost?: (id: string) => void
+  onDeleteWhatsApp?: (id: string) => void
+  onSendWhatsApp?: (id: string) => void
+}
+```
+
+Render existing `TemplateCard`s first, then `WhatsAppTemplateCard`s, in the same grid container. **Both existing call sites keep working untouched** — `whatsappTemplates` is optional.
+
+Update the early return: `if (templates.length === 0 && !whatsappTemplates?.length) return null`.
+
+- [ ] **Step 3: Verify both call sites still compile**
+
+Run: `npm run build`
+Expected: PASS. `starred-view.tsx:358` and `type-view.tsx:622` must compile without edits.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/media-library/components/items/
+git commit -m "feat(whatsapp): WhatsApp template card variant in the library grid"
+```
+
+---
+
+## Task 11: Wire the Library view
+
+**Files:**
+- Modify: `src/features/media-library/components/type-view/type-view.tsx:615-645`
+
+**Interfaces:**
+- Consumes: `useWhatsAppTemplates`, `useDeleteWhatsAppTemplate` (Task 9); the widened grid (Task 10).
+- Produces: nothing new.
+
+- [ ] **Step 1: Feed WhatsApp templates into the grid**
+
+In the `type === 'template'` branch, call `useWhatsAppTemplates(workspaceId)` and pass `whatsappTemplates` plus `onDeleteWhatsApp` to `TemplateCardGrid`.
+
+- [ ] **Step 2: Fix the empty state**
+
+The current copy is `'No templates yet.'`. It must not appear when only WhatsApp templates exist. Gate on both lists being empty.
+
+- [ ] **Step 3: Loading state**
+
+WhatsApp templates load independently. Reuse the existing `CardGridSkeleton` while either list is loading — do not let the grid flash empty.
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run build`
+Expected: PASS.
+
+Run: `npm run dev`, open the Library → Templates. Expected: post templates render as before; WhatsApp templates render alongside with status badges. Check at 375px width — cards must not be cramped.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/media-library/components/type-view/type-view.tsx
+git commit -m "feat(whatsapp): show WhatsApp templates in the library"
+```
+
+---
+
+## Task 12: Inbox picker
+
+**Files:**
+- Create: `src/features/inbox/components/whatsapp-template-picker.tsx`
+- Modify: the inbox composer that renders the closed-window notice
+
+**Interfaces:**
+- Consumes: `useWhatsAppTemplates` (Task 9), `isSendable` (Task 8), the backend send path (Task 7).
+- Produces: `WhatsAppTemplatePicker` component.
+
+- [ ] **Step 1: Find the closed-window UI**
+
+Search the inbox feature for where `canReply === false` and `reason` are rendered. That is the insertion point.
+
+- [ ] **Step 2: Build the picker**
+
+- Lists **only** templates where `isSendable(status)` — a `PENDING` template in a send list would fail at Meta
+- Each row: name, language, BODY preview
+- Empty state: *"No approved templates yet. Create one in the Library to reopen conversations after 24 hours."* with a link to the Library — never a bare "No data"
+- Loading: skeleton. Error: inline message
+- Uses shadcn (`Dialog` or `Popover` + `Command`), confirmed via MCP
+
+- [ ] **Step 3: Wire the send**
+
+On select, call the backend send path from Task 7 and refresh the conversation.
+
+**Templates with variables are out of scope for Phase 1.** If the chosen template's BODY contains `{{1}}`, the send needs component parameters. Send only templates with no variables; disable the rest with a tooltip reading *"This template needs variables — coming with the builder."* This keeps Phase 1 honest instead of failing at Meta.
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/inbox/
+git commit -m "feat(whatsapp): approved-template picker in the inbox"
+```
+
+---
+
+## Task 13: Full verification
+
+**Files:** none.
+
+- [ ] **Step 1: Backend suite**
+
+Run: `npm test` in `socialmedia-workspace`
+Expected: PASS, all green. Compare the count against `main` — no pre-existing test may have been weakened.
+
+- [ ] **Step 2: Backend build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Frontend suite**
+
+Run: `npm test` in `socialmedia-frontend`
+Expected: PASS.
+
+- [ ] **Step 4: Frontend build**
+
+Run: `npm run build`
+Expected: PASS (`tsc -b && vite build`).
+
+- [ ] **Step 5: Confirm `media_templates` was never touched**
+
+Run: `git diff main --stat -- src/drizzle/schema/media-library.schema.ts`
+Expected: **empty output.** Any diff violates a global constraint.
+
+- [ ] **Step 6: Confirm `parseWhatsAppMessages` was never touched**
+
+Run: `git diff main -- src/channels/services/whatsapp-webhook.util.ts`
+Expected: **empty output.**
+
+- [ ] **Step 7: Migration SQL for production**
+
+Print the migration for the user to run via Railway → Postgres → Console → `psql $DATABASE_URL`. Do **not** run it — the user applies production SQL themselves.
+
+---
+
+## Manual verification (user, after deploy)
+
+Automated tests cannot reach Meta. These checks must be done by hand:
+
+1. Library → Templates shows the real WhatsApp templates from WhatsApp Manager
+2. A template `PENDING` at Meta shows an amber badge; when Meta approves it, the badge turns green **without a page reload** — this proves the webhook path
+3. Delete shows the permanence warning, and the template is gone from WhatsApp Manager afterwards
+4. A conversation older than 24 hours offers the template picker instead of the old "coming soon" text
+5. Sending an approved template actually reaches the customer's phone
+6. Only `APPROVED` templates appear in the picker
+7. 375px viewport: cards and picker are not cramped
+
+## Deferred to Phase 2
+
+- Template builder (create/edit) with components and variables
+- Templates with variables in the inbox picker (Task 12 disables them)
+- Category selection and sample values
+- Template analytics and quality rating

--- a/drizzle/migrations/0028_maestro_byok.sql
+++ b/drizzle/migrations/0028_maestro_byok.sql
@@ -1,0 +1,15 @@
+-- Maestro BYOK (bring your own Anthropic key) + first-run wizard flag.
+--
+-- maestro_anthropic_key      encrypted (AES-256-GCM) Anthropic API key. NULL =
+--                            use the platform key and bill plan credits.
+-- maestro_anthropic_key_hint last 4 chars, plaintext, so settings can show
+--                            "sk-ant-...4f2a" without decrypting the real key.
+-- maestro_onboarded_at       NULL = the first-run Maestro wizard is still due.
+--
+-- Written by hand (not drizzle-kit) to match 0024/0027 and avoid reconciling
+-- unrelated journal drift. Idempotent so it is safe to re-run on prod.
+
+ALTER TABLE "workspace" ADD COLUMN IF NOT EXISTS "maestro_anthropic_key" text;
+ALTER TABLE "workspace" ADD COLUMN IF NOT EXISTS "maestro_anthropic_key_hint" varchar(8);
+ALTER TABLE "workspace" ADD COLUMN IF NOT EXISTS "maestro_anthropic_key_set_at" timestamp;
+ALTER TABLE "workspace" ADD COLUMN IF NOT EXISTS "maestro_onboarded_at" timestamp;

--- a/src/auth/workspace-membership.util.ts
+++ b/src/auth/workspace-membership.util.ts
@@ -3,12 +3,19 @@ import type { Workspace } from '../drizzle/schema';
 export type WorkspaceRoleLabel = 'OWNER' | 'ADMIN' | 'MEMBER' | 'GUEST';
 
 // Workspace shape safe to return to clients: excludes admin-only internal
-// columns (`suspensionNote`, `suspendedById`) that must never leak via
-// /auth/me. Keep in sync with the `columns` projection used in
+// columns (`suspensionNote`, `suspendedById`) and the Maestro BYOK credential
+// (`maestroAnthropicKey`, encrypted but still a secret — it must NEVER leave
+// the server; settings read it via GET /maestro/key, which returns only a
+// masked hint). Keep in sync with the `columns` projection used in
 // AuthService#whoAmI.
 export type PublicWorkspace = Omit<
   Workspace,
-  'suspensionNote' | 'suspendedById'
+  | 'suspensionNote'
+  | 'suspendedById'
+  | 'maestroAnthropicKey'
+  | 'maestroAnthropicKeyHint'
+  | 'maestroAnthropicKeySetAt'
+  | 'maestroOnboardedAt'
 >;
 
 export type WorkspaceWithRole = PublicWorkspace & { role: WorkspaceRoleLabel };

--- a/src/chatbot/services/token-tracking.service.ts
+++ b/src/chatbot/services/token-tracking.service.ts
@@ -63,6 +63,11 @@ export class TokenTrackingService {
   /**
    * Record token usage after a successful AI operation.
    * Increments the workspace counter and inserts a log entry.
+   *
+   * Pass `billable: false` to LOG the usage without charging plan credits —
+   * used by Maestro BYOK, where the workspace pays Anthropic directly. We still
+   * want the log row for abuse detection, support ("how much have I used?") and
+   * margin analysis; we just must not double-charge.
    */
   async recordUsage(
     workspaceId: string,
@@ -75,23 +80,28 @@ export class TokenTrackingService {
       inputSummary?: string;
       outputLength?: number;
     },
+    options?: { billable?: boolean },
   ): Promise<void> {
     if (tokensUsed <= 0) return;
+    const billable = options?.billable !== false;
 
     try {
-      // Atomic increment to avoid race conditions
-      await this.db
-        .update(workspaceUsage)
-        .set({
-          aiTokensUsedThisMonth: sql`${workspaceUsage.aiTokensUsedThisMonth} + ${tokensUsed}`,
-        })
-        .where(eq(workspaceUsage.workspaceId, workspaceId));
+      if (billable) {
+        // Atomic increment to avoid race conditions
+        await this.db
+          .update(workspaceUsage)
+          .set({
+            aiTokensUsedThisMonth: sql`${workspaceUsage.aiTokensUsedThisMonth} + ${tokensUsed}`,
+          })
+          .where(eq(workspaceUsage.workspaceId, workspaceId));
+      }
 
       // Insert detailed log entry
       await this.db.insert(aiUsageLog).values({
         workspaceId,
         userId,
-        operation,
+        // Suffix un-billed rows so BYOK spend is separable from plan spend.
+        operation: billable ? operation : `${operation}_byok`,
         tokensUsed,
         apiInputTokens: details?.apiInputTokens,
         apiOutputTokens: details?.apiOutputTokens,

--- a/src/drizzle/schema/workspace.schema.ts
+++ b/src/drizzle/schema/workspace.schema.ts
@@ -23,6 +23,22 @@ export const workspace = pgTable('workspace', {
   // AI provider preference (null = system default)
   preferredAiProvider: varchar('preferred_ai_provider', { length: 20 }),
 
+  // --- Maestro BYOK (bring your own Anthropic key) ---
+  // The workspace's own Anthropic API key, ENCRYPTED at rest (AES-256-GCM via
+  // common/utils/encryption.util). Null = use the platform key and bill the
+  // workspace's plan credits. Set = the workspace pays Anthropic directly, so
+  // Maestro turns are logged but NOT billed against plan credits.
+  // Never returned to the client — the API exposes `maestroKeyHint` instead.
+  maestroAnthropicKey: text('maestro_anthropic_key'),
+  // Last 4 characters of the live key, stored in PLAINTEXT purely so settings
+  // can render "sk-ant-…4f2a" without ever decrypting the real key.
+  maestroAnthropicKeyHint: varchar('maestro_anthropic_key_hint', { length: 8 }),
+  // When the key was last saved/replaced (shown in settings).
+  maestroAnthropicKeySetAt: timestamp('maestro_anthropic_key_set_at'),
+  // Marks the first-run Maestro wizard as finished, so it runs once, not on
+  // every reload. Null = the user has not completed it yet.
+  maestroOnboardedAt: timestamp('maestro_onboarded_at'),
+
   // Workspace suspension
   isActive: boolean('is_active').notNull().default(true),
   suspendedAt: timestamp('suspended_at'),

--- a/src/maestro/auth/agent-auth.spec.ts
+++ b/src/maestro/auth/agent-auth.spec.ts
@@ -1,0 +1,126 @@
+import { resolveAgentAuth, MaestroAuthUnavailableError } from './agent-auth';
+
+/**
+ * These guard the credential decision that bills real money: which Anthropic
+ * key a Maestro run uses, and whether that run is billable to the workspace.
+ */
+describe('resolveAgentAuth', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    // Fresh copy per test so mutations never leak between cases.
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAESTRO_AUTH_MODE;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.NODE_ENV;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('default (apiKey) mode', () => {
+    it('uses the platform key when no mode is set', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      const auth = resolveAgentAuth();
+
+      expect(auth.mode).toBe('apiKey');
+      expect(auth.keySource).toBe('platform');
+      expect(auth.env.ANTHROPIC_API_KEY).toBe('sk-ant-platform');
+    });
+
+    it('throws a typed error when no key is configured at all', () => {
+      expect(() => resolveAgentAuth()).toThrow(MaestroAuthUnavailableError);
+    });
+
+    it('treats a whitespace-only key as missing', () => {
+      process.env.ANTHROPIC_API_KEY = '   ';
+
+      expect(() => resolveAgentAuth()).toThrow(MaestroAuthUnavailableError);
+    });
+
+    it('tags the run as billable to the platform', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      expect(resolveAgentAuth().keySource).toBe('platform');
+    });
+  });
+
+  describe('BYOK', () => {
+    it('prefers the workspace key over the platform key', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      const auth = resolveAgentAuth({ workspaceApiKey: 'sk-ant-workspace' });
+
+      expect(auth.env.ANTHROPIC_API_KEY).toBe('sk-ant-workspace');
+      expect(auth.keySource).toBe('byok');
+    });
+
+    it('works with no platform key configured', () => {
+      const auth = resolveAgentAuth({ workspaceApiKey: 'sk-ant-workspace' });
+
+      expect(auth.mode).toBe('apiKey');
+      expect(auth.keySource).toBe('byok');
+    });
+
+    it('falls back to the platform key when the workspace key is blank', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      const auth = resolveAgentAuth({ workspaceApiKey: '  ' });
+
+      expect(auth.env.ANTHROPIC_API_KEY).toBe('sk-ant-platform');
+      expect(auth.keySource).toBe('platform');
+    });
+
+    it('falls back to the platform key when the workspace key is null', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      expect(resolveAgentAuth({ workspaceApiKey: null }).keySource).toBe(
+        'platform',
+      );
+    });
+  });
+
+  describe('subscription mode', () => {
+    it('strips the API key so the subprocess uses Claude Code OAuth', () => {
+      process.env.MAESTRO_AUTH_MODE = 'subscription';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      const auth = resolveAgentAuth();
+
+      expect(auth.mode).toBe('subscription');
+      expect(auth.env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('is refused in production', () => {
+      process.env.MAESTRO_AUTH_MODE = 'subscription';
+      process.env.NODE_ENV = 'production';
+
+      expect(() => resolveAgentAuth()).toThrow(MaestroAuthUnavailableError);
+    });
+
+    it('never reports byok, even with a workspace key present', () => {
+      process.env.MAESTRO_AUTH_MODE = 'subscription';
+
+      const auth = resolveAgentAuth({ workspaceApiKey: 'sk-ant-workspace' });
+
+      expect(auth.keySource).toBe('platform');
+    });
+  });
+
+  describe('production safety', () => {
+    it('still resolves the platform key in production', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-platform';
+
+      expect(resolveAgentAuth().mode).toBe('apiKey');
+    });
+
+    it('throws in production when the key is missing', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(() => resolveAgentAuth()).toThrow(MaestroAuthUnavailableError);
+    });
+  });
+});

--- a/src/maestro/auth/agent-auth.ts
+++ b/src/maestro/auth/agent-auth.ts
@@ -2,46 +2,106 @@ import { Logger } from '@nestjs/common';
 
 const logger = new Logger('MaestroAgentAuth');
 
+export type AgentAuthMode = 'apiKey' | 'subscription';
+
+/** Where the resolved API key came from — drives billing downstream. */
+export type AgentKeySource = 'platform' | 'byok';
+
 export interface ResolvedAgentAuth {
-  /** 'subscription' = Claude Code OAuth (Max plan); 'apiKey' = ANTHROPIC_API_KEY. */
-  mode: 'apiKey' | 'subscription';
+  /** 'apiKey' = ANTHROPIC_API_KEY; 'subscription' = Claude Code OAuth (dev only). */
+  mode: AgentAuthMode;
+  /** Which key is paying for this run. 'byok' = the workspace's own key, so the
+   *  turn must NOT be billed against plan credits. Always 'platform' under
+   *  subscription mode. */
+  keySource: AgentKeySource;
   /** Env to hand the Agent SDK subprocess (it REPLACES the subprocess env). */
   env: Record<string, string | undefined>;
 }
 
+/** Optional per-workspace overrides. Phase 2 (BYOK) passes the decrypted key. */
+export interface AgentAuthOptions {
+  /**
+   * The workspace's own Anthropic API key (already decrypted), when it has one.
+   * Takes priority over the platform key — the whole point of BYOK is that the
+   * user's own Anthropic account is billed instead of ours.
+   */
+  workspaceApiKey?: string | null;
+}
+
 /**
- * Resolve which auth the Agent SDK subprocess should use.
+ * Thrown when no usable credential exists. Surfaced to the user as a clean
+ * error rather than letting the Agent SDK subprocess fail cryptically.
+ */
+export class MaestroAuthUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MaestroAuthUnavailableError';
+  }
+}
+
+/**
+ * Resolve which credential the Agent SDK subprocess should use for one run.
  *
- * DEFAULT = Claude Code subscription (Max plan): the subprocess authenticates
- * via the logged-in Claude Code OAuth. We strip `ANTHROPIC_API_KEY` from the
- * subprocess env so it does NOT silently fall back to the API-console key — that
- * key is the legacy chatbot's (Messages API) and may carry zero credits.
+ * DEFAULT = API key. Maestro is a paid, multi-tenant product: every run must be
+ * billable to an Anthropic API account, so the API key is the only mode that
+ * works in production.
  *
- * Set `MAESTRO_AUTH_MODE=apikey` to bill via the Anthropic API instead
- * (production / scale); that keeps `ANTHROPIC_API_KEY` in the subprocess env.
+ * `MAESTRO_AUTH_MODE=subscription` opts INTO Claude Code OAuth (a logged-in Max
+ * plan) for LOCAL DEVELOPMENT ONLY. It is refused when NODE_ENV=production: a
+ * container has no interactive OAuth session, and billing many tenants to one
+ * personal subscription is not a commercial billing path.
+ *
+ * Key priority under apiKey mode:
+ *   1. the workspace's own key (BYOK)   → keySource 'byok', not billed
+ *   2. ANTHROPIC_API_KEY (platform)     → keySource 'platform', billed
  *
  * `Options.env` REPLACES the subprocess environment, so we spread `process.env`.
+ *
+ * @throws MaestroAuthUnavailableError when no usable credential is configured.
  */
-export function resolveAgentAuth(): ResolvedAgentAuth {
+export function resolveAgentAuth(
+  options: AgentAuthOptions = {},
+): ResolvedAgentAuth {
   const env: Record<string, string | undefined> = {
     ...process.env,
     CLAUDE_AGENT_SDK_CLIENT_APP: 'schedura-maestro/0.1',
   };
 
-  const mode = (process.env.MAESTRO_AUTH_MODE || '').toLowerCase();
+  const isProduction = process.env.NODE_ENV === 'production';
+  const rawMode = (process.env.MAESTRO_AUTH_MODE || '').toLowerCase();
+  const wantsSubscription =
+    rawMode === 'subscription' || rawMode === 'sub' || rawMode === 'oauth';
 
-  // Explicit API-key billing (production / scale). Keep ANTHROPIC_API_KEY.
-  if (mode === 'apikey' || mode === 'api' || mode === 'key') {
-    if (!env.ANTHROPIC_API_KEY) {
-      logger.warn('MAESTRO_AUTH_MODE=apikey but ANTHROPIC_API_KEY is not set');
+  // Subscription mode: local-dev convenience only, never in production.
+  if (wantsSubscription) {
+    if (isProduction) {
+      throw new MaestroAuthUnavailableError(
+        'MAESTRO_AUTH_MODE=subscription is not usable in production (no interactive Claude Code session). Set MAESTRO_AUTH_MODE=apikey and provide ANTHROPIC_API_KEY.',
+      );
     }
-    logger.debug('Auth mode: apiKey');
-    return { mode: 'apiKey', env };
+    // Strip the API key so the subprocess genuinely uses the Claude Code OAuth
+    // rather than silently falling back to the console key.
+    delete env.ANTHROPIC_API_KEY;
+    logger.debug('Auth mode: subscription (local dev, Claude Code OAuth)');
+    return { mode: 'subscription', keySource: 'platform', env };
   }
 
-  // DEFAULT: Claude Code subscription (Max plan). Strip the API-console key so
-  // the subprocess uses the logged-in Claude Code OAuth instead.
-  delete env.ANTHROPIC_API_KEY;
-  logger.debug('Auth mode: subscription (Max plan)');
-  return { mode: 'subscription', env };
+  // BYOK — the workspace pays its own Anthropic bill.
+  const byok = options.workspaceApiKey?.trim();
+  if (byok) {
+    env.ANTHROPIC_API_KEY = byok;
+    logger.debug('Auth mode: apiKey (workspace BYOK)');
+    return { mode: 'apiKey', keySource: 'byok', env };
+  }
+
+  // Platform key — the default paid path.
+  const platformKey = process.env.ANTHROPIC_API_KEY?.trim();
+  if (!platformKey) {
+    throw new MaestroAuthUnavailableError(
+      'Maestro is not configured: ANTHROPIC_API_KEY is missing. Set it in the environment, or set MAESTRO_AUTH_MODE=subscription for local development.',
+    );
+  }
+  env.ANTHROPIC_API_KEY = platformKey;
+  logger.debug('Auth mode: apiKey (platform key)');
+  return { mode: 'apiKey', keySource: 'platform', env };
 }

--- a/src/maestro/dto/send-message.dto.ts
+++ b/src/maestro/dto/send-message.dto.ts
@@ -130,3 +130,21 @@ export class SendMaestroMessageDto {
   @Type(() => MaestroAttachmentDto)
   attachments?: MaestroAttachmentDto[];
 }
+
+/** Save a workspace's own Anthropic API key (BYOK). */
+export class SetMaestroKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  workspaceId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  apiKey: string;
+}
+
+/** Target a workspace for key removal / wizard completion. */
+export class MaestroWorkspaceDto {
+  @IsString()
+  @IsNotEmpty()
+  workspaceId: string;
+}

--- a/src/maestro/maestro.controller.ts
+++ b/src/maestro/maestro.controller.ts
@@ -20,9 +20,11 @@ import { BridgeService } from './bridge/services/bridge.service';
 import { TelegramLinkTokenDto } from './bridge/dto/bridge.dto';
 import {
   CreateMaestroConversationDto,
+  MaestroWorkspaceDto,
   PresignMaestroAttachmentDto,
   SendMaestroMessageDto,
   SetFeedbackDto,
+  SetMaestroKeyDto,
 } from './dto/send-message.dto';
 
 @Controller('maestro')
@@ -107,6 +109,48 @@ export class MaestroController {
     @Body() dto: PresignMaestroAttachmentDto,
   ) {
     return this.maestro.presignAttachment(user.userId, dto);
+  }
+
+  /**
+   * Maestro key + first-run wizard state (owner-only).
+   * Never returns the key itself — only a masked hint like "sk-ant-…4f2a".
+   */
+  @Get('key')
+  async getKeyStatus(
+    @CurrentUser() user: { userId: string; email: string },
+    @Query('workspaceId') workspaceId: string,
+  ) {
+    return this.maestro.getKeyStatus(user.userId, workspaceId);
+  }
+
+  /** Save the workspace's own Anthropic key (validated before storing). */
+  @Post('key')
+  @HttpCode(HttpStatus.OK)
+  async setKey(
+    @CurrentUser() user: { userId: string; email: string },
+    @Body() dto: SetMaestroKeyDto,
+  ) {
+    return this.maestro.setOwnKey(user.userId, dto.workspaceId, dto.apiKey);
+  }
+
+  /** Remove the workspace's own key — Maestro reverts to the platform key. */
+  @Post('key/remove')
+  @HttpCode(HttpStatus.OK)
+  async removeKey(
+    @CurrentUser() user: { userId: string; email: string },
+    @Body() dto: MaestroWorkspaceDto,
+  ) {
+    return this.maestro.removeOwnKey(user.userId, dto.workspaceId);
+  }
+
+  /** Mark the first-run Maestro wizard as completed. */
+  @Post('onboarding/complete')
+  @HttpCode(HttpStatus.OK)
+  async completeOnboarding(
+    @CurrentUser() user: { userId: string; email: string },
+    @Body() dto: MaestroWorkspaceDto,
+  ) {
+    return this.maestro.completeOnboarding(user.userId, dto.workspaceId);
   }
 
   /** Current AI-token budget for the workspace (powers the UI meter). */

--- a/src/maestro/maestro.module.ts
+++ b/src/maestro/maestro.module.ts
@@ -14,6 +14,7 @@ import { PostsModule } from '../posts/posts.module';
 import { InboxModule } from '../inbox/inbox.module';
 import { MaestroController } from './maestro.controller';
 import { MaestroService } from './services/maestro.service';
+import { MaestroKeyService } from './services/maestro-key.service';
 import { ClaudeAgentSdkRuntime } from './runtime/claude-agent-sdk.runtime';
 // Reuse the existing chatbot conversation persistence (same DB tables).
 // ConversationService + TokenTrackingService only depend on the global DRIZZLE provider.
@@ -58,6 +59,7 @@ import { MaestroBridgeProcessor } from './bridge/processors/maestro-bridge.proce
   controllers: [MaestroController],
   providers: [
     MaestroService,
+    MaestroKeyService,
     ClaudeAgentSdkRuntime,
     ConversationService,
     TokenTrackingService,

--- a/src/maestro/services/maestro-key.service.spec.ts
+++ b/src/maestro/services/maestro-key.service.spec.ts
@@ -1,0 +1,183 @@
+import { BadRequestException } from '@nestjs/common';
+import { MaestroKeyService } from './maestro-key.service';
+import { encrypt } from '../../common/utils/encryption.util';
+
+/** Minimal Drizzle stand-in: records writes, replays a canned row. */
+function makeDb(row: Record<string, unknown> | undefined) {
+  const sets: Record<string, unknown>[] = [];
+  return {
+    sets,
+    query: { workspace: { findFirst: jest.fn().mockResolvedValue(row) } },
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        sets.push(values);
+        return { where: () => Promise.resolve(undefined) };
+      },
+    }),
+  };
+}
+
+const VALID_KEY = 'sk-ant-api03-abcdefghijklmnop4f2a';
+
+describe('MaestroKeyService', () => {
+  const ORIGINAL_ENV = process.env;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    // 64 hex chars, required by encryption.util.
+    process.env.ENCRYPTION_KEY = 'a'.repeat(64);
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('getStatus', () => {
+    it('reports no key for a fresh workspace', async () => {
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      const status = await svc.getStatus('ws-1');
+
+      expect(status).toEqual({
+        hasOwnKey: false,
+        hint: null,
+        setAt: null,
+        onboarded: false,
+      });
+    });
+
+    it('returns a MASKED hint and never the key itself', async () => {
+      const setAt = new Date('2026-08-26T10:00:00.000Z');
+      const db = makeDb({
+        maestroAnthropicKey: encrypt(VALID_KEY),
+        maestroAnthropicKeyHint: '4f2a',
+        maestroAnthropicKeySetAt: setAt,
+        maestroOnboardedAt: setAt,
+      });
+      const svc = new MaestroKeyService(db as never);
+
+      const status = await svc.getStatus('ws-1');
+
+      expect(status.hasOwnKey).toBe(true);
+      expect(status.hint).toBe('sk-ant-…4f2a');
+      expect(status.onboarded).toBe(true);
+      // The real secret must not appear anywhere in the payload.
+      expect(JSON.stringify(status)).not.toContain(VALID_KEY);
+    });
+  });
+
+  describe('getDecryptedKey', () => {
+    it('round-trips the stored key', async () => {
+      const db = makeDb({ maestroAnthropicKey: encrypt(VALID_KEY) });
+      const svc = new MaestroKeyService(db as never);
+
+      await expect(svc.getDecryptedKey('ws-1')).resolves.toBe(VALID_KEY);
+    });
+
+    it('returns null when the workspace has no key', async () => {
+      const svc = new MaestroKeyService(makeDb({}) as never);
+
+      await expect(svc.getDecryptedKey('ws-1')).resolves.toBeNull();
+    });
+
+    it('returns null instead of throwing when the value cannot be decrypted', async () => {
+      // Simulates a rotated ENCRYPTION_KEY: chat must degrade, not crash.
+      const db = makeDb({ maestroAnthropicKey: 'aaa:bbb:ccc' });
+      const svc = new MaestroKeyService(db as never);
+
+      await expect(svc.getDecryptedKey('ws-1')).resolves.toBeNull();
+    });
+  });
+
+  describe('setKey', () => {
+    it('rejects a key that is not an Anthropic key without calling out', async () => {
+      const svc = new MaestroKeyService(makeDb({}) as never);
+
+      await expect(svc.setKey('ws-1', 'not-a-key')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a key Anthropic returns 401 for', async () => {
+      fetchSpy.mockResolvedValue({ ok: false, status: 401 } as Response);
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      await expect(svc.setKey('ws-1', VALID_KEY)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      // Nothing may be persisted when validation fails.
+      expect(db.sets).toHaveLength(0);
+    });
+
+    it('refuses to store a key it could not verify (network failure)', async () => {
+      fetchSpy.mockRejectedValue(new Error('ENOTFOUND'));
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      await expect(svc.setKey('ws-1', VALID_KEY)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(db.sets).toHaveLength(0);
+    });
+
+    it('stores the key ENCRYPTED, never in plaintext', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, status: 200 } as Response);
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      await svc.setKey('ws-1', VALID_KEY);
+
+      expect(db.sets).toHaveLength(1);
+      const written = db.sets[0].maestroAnthropicKey as string;
+      expect(written).not.toBe(VALID_KEY);
+      expect(written).toContain(':'); // iv:authTag:ciphertext
+      expect(db.sets[0].maestroAnthropicKeyHint).toBe('4f2a');
+    });
+
+    it('sends the key to Anthropic for validation, not to any other host', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, status: 200 } as Response);
+      const svc = new MaestroKeyService(makeDb({}) as never);
+
+      await svc.setKey('ws-1', VALID_KEY);
+
+      const [firstCall] = fetchSpy.mock.calls as unknown[][];
+      const url = String(firstCall[0]);
+      expect(new URL(url).host).toBe('api.anthropic.com');
+    });
+  });
+
+  describe('removeKey', () => {
+    it('clears the key and its hint', async () => {
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      await svc.removeKey('ws-1');
+
+      expect(db.sets[0]).toMatchObject({
+        maestroAnthropicKey: null,
+        maestroAnthropicKeyHint: null,
+        maestroAnthropicKeySetAt: null,
+      });
+    });
+  });
+
+  describe('markOnboarded', () => {
+    it('stamps the wizard as complete', async () => {
+      const db = makeDb({});
+      const svc = new MaestroKeyService(db as never);
+
+      await svc.markOnboarded('ws-1');
+
+      expect(db.sets[0].maestroOnboardedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/src/maestro/services/maestro-key.service.ts
+++ b/src/maestro/services/maestro-key.service.ts
@@ -1,0 +1,189 @@
+import {
+  Injectable,
+  Inject,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { DRIZZLE } from '../../drizzle/drizzle.module';
+import type { DbType } from '../../drizzle/db';
+import { workspace } from '../../drizzle/schema/workspace.schema';
+import { encrypt, decrypt } from '../../common/utils/encryption.util';
+
+/** What settings/the wizard may safely see about a stored key. */
+export interface MaestroKeyStatus {
+  /** True when the workspace has its own key (BYOK) configured. */
+  hasOwnKey: boolean;
+  /** Masked tail for display, e.g. "sk-ant-…4f2a". Null when no key is set. */
+  hint: string | null;
+  /** When the key was last saved. Null when no key is set. */
+  setAt: string | null;
+  /** True once the first-run Maestro wizard has been completed. */
+  onboarded: boolean;
+}
+
+/** Anthropic keys look like `sk-ant-…`; length varies, so keep the check loose. */
+const KEY_PREFIX = 'sk-ant-';
+const MIN_KEY_LENGTH = 20;
+
+/** Anthropic endpoint used to prove a key works before we store it. */
+const ANTHROPIC_MODELS_URL = 'https://api.anthropic.com/v1/models?limit=1';
+const ANTHROPIC_VERSION = '2023-06-01';
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+/**
+ * Stores and resolves a workspace's own Anthropic API key (BYOK).
+ *
+ * The key is encrypted at rest with the same AES-256-GCM helper that protects
+ * OAuth/channel tokens, and is NEVER returned to the client — callers get a
+ * masked `hint` instead. It is decrypted only at the moment a Maestro turn
+ * hands it to the Agent SDK.
+ *
+ * A key is validated against Anthropic BEFORE it is stored, so a typo fails at
+ * save time (where the user can fix it) rather than on their first chat turn.
+ */
+@Injectable()
+export class MaestroKeyService {
+  private readonly logger = new Logger(MaestroKeyService.name);
+
+  constructor(@Inject(DRIZZLE) private readonly db: DbType) {}
+
+  /** Non-sensitive key/onboarding state for settings + the first-run wizard. */
+  async getStatus(workspaceId: string): Promise<MaestroKeyStatus> {
+    const row = await this.db.query.workspace.findFirst({
+      where: eq(workspace.id, workspaceId),
+      columns: {
+        maestroAnthropicKey: true,
+        maestroAnthropicKeyHint: true,
+        maestroAnthropicKeySetAt: true,
+        maestroOnboardedAt: true,
+      },
+    });
+    const hint = row?.maestroAnthropicKeyHint ?? null;
+    return {
+      hasOwnKey: Boolean(row?.maestroAnthropicKey),
+      hint: hint ? `${KEY_PREFIX}…${hint}` : null,
+      setAt: row?.maestroAnthropicKeySetAt
+        ? row.maestroAnthropicKeySetAt.toISOString()
+        : null,
+      onboarded: Boolean(row?.maestroOnboardedAt),
+    };
+  }
+
+  /**
+   * The workspace's decrypted key, or null when it has none (→ platform key).
+   * Called on every Maestro turn, so a corrupt/undecryptable value must not
+   * break chat: we log and fall back to null rather than throwing.
+   */
+  async getDecryptedKey(workspaceId: string): Promise<string | null> {
+    const row = await this.db.query.workspace.findFirst({
+      where: eq(workspace.id, workspaceId),
+      columns: { maestroAnthropicKey: true },
+    });
+    if (!row?.maestroAnthropicKey) return null;
+    try {
+      return decrypt(row.maestroAnthropicKey) || null;
+    } catch (err) {
+      // Usually a rotated ENCRYPTION_KEY. Never log the ciphertext itself.
+      this.logger.error(
+        `Failed to decrypt Maestro key for workspace ${workspaceId}: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Validate a key against Anthropic, then store it encrypted.
+   * @throws BadRequestException when the key is malformed or rejected.
+   */
+  async setKey(workspaceId: string, rawKey: string): Promise<MaestroKeyStatus> {
+    const key = (rawKey ?? '').trim();
+    if (!key.startsWith(KEY_PREFIX) || key.length < MIN_KEY_LENGTH) {
+      throw new BadRequestException(
+        'That does not look like an Anthropic API key. It should start with "sk-ant-".',
+      );
+    }
+
+    await this.assertKeyWorks(key);
+
+    await this.db
+      .update(workspace)
+      .set({
+        maestroAnthropicKey: encrypt(key),
+        maestroAnthropicKeyHint: key.slice(-4),
+        maestroAnthropicKeySetAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(workspace.id, workspaceId));
+
+    this.logger.log(`Maestro BYOK key set for workspace ${workspaceId}`);
+    return this.getStatus(workspaceId);
+  }
+
+  /** Remove the workspace's key — Maestro reverts to the platform key. */
+  async removeKey(workspaceId: string): Promise<MaestroKeyStatus> {
+    await this.db
+      .update(workspace)
+      .set({
+        maestroAnthropicKey: null,
+        maestroAnthropicKeyHint: null,
+        maestroAnthropicKeySetAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(workspace.id, workspaceId));
+
+    this.logger.log(`Maestro BYOK key removed for workspace ${workspaceId}`);
+    return this.getStatus(workspaceId);
+  }
+
+  /** Mark the first-run wizard complete so it does not show again. */
+  async markOnboarded(workspaceId: string): Promise<MaestroKeyStatus> {
+    await this.db
+      .update(workspace)
+      .set({ maestroOnboardedAt: new Date(), updatedAt: new Date() })
+      .where(eq(workspace.id, workspaceId));
+    return this.getStatus(workspaceId);
+  }
+
+  /**
+   * Prove a key works by making one cheap authenticated call. Distinguishes a
+   * rejected key (401/403) from Anthropic being unreachable — we refuse to
+   * store a key we could not verify either way, so the user is never left
+   * believing a broken key is active.
+   */
+  private async assertKeyWorks(key: string): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(ANTHROPIC_MODELS_URL, {
+        method: 'GET',
+        headers: {
+          'x-api-key': key,
+          'anthropic-version': ANTHROPIC_VERSION,
+        },
+        signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+      });
+    } catch {
+      throw new BadRequestException(
+        "Couldn't reach Anthropic to verify that key. Please try again in a moment.",
+      );
+    }
+
+    if (res.ok) return;
+
+    if (res.status === 401 || res.status === 403) {
+      throw new BadRequestException(
+        'Anthropic rejected that API key. Check that you copied it correctly and that it is still active.',
+      );
+    }
+    if (res.status === 429) {
+      throw new BadRequestException(
+        'That key is currently rate-limited by Anthropic, so we could not verify it. Try again shortly.',
+      );
+    }
+    throw new BadRequestException(
+      `Anthropic could not verify that key (HTTP ${res.status}). Please try again.`,
+    );
+  }
+}

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -27,7 +27,10 @@ import { createSlackTools } from '../tools/slack.tools';
 import { createTelegramTools } from '../tools/telegram.tools';
 import { createWhatsAppTools } from '../tools/whatsapp.tools';
 import { createPostTools } from '../tools/post.tools';
-import { resolveAgentAuth } from '../auth/agent-auth';
+import {
+  resolveAgentAuth,
+  MaestroAuthUnavailableError,
+} from '../auth/agent-auth';
 import {
   STATIC_SYSTEM_PROMPT,
   CONFIRM_BEFORE_SEND_POLICY,
@@ -387,6 +390,27 @@ export class MaestroService {
       workspaceId: conversation.workspaceId,
     };
 
+    // Resolve the Anthropic credential BEFORE persisting anything. A
+    // misconfigured deployment (no ANTHROPIC_API_KEY) must surface as a clean
+    // error, not an uncaught throw mid-SSE that saves a user turn with no reply.
+    let auth: ReturnType<typeof resolveAgentAuth>;
+    try {
+      auth = resolveAgentAuth();
+    } catch (err) {
+      if (err instanceof MaestroAuthUnavailableError) {
+        this.logger.error(`Maestro auth unavailable: ${err.message}`);
+        yield {
+          event: 'error',
+          data: {
+            message:
+              "Maestro isn't configured on this server yet. Please contact support.",
+          },
+        };
+        return;
+      }
+      throw err;
+    }
+
     // Block the turn up front if the workspace has exhausted its AI-token budget.
     const preBudget = await this.tokens.checkBudget(ctx.workspaceId);
     if (preBudget.exceeded) {
@@ -467,7 +491,6 @@ export class MaestroService {
           })
         : null;
 
-    const auth = resolveAgentAuth();
     const abortController = new AbortController();
     signal.addEventListener('abort', () => abortController.abort());
 

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -18,6 +18,7 @@ import { InboxService } from '../../inbox/inbox.service';
 import { PostService } from '../../posts/services/post.service';
 import { CloudflareR2Service } from '../../media/cloudflare-r2.service';
 import { ClaudeAgentSdkRuntime } from '../runtime/claude-agent-sdk.runtime';
+import { MaestroKeyService } from './maestro-key.service';
 import { createUserTools } from '../tools/user.tools';
 import { createMediaTools } from '../tools/media.tools';
 import { createInteractionTools } from '../tools/interaction.tools';
@@ -148,6 +149,7 @@ export class MaestroService {
     private readonly posts: PostService,
     private readonly inbox: InboxService,
     private readonly r2: CloudflareR2Service,
+    private readonly keys: MaestroKeyService,
   ) {}
 
   /**
@@ -200,6 +202,34 @@ export class MaestroService {
       sizeBytes,
       filename,
     });
+  }
+
+  /**
+   * Maestro key + first-run state for a workspace. Owner-checked: the key is a
+   * billing credential, so only the workspace owner may see or change it.
+   * Returns only a MASKED hint — the key itself never leaves the server.
+   */
+  async getKeyStatus(userId: string, workspaceId: string) {
+    await this.workspaceService.findOne(workspaceId, userId);
+    return this.keys.getStatus(workspaceId);
+  }
+
+  /** Validate against Anthropic, then store the workspace's own key. */
+  async setOwnKey(userId: string, workspaceId: string, apiKey: string) {
+    await this.workspaceService.findOne(workspaceId, userId);
+    return this.keys.setKey(workspaceId, apiKey);
+  }
+
+  /** Drop the workspace's key — Maestro reverts to the platform key. */
+  async removeOwnKey(userId: string, workspaceId: string) {
+    await this.workspaceService.findOne(workspaceId, userId);
+    return this.keys.removeKey(workspaceId);
+  }
+
+  /** Mark the first-run Maestro wizard complete. */
+  async completeOnboarding(userId: string, workspaceId: string) {
+    await this.workspaceService.findOne(workspaceId, userId);
+    return this.keys.markOnboarded(workspaceId);
   }
 
   /** Record a 👍/👎 on an assistant message (owner-checked). */
@@ -393,9 +423,12 @@ export class MaestroService {
     // Resolve the Anthropic credential BEFORE persisting anything. A
     // misconfigured deployment (no ANTHROPIC_API_KEY) must surface as a clean
     // error, not an uncaught throw mid-SSE that saves a user turn with no reply.
+    // BYOK: when the workspace has its own Anthropic key, it pays Anthropic
+    // directly, so this turn runs on that key and is NOT billed plan credits.
+    const workspaceApiKey = await this.keys.getDecryptedKey(ctx.workspaceId);
     let auth: ReturnType<typeof resolveAgentAuth>;
     try {
-      auth = resolveAgentAuth();
+      auth = resolveAgentAuth({ workspaceApiKey });
     } catch (err) {
       if (err instanceof MaestroAuthUnavailableError) {
         this.logger.error(`Maestro auth unavailable: ${err.message}`);
@@ -411,9 +444,11 @@ export class MaestroService {
       throw err;
     }
 
-    // Block the turn up front if the workspace has exhausted its AI-token budget.
+    // Block the turn up front if the workspace has exhausted its AI-token
+    // budget. A BYOK workspace is exempt: plan credits are not what pays for
+    // its turns, so its own key must keep working past the plan allowance.
     const preBudget = await this.tokens.checkBudget(ctx.workspaceId);
-    if (preBudget.exceeded) {
+    if (preBudget.exceeded && auth.keySource !== 'byok') {
       yield {
         event: 'error',
         data: {
@@ -700,6 +735,9 @@ export class MaestroService {
         1,
         Math.ceil(totalTokens / AGENT_TOKENS_PER_USER_TOKEN),
       );
+      // BYOK turns are LOGGED but not charged — the workspace already paid
+      // Anthropic directly with its own key.
+      const isByok = auth.keySource === 'byok';
       await this.tokens.recordUsage(
         ctx.workspaceId,
         userId,
@@ -710,6 +748,7 @@ export class MaestroService {
           apiOutputTokens: usage.outputTokens,
           outputLength: displayText.length,
         },
+        { billable: !isByok },
       );
 
       if (followups.length > 0) {

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -19,7 +19,8 @@ import { UsersService } from 'src/users/users.service';
 import { SubscriptionService } from 'src/billing/services/subscription.service';
 
 type GetAllREsponse = {
-  data: Workspace[];
+  // Omits the Maestro BYOK credential — it must never reach a client.
+  data: Omit<Workspace, 'maestroAnthropicKey'>[];
   pagination: {
     page: number;
     limit: number;
@@ -135,6 +136,8 @@ export class WorkspaceService {
 
     const workspaces = await this.db.query.workspace.findMany({
       where: and(...conditions),
+      // Never ship the Maestro BYOK credential to a client. See findOne.
+      columns: { maestroAnthropicKey: false },
       limit: limit,
       offset: offset,
       orderBy: (workspace, { desc }) => [desc(workspace.createdAt)],
@@ -156,9 +159,13 @@ export class WorkspaceService {
     };
   }
 
-  async findAllByUser(userId: string): Promise<Workspace[]> {
+  async findAllByUser(
+    userId: string,
+  ): Promise<Omit<Workspace, 'maestroAnthropicKey'>[]> {
     const workspaces = await this.db.query.workspace.findMany({
       where: eq(workspace.ownerId, userId),
+      // Never ship the Maestro BYOK credential to a client. See findOne.
+      columns: { maestroAnthropicKey: false },
       orderBy: (workspace, { desc }) => [desc(workspace.createdAt)],
     });
 

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -169,13 +169,20 @@ export class WorkspaceService {
     identifier: string,
     userId: string,
     bySlug: boolean = false,
-  ): Promise<Workspace> {
+  ): Promise<Omit<Workspace, 'maestroAnthropicKey'>> {
     const condition = bySlug
       ? eq(workspace.slug, identifier)
       : eq(workspace.id, identifier);
 
     const result = await this.db.query.workspace.findFirst({
       where: and(condition, eq(workspace.ownerId, userId)),
+      columns: {
+        // Everything EXCEPT the Maestro BYOK credential. This row is returned
+        // straight to the client by GET /workspace/:id and /slug/:slug, so the
+        // encrypted key must never be part of it. Read it only through
+        // MaestroKeyService, which exposes a masked hint instead.
+        maestroAnthropicKey: false,
+      },
       with: {
         owner: {
           columns: {


### PR DESCRIPTION
Maestro could not run in production: auth defaulted to Claude subscription mode, which has no credential on a server. This makes API-key auth the default and adds BYOK so a workspace can run Maestro on its own Anthropic key.

## What changed

**Auth resolution** (`src/maestro/auth/agent-auth.ts`)
- Default flipped from `subscription` to `apiKey`. Subscription mode still works locally but is refused in production with a clear error rather than a confusing SDK failure.
- Resolution order: workspace BYOK key → platform `ANTHROPIC_API_KEY` → `MaestroAuthUnavailableError`.

**BYOK** (`src/maestro/services/maestro-key.service.ts`)
- Per-workspace Anthropic key, encrypted at rest (AES-256-GCM).
- Validated against Anthropic *before* being stored, so an invalid key fails at save time, not mid-conversation.
- The raw key is never returned — status exposes only a hint (`sk-ant-…4f2a`) and a set-at timestamp.

**Billing**
- BYOK turns run on the workspace's own key, so usage is logged but not billed. The budget check is skipped for them too.

## Security

The encrypted key lives on the workspace row, so every endpoint returning a workspace had to be checked. `tsc` caught the first leak (`PublicWorkspace` via `/auth/me`); live testing caught a second in the LIST endpoints (`findAllPaginated` / `findAllByUser`), fixed in 6f84804. All four paths now project the column out.

## Deploy prerequisites

1. Set `ANTHROPIC_API_KEY` on Railway. Leave `MAESTRO_AUTH_MODE` unset.
2. Apply `drizzle/migrations/0028_maestro_byok.sql` (idempotent `ADD COLUMN IF NOT EXISTS` × 4).

Without step 1 Maestro returns a clean "not configured" error rather than failing mid-stream.

## Testing

Live-tested end-to-end with real JWTs: encryption at rest verified in the DB, a deliberately invalid key rejected by Anthropic at save time, owner-only access enforced, and no key present in any of the four workspace-returning endpoints. `npm run build` green.

Frontend counterpart: asad00712/schedura-frontend#78

🤖 Generated with [Claude Code](https://claude.com/claude-code)