### PR TITLE
feat(whatsapp): mirror WhatsApp message templates + send from inbox

### DIFF
--- a/docs/superpowers/specs/2026-08-26-whatsapp-templates-design.md
+++ b/docs/superpowers/specs/2026-08-26-whatsapp-templates-design.md
@@ -1,0 +1,258 @@
+# WhatsApp Message Templates — Design
+
+**Date:** 2026-08-26
+**Branch:** `feat/whatsapp-templates` (both repos)
+**Status:** Approved, ready for planning
+
+## Problem
+
+Two problems, one solution.
+
+**1. The inbox has a dead end.** `whatsapp-dm.adapter.ts:147` tells the user:
+
+> "The 24-hour reply window has closed. A pre-approved template is required (coming soon)."
+
+WhatsApp only allows free-form replies within 24 hours of the customer's last
+message. After that, the only way to reach the customer is an approved template.
+Today Schedura has no template surface, so the conversation simply stops. The
+copy promises a feature that does not exist.
+
+**2. The Library has no WhatsApp templates.** Users manage post templates in the
+Library but must leave Schedura and use WhatsApp Manager to manage WhatsApp
+templates.
+
+## What makes this non-trivial
+
+WhatsApp templates are not our data. They live on the customer's WhatsApp
+Business Account (WABA) at Meta. We mirror them; we do not own them. Every
+design decision below follows from that.
+
+- Creation is **asynchronous**. Meta reviews each template — the docs say up to
+  24 hours. A template is unusable until `APPROVED`.
+- Deletion is **permanent**. There is no recycle bin at Meta.
+- **Meta can override the category.** If you submit `UTILITY` and Meta decides
+  it is `MARKETING`, it is approved as `MARKETING`. Category drives pricing, so
+  we must display Meta's category, never the user's requested one.
+
+## Permission status (verified 2026-08-26)
+
+`whatsapp_business_management` gates both reading and writing templates.
+
+| App | Status |
+|---|---|
+| `1498206521956735` | **live, Advanced Access, approved** |
+| `1645427979885306` (Threads) | not present |
+
+`channels.schema.ts:819` already requests both `whatsapp_business_messaging`
+and `whatsapp_business_management`. The user has reconnected channels and
+confirmed messaging works, so tokens carry the scope.
+
+**No App Review blocker.** This differs from other WhatsApp work that is
+waiting on review.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Data model | Separate `whatsapp_message_templates` table | Shape shares nothing with `media_templates` beyond the word "template" |
+| Library placement | Same grid, two card variants | User gets one place; actions stay honest per variant |
+| Status freshness | Webhook **and** fetch-on-load | Webhook for real-time; fetch as backstop for missed webhooks |
+| Delete | Confirm dialog + hard delete | Meta has no recycle bin — the UI must not imply one |
+| Phasing | Phase 1 sync, Phase 2 builder | Unblocks the inbox first; teaches us Meta's real payloads before we build a creator |
+
+### Why not extend `media_templates`
+
+They overlap in name only:
+
+| | `media_templates` | WhatsApp template |
+|---|---|---|
+| Lives | our DB | customer's WABA at Meta |
+| Type | `post/story/reel/carousel` | `MARKETING/UTILITY/AUTHENTICATION` |
+| Body | `text + mediaSlots + hashtags` | `components[]` — HEADER/BODY/FOOTER/BUTTONS |
+| Variables | `{{placeholder}}` free-form | `{{1}}`, `{{2}}` positional, strict rules |
+| Edit | anytime | re-enters review |
+| Delete | soft, recycle bin | permanent at Meta |
+| On create | ready | `PENDING` |
+
+Merging them would put `if (platform === 'whatsapp')` into the schema, builder,
+picker, and composer. `media_templates` is not modified by this work — not one
+column.
+
+### Why the grid is shared but the card is not
+
+`TemplateCardGrid` exposes five actions. Four are wrong for WhatsApp:
+
+| Action | On a WhatsApp template |
+|---|---|
+| `onToggleStar` | needs our own column (Meta has no star) |
+| `onDelete` | soft-delete promise is false — Meta deletes permanently |
+| `onDuplicate` | the copy re-enters review; not an instant clone |
+| `onUseInPost` | templates go to the **inbox**, not the composer |
+
+Keeping one grid with shared actions would either break the recycle-bin promise
+or ship buttons that lie. Splitting at the **card** keeps both call sites
+(`starred-view.tsx:358`, `type-view.tsx:622`) unchanged while each variant keeps
+honest actions.
+
+## Architecture
+
+### Data model (backend)
+
+New table `whatsapp_message_templates`:
+
+```
+id                uuid pk
+workspaceId       uuid → workspace (cascade)
+channelId         uuid → channels (cascade)
+wabaId            varchar          -- denormalized; sync key
+metaTemplateId    varchar          -- Meta's id; upsert key
+name              varchar
+language          varchar          -- (name, language) is Meta's unique pair
+category           varchar          -- Meta's RETURNED category, not requested
+status            varchar          -- 14 values, see below
+rejectionReason   varchar null     -- when REJECTED
+components        jsonb            -- HEADER/BODY/FOOTER/BUTTONS
+lastSyncedAt      timestamptz
+createdAt / updatedAt
+```
+
+- **No soft delete.** Deletion is permanent at Meta; a recycle bin would be a
+  lie. Rows disappear when they disappear from Meta.
+- Unique index on `(channelId, name, language)`; index on `metaTemplateId`.
+
+### Status values
+
+Meta's `event` has 14 values, not 3:
+
+`APPROVED, PENDING, REJECTED, PAUSED, DISABLED, FLAGGED, ARCHIVED,
+UNARCHIVED, DELETED, IN_APPEAL, LIMIT_EXCEEDED, LOCKED, REINSTATED,
+PENDING_DELETION`
+
+`reason`: `ABUSIVE_CONTENT, CATEGORY_NOT_AVAILABLE, INCORRECT_CATEGORY,
+INVALID_FORMAT, NONE, PROMOTIONAL, SCAM, TAG_CONTENT_MISMATCH`, or null.
+
+Stored verbatim. The UI groups them into four tones (below). An unrecognized
+value must render as neutral, never blank — Meta may add values.
+
+Only `APPROVED` is sendable.
+
+### Sync
+
+`GET /<wabaId>/message_templates` using the channel's token.
+
+- Upsert on `metaTemplateId`
+- Delete local rows absent from Meta's response
+- Triggered on: Library templates page load, and channel connect
+
+**Fan-out:** one WABA can be connected to two workspaces. We have shipped this
+bug before (`findChannelsByPlatformAccount`). Sync and webhook handling resolve
+**all** matching channels from the start.
+
+### Webhook
+
+`parseWhatsAppMessages` hard-filters `change.field !== 'messages'`, so template
+events are **dropped today**. The route exists; the event does not flow.
+
+Add a **separate** `parseWhatsAppTemplateEvents()` in
+`whatsapp-webhook.util.ts` and route to it from `webhooks.controller.ts`.
+`parseWhatsAppMessages` is untouched — inbox ingest and the Maestro bridge both
+depend on it.
+
+Payload:
+
+```json
+{
+  "object": "whatsapp_business_account",
+  "entry": [{ "id": "<WABA_ID>", "changes": [{
+    "field": "message_template_status_update",
+    "value": {
+      "event": "APPROVED",
+      "message_template_id": 1689556908129832,
+      "message_template_name": "order_confirmation",
+      "message_template_language": "en-US",
+      "reason": "NONE",
+      "message_template_category": "UTILITY"
+    }
+  }]}]
+}
+```
+
+A webhook for an unknown `message_template_id` is ignored, not an error — it
+may belong to a WABA we do not track.
+
+### Sending
+
+`whatsapp.service.ts` has `sendText` and `sendMedia`; add `sendTemplate` on the
+same seam. `whatsapp-dm.adapter.ts` gains a template send path.
+
+### Frontend
+
+- `WhatsAppTemplate` type in `media-library/types/`
+- `TemplateCardGrid` takes a discriminated union; renders `TemplateCard` or
+  `WhatsAppTemplateCard`
+- WhatsApp card actions: **View**, **Delete** (confirm + hard), **Send in inbox**
+- Status badge tones:
+  - green — `APPROVED`, `REINSTATED`
+  - amber — `PENDING`, `IN_APPEAL`, `PENDING_DELETION`
+  - red — `REJECTED`, `DISABLED`, `PAUSED`, `FLAGGED`, `LIMIT_EXCEEDED`, `LOCKED`
+  - muted — `ARCHIVED`, `UNARCHIVED`, `DELETED`, anything unrecognized
+- Rejected cards surface `rejectionReason` in human words
+- **Inbox**: when the 24-hour window is closed, replace the "coming soon" copy
+  with a picker of `APPROVED` templates
+
+## Scope
+
+### Phase 1 (this effort)
+
+- Table + migration
+- Sync service (list, upsert, prune) with fan-out
+- Webhook parser + routing + status updates
+- Read endpoints
+- Library grid: WhatsApp cards, status badges
+- Delete (confirm + hard)
+- Inbox: approved-template picker replacing the dead end
+
+### Phase 2 (not now)
+
+- Template builder (create/edit) with components and variables
+- Category selection, variable samples, button config
+
+### Explicitly out
+
+- Template analytics / quality rating
+- Media-header uploads for template creation
+- Marketing Messages API
+- Bulk template campaigns
+
+## Testing
+
+Pure functions, unit-testable without network or DOM:
+
+- **Sync reconciliation** — upsert existing, insert new, prune missing; and the
+  fan-out case (one WABA, two workspaces)
+- **Webhook parser** — all 14 events; malformed payloads; the `field` filter
+  keeps `messages` events flowing to the existing parser untouched
+- **Status→tone mapping** — every known status, plus an unknown value rendering
+  neutral rather than blank
+- **Sendability** — only `APPROVED` is offered in the inbox picker
+
+Regression guard: an existing `parseWhatsAppMessages` test must still pass
+unchanged, proving inbox ingest was not disturbed.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Webhook missed | fetch-on-load reconciles |
+| Meta adds a status value | unknown → neutral badge, never blank |
+| Meta overrides category | store and display Meta's returned category |
+| Same WABA in two workspaces | fan-out from the start |
+| Touching the shared webhook parser | new function; existing one untouched + regression test |
+| Sync on every page load is chatty | `lastSyncedAt` throttle |
+
+## References
+
+- [Templates overview](https://developers.facebook.com/documentation/business-messaging/whatsapp/templates/overview)
+- [message_template_status_update](https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/message_template_status_update)
+- [Template categorization](https://developers.facebook.com/documentation/business-messaging/whatsapp/templates/template-categorization)
+- [Graph API: WABA message_templates](https://developers.facebook.com/docs/graph-api/reference/whats-app-business-account/message_templates/)

--- a/drizzle/migrations/0027_whatsapp_templates.sql
+++ b/drizzle/migrations/0027_whatsapp_templates.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS "whatsapp_message_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "channel_id" bigint NOT NULL,
+  "waba_id" varchar(64) NOT NULL,
+  "meta_template_id" varchar(64) NOT NULL,
+  "name" varchar(512) NOT NULL,
+  "language" varchar(32) NOT NULL,
+  "category" varchar(32) NOT NULL,
+  "status" varchar(32) NOT NULL,
+  "rejection_reason" varchar(64),
+  "components" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "last_synced_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "whatsapp_message_templates_workspace_id_fk"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspace"("id") ON DELETE CASCADE,
+  CONSTRAINT "whatsapp_message_templates_channel_id_fk"
+    FOREIGN KEY ("channel_id") REFERENCES "social_media_channels"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "whatsapp_templates_channel_name_lang_uq"
+  ON "whatsapp_message_templates" ("channel_id","name","language");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_meta_id_idx"
+  ON "whatsapp_message_templates" ("meta_template_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_waba_id_idx"
+  ON "whatsapp_message_templates" ("waba_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_workspace_id_idx"
+  ON "whatsapp_message_templates" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "whatsapp_templates_channel_id_idx"
+  ON "whatsapp_message_templates" ("channel_id");

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { AdsModule } from './ads/ads.module';
 import { MediaSourcesModule } from './media-sources/media-sources.module';
 import { CalendarSyncModule } from './calendar-sync/calendar-sync.module';
 import { CampaignsModule } from './campaigns/campaigns.module';
+import { WhatsAppTemplatesModule } from './whatsapp-templates/whatsapp-templates.module';
 import { BullBoardModule } from '@bull-board/nestjs';
 import { ExpressAdapter } from '@bull-board/express';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
@@ -89,6 +90,7 @@ import { QUEUES } from './queue/queue.module';
     MediaSourcesModule,
     CalendarSyncModule,
     CampaignsModule,
+    WhatsAppTemplatesModule,
     BullBoardModule.forRoot({
       // Moved off '/admin/queues' so it stops swallowing the admin queue API,
       // which lives under that same prefix. Bull Board keeps its full job

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -142,6 +142,7 @@ import { YoutubeAuthorizationCheckScheduler } from './schedulers/youtube-authori
     RedditService,
     SlackService,
     TelegramService,
+    WhatsAppService,
     DiscordService,
     MetaAdsClient,
     AdAccountsService,

--- a/src/channels/services/whatsapp-template.util.spec.ts
+++ b/src/channels/services/whatsapp-template.util.spec.ts
@@ -1,0 +1,168 @@
+import {
+  parseWhatsAppTemplateEvents,
+  mapMetaTemplateRow,
+} from './whatsapp-template.util';
+import { parseWhatsAppMessages } from './whatsapp-webhook.util';
+
+const statusPayload = (event: string, reason: string | null = 'NONE') => ({
+  object: 'whatsapp_business_account',
+  entry: [
+    {
+      id: '102290129340398',
+      time: 1751247548,
+      changes: [
+        {
+          field: 'message_template_status_update',
+          value: {
+            event,
+            message_template_id: 1689556908129832,
+            message_template_name: 'order_confirmation',
+            message_template_language: 'en-US',
+            reason,
+            message_template_category: 'UTILITY',
+          },
+        },
+      ],
+    },
+  ],
+});
+
+describe('parseWhatsAppTemplateEvents', () => {
+  it('parses an APPROVED event', () => {
+    const [ev] = parseWhatsAppTemplateEvents(statusPayload('APPROVED'));
+    expect(ev).toEqual({
+      wabaId: '102290129340398',
+      metaTemplateId: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en-US',
+      status: 'APPROVED',
+      category: 'UTILITY',
+      reason: 'NONE',
+    });
+  });
+
+  it.each([
+    'APPROVED',
+    'PENDING',
+    'REJECTED',
+    'PAUSED',
+    'DISABLED',
+    'FLAGGED',
+    'ARCHIVED',
+    'UNARCHIVED',
+    'DELETED',
+    'IN_APPEAL',
+    'LIMIT_EXCEEDED',
+    'LOCKED',
+    'REINSTATED',
+    'PENDING_DELETION',
+  ])('parses the %s event', (event) => {
+    const [ev] = parseWhatsAppTemplateEvents(statusPayload(event));
+    expect(ev.status).toBe(event);
+  });
+
+  it('carries the rejection reason through', () => {
+    const [ev] = parseWhatsAppTemplateEvents(
+      statusPayload('REJECTED', 'INCORRECT_CATEGORY'),
+    );
+    expect(ev.reason).toBe('INCORRECT_CATEGORY');
+  });
+
+  it('tolerates a null reason', () => {
+    const [ev] = parseWhatsAppTemplateEvents(
+      statusPayload('PENDING_DELETION', null),
+    );
+    expect(ev.reason).toBeNull();
+  });
+
+  it('ignores message events', () => {
+    const messagePayload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: 'WABA_ID',
+          changes: [
+            { field: 'messages', value: { messages: [{ id: 'wamid.X' }] } },
+          ],
+        },
+      ],
+    };
+    expect(parseWhatsAppTemplateEvents(messagePayload)).toEqual([]);
+  });
+
+  it.each([
+    [null],
+    [undefined],
+    [{}],
+    [{ object: 'page' }],
+    [{ object: 'whatsapp_business_account' }],
+    [{ object: 'whatsapp_business_account', entry: [{}] }],
+    [{ object: 'whatsapp_business_account', entry: [{ changes: [{}] }] }],
+  ])('returns [] for malformed payload %#', (payload) => {
+    expect(parseWhatsAppTemplateEvents(payload as any)).toEqual([]);
+  });
+
+  it('leaves parseWhatsAppMessages untouched for message payloads', () => {
+    // Regression guard: the two parsers must not interfere. Inbox ingest and
+    // the Maestro bridge both depend on parseWhatsAppMessages.
+    const messagePayload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: 'WABA_ID',
+          changes: [
+            {
+              field: 'messages',
+              value: {
+                metadata: { phone_number_id: '1010' },
+                messages: [
+                  {
+                    from: '15551234567',
+                    id: 'wamid.HBgL',
+                    timestamp: '1719400000',
+                    type: 'text',
+                    text: { body: 'Hi' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(parseWhatsAppMessages(messagePayload)).toHaveLength(1);
+    expect(parseWhatsAppTemplateEvents(messagePayload)).toEqual([]);
+  });
+});
+
+describe('mapMetaTemplateRow', () => {
+  it('maps a Meta list row', () => {
+    const row = {
+      id: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en_US',
+      category: 'UTILITY',
+      status: 'APPROVED',
+      components: [{ type: 'BODY', text: 'Your order {{1}} shipped.' }],
+    };
+    expect(mapMetaTemplateRow(row)).toEqual({
+      metaTemplateId: '1689556908129832',
+      name: 'order_confirmation',
+      language: 'en_US',
+      category: 'UTILITY',
+      status: 'APPROVED',
+      components: [{ type: 'BODY', text: 'Your order {{1}} shipped.' }],
+    });
+  });
+
+  it('defaults components to [] when Meta omits them', () => {
+    const row = {
+      id: '1',
+      name: 'n',
+      language: 'en',
+      category: 'MARKETING',
+      status: 'PENDING',
+    };
+    expect(mapMetaTemplateRow(row).components).toEqual([]);
+  });
+});

--- a/src/channels/services/whatsapp-template.util.ts
+++ b/src/channels/services/whatsapp-template.util.ts
@@ -1,0 +1,67 @@
+import type { WhatsAppTemplateComponent } from '../../drizzle/schema/whatsapp-templates.schema';
+
+export interface ParsedTemplateEvent {
+  wabaId: string;
+  metaTemplateId: string;
+  name: string;
+  language: string;
+  status: string;
+  category?: string;
+  reason?: string | null;
+}
+
+/**
+ * Flatten `message_template_status_update` webhooks into status rows.
+ *
+ * Deliberately separate from `parseWhatsAppMessages`: that parser feeds inbox
+ * ingest and the Maestro bridge, and both filter on `field === 'messages'`.
+ * Widening it would put template payloads through message code paths.
+ */
+export function parseWhatsAppTemplateEvents(
+  payload: any,
+): ParsedTemplateEvent[] {
+  const out: ParsedTemplateEvent[] = [];
+  if (payload?.object !== 'whatsapp_business_account') return out;
+  for (const entry of payload?.entry ?? []) {
+    const wabaId = entry?.id;
+    if (!wabaId) continue;
+    for (const change of entry?.changes ?? []) {
+      if (change?.field !== 'message_template_status_update') continue;
+      const v = change.value ?? {};
+      if (!v?.message_template_id || !v?.event) continue;
+      out.push({
+        wabaId: String(wabaId),
+        metaTemplateId: String(v.message_template_id),
+        name: String(v.message_template_name ?? ''),
+        language: String(v.message_template_language ?? ''),
+        status: String(v.event),
+        category: v.message_template_category
+          ? String(v.message_template_category)
+          : undefined,
+        reason: v.reason === undefined ? undefined : v.reason,
+      });
+    }
+  }
+  return out;
+}
+
+export interface MappedMetaTemplate {
+  metaTemplateId: string;
+  name: string;
+  language: string;
+  category: string;
+  status: string;
+  components: WhatsAppTemplateComponent[];
+}
+
+/** Normalize one row of `GET /<waba>/message_templates` into our column shape. */
+export function mapMetaTemplateRow(row: any): MappedMetaTemplate {
+  return {
+    metaTemplateId: String(row?.id ?? ''),
+    name: String(row?.name ?? ''),
+    language: String(row?.language ?? ''),
+    category: String(row?.category ?? ''),
+    status: String(row?.status ?? ''),
+    components: Array.isArray(row?.components) ? row.components : [],
+  };
+}

--- a/src/channels/services/whatsapp.service.spec.ts
+++ b/src/channels/services/whatsapp.service.spec.ts
@@ -1,4 +1,8 @@
-import { WhatsAppService, GRAPH_API_VERSION } from './whatsapp.service';
+import {
+  WhatsAppService,
+  GRAPH_API_VERSION,
+  MAX_TEMPLATE_PAGES,
+} from './whatsapp.service';
 
 describe('WhatsAppService.sendText', () => {
   const svc = new WhatsAppService();
@@ -240,5 +244,86 @@ describe('WhatsAppService — Embedded Signup Graph methods', () => {
       { id: '111', displayPhoneNumber: '+1 555', verifiedName: 'Acme' },
       { id: '222', displayPhoneNumber: null, verifiedName: null },
     ]);
+  });
+});
+
+describe('WhatsAppService.listMessageTemplates', () => {
+  const svc = new WhatsAppService();
+
+  beforeEach(() => {
+    // Assign a fresh mock rather than jest.spyOn: an earlier describe block
+    // in this file (`Embedded Signup Graph methods`) reassigns `global.fetch`
+    // directly and only `jest.resetAllMocks()`s it in its own afterEach —
+    // it never restores the original fetch — so spying on top of whatever
+    // `global.fetch` currently is would spy on someone else's leftover mock.
+    global.fetch = jest.fn();
+  });
+  afterEach(() => jest.resetAllMocks());
+
+  it('returns all rows from a single page with no paging.next', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 't1', name: 'welcome', language: 'en', category: 'MARKETING', status: 'APPROVED' },
+          { id: 't2', name: 'otp', language: 'en', category: 'AUTHENTICATION', status: 'APPROVED' },
+        ],
+        paging: {},
+      }),
+    });
+
+    const res = await svc.listMessageTemplates('tok', 'waba1');
+
+    expect(res).toEqual([
+      { id: 't1', name: 'welcome', language: 'en', category: 'MARKETING', status: 'APPROVED' },
+      { id: 't2', name: 'otp', language: 'en', category: 'AUTHENTICATION', status: 'APPROVED' },
+    ]);
+  });
+
+  it('follows paging.next across two pages and returns rows from both', async () => {
+    const fetchMock = (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 't1', name: 'welcome', language: 'en', category: 'MARKETING', status: 'APPROVED' }],
+          paging: { next: 'https://graph.facebook.com/v21.0/waba1/message_templates?after=abc' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 't2', name: 'otp', language: 'en', category: 'AUTHENTICATION', status: 'APPROVED' }],
+          paging: {},
+        }),
+      });
+
+    const res = await svc.listMessageTemplates('tok', 'waba1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res).toEqual([
+      { id: 't1', name: 'welcome', language: 'en', category: 'MARKETING', status: 'APPROVED' },
+      { id: 't2', name: 'otp', language: 'en', category: 'AUTHENTICATION', status: 'APPROVED' },
+    ]);
+  });
+
+  it('throws instead of returning a truncated list when the page cap is hit with more pages remaining', async () => {
+    // Every page reports a paging.next cursor, so the cap is always the reason the loop stops.
+    const fetchMock = (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'tX', name: 'x', language: 'en', category: 'MARKETING', status: 'APPROVED' }],
+        paging: { next: 'https://graph.facebook.com/v21.0/waba1/message_templates?after=next' },
+      }),
+    });
+
+    await expect(svc.listMessageTemplates('tok', 'waba1')).rejects.toThrow(
+      /waba1/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_TEMPLATE_PAGES);
+
+    fetchMock.mockClear();
+    await expect(svc.listMessageTemplates('tok', 'waba1')).rejects.toThrow(
+      new RegExp(String(MAX_TEMPLATE_PAGES)),
+    );
   });
 });

--- a/src/channels/services/whatsapp.service.ts
+++ b/src/channels/services/whatsapp.service.ts
@@ -7,6 +7,14 @@ export const WHATSAPP_GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSI
 export const WA_ERROR_PIN_MISMATCH = 133005;
 
 /**
+ * Cap on `listMessageTemplates` pages (at `limit=100` each). Guards against a
+ * malformed `paging.next` cursor spinning forever. If a WABA genuinely has
+ * more templates than this covers, `listMessageTemplates` throws rather than
+ * silently returning a truncated (and therefore misleading) list.
+ */
+export const MAX_TEMPLATE_PAGES = 20;
+
+/**
  * A Graph error that carries Meta's numeric code. Callers branch on `code` rather
  * than pattern-matching `message`, which is prose Meta is free to reword or
  * localise.
@@ -302,8 +310,10 @@ export class WhatsAppService {
     let url =
       `${WHATSAPP_GRAPH_BASE}/${wabaId}/message_templates` +
       `?limit=100&fields=id,name,language,category,status,components`;
-    // Bounded so a malformed paging cursor cannot spin forever.
-    for (let page = 0; page < 20 && url; page++) {
+    // Bounded so a malformed paging cursor cannot spin forever. At limit=100
+    // this covers up to MAX_TEMPLATE_PAGES * 100 templates in one sync.
+    let page = 0;
+    for (; page < MAX_TEMPLATE_PAGES && url; page++) {
       const res = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
@@ -316,6 +326,20 @@ export class WhatsAppService {
       }
       out.push(...(data?.data ?? []));
       url = data?.paging?.next ?? '';
+    }
+    // If we stopped only because we hit the page cap and Meta still has more
+    // pages, `out` is a truncated list that is indistinguishable from a
+    // complete one to the caller. Reconciliation treats "absent from the
+    // fetched list" as "deleted at Meta" — silently returning a partial list
+    // here would prune every template past the cap on the next sync. Throw
+    // instead so the caller's per-channel error handling skips this sync and
+    // leaves the mirror untouched; a stale mirror beats a destroyed one.
+    if (page >= MAX_TEMPLATE_PAGES && url) {
+      throw new Error(
+        `WhatsApp template list for WABA ${wabaId} exceeded ${MAX_TEMPLATE_PAGES} pages ` +
+          `(more than ${MAX_TEMPLATE_PAGES * 100} templates) with more pages remaining; ` +
+          `aborting to avoid treating a truncated list as complete`,
+      );
     }
     return out;
   }

--- a/src/channels/services/whatsapp.service.ts
+++ b/src/channels/services/whatsapp.service.ts
@@ -289,4 +289,100 @@ export class WhatsAppService {
     }
     return { messageId: data?.messages?.[0]?.id ?? '' };
   }
+
+  /**
+   * List every template on a WABA. Meta paginates; follow `paging.next` so a
+   * business with more than one page does not silently lose the tail.
+   */
+  async listMessageTemplates(
+    accessToken: string,
+    wabaId: string,
+  ): Promise<any[]> {
+    const out: any[] = [];
+    let url =
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/message_templates` +
+      `?limit=100&fields=id,name,language,category,status,components`;
+    // Bounded so a malformed paging cursor cannot spin forever.
+    for (let page = 0; page < 20 && url; page++) {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg =
+          data?.error?.message ||
+          `WhatsApp template list failed (${res.status})`;
+        throw new Error(msg);
+      }
+      out.push(...(data?.data ?? []));
+      url = data?.paging?.next ?? '';
+    }
+    return out;
+  }
+
+  /**
+   * Delete a template at Meta. Permanent — there is no recycle bin. Deleting
+   * by name removes every language variant, so pass `hsm_id` to scope the
+   * delete to the one row the user actually chose.
+   */
+  async deleteMessageTemplate(
+    accessToken: string,
+    wabaId: string,
+    name: string,
+    metaTemplateId: string,
+  ): Promise<void> {
+    const url =
+      `${WHATSAPP_GRAPH_BASE}/${wabaId}/message_templates` +
+      `?name=${encodeURIComponent(name)}` +
+      `&hsm_id=${encodeURIComponent(metaTemplateId)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg =
+        data?.error?.message || `WhatsApp template delete failed (${res.status})`;
+      throw new Error(msg);
+    }
+  }
+
+  /**
+   * Send an approved template. Unlike `sendText`, this is valid *outside* the
+   * 24-hour customer window — that is the whole point of templates.
+   */
+  async sendTemplate(
+    accessToken: string,
+    phoneNumberId: string,
+    toWaId: string,
+    name: string,
+    language: string,
+    components?: Array<Record<string, any>>,
+  ): Promise<{ messageId: string }> {
+    const res = await fetch(`${WHATSAPP_GRAPH_BASE}/${phoneNumberId}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        to: toWaId,
+        type: 'template',
+        template: {
+          name,
+          language: { code: language },
+          ...(components?.length ? { components } : {}),
+        },
+      }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg =
+        data?.error?.message || `WhatsApp template send failed (${res.status})`;
+      throw new Error(msg);
+    }
+    return { messageId: data?.messages?.[0]?.id ?? '' };
+  }
 }

--- a/src/channels/webhooks.controller.ts
+++ b/src/channels/webhooks.controller.ts
@@ -7,11 +7,13 @@ import {
   HttpCode,
   HttpStatus,
   HttpException,
+  Inject,
   Logger,
   Param,
   Req,
   Res,
   Headers,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
@@ -23,7 +25,9 @@ import {
 import { verifyTelegramWebhookSecret } from './utils/telegram-webhook-secret.util';
 import { secureCompare } from '../common/utils/encryption.util';
 import { parseWhatsAppMessages } from './services/whatsapp-webhook.util';
+import { parseWhatsAppTemplateEvents } from './services/whatsapp-template.util';
 import { InboxService } from '../inbox/inbox.service';
+import { WhatsAppTemplatesService } from '../whatsapp-templates/whatsapp-templates.service';
 import { FacebookService } from './services/facebook.service';
 import { InstagramService } from './services/instagram.service';
 import { ChannelService } from './services/channel.service';
@@ -65,6 +69,10 @@ export class WebhooksController {
     private readonly whatsappIngestQueue: Queue,
     @InjectQueue(QUEUES.MAESTRO_BRIDGE)
     private readonly maestroBridgeQueue: Queue,
+    // WhatsAppTemplatesModule -> ChannelsModule -> (forwardRef) InboxModule,
+    // and this controller lives in InboxModule -> forwardRef on both sides.
+    @Inject(forwardRef(() => WhatsAppTemplatesService))
+    private readonly whatsappTemplates: WhatsAppTemplatesService,
   ) {}
 
   // ==========================================================================
@@ -193,6 +201,19 @@ export class WebhooksController {
     // ACK fast, then process async.
     res.status(200).send('EVENT_RECEIVED');
     try {
+      // Template status updates carry no `messages`, so they would fall
+      // through to inbox ingest and vanish. Handle them first and return.
+      const templateEvents = parseWhatsAppTemplateEvents(req.body);
+      if (templateEvents.length > 0) {
+        try {
+          await this.whatsappTemplates.applyStatusEvents(templateEvents);
+        } catch (err) {
+          this.logger.error(
+            `WhatsApp template status update failed: ${(err as Error).message}`,
+          );
+        }
+        return;
+      }
       // One Meta app = one webhook URL. If this payload is for the dedicated
       // Maestro number, divert it to the bridge instead of the inbox ingest so a
       // single callback URL can serve both.

--- a/src/drizzle/schema/index.ts
+++ b/src/drizzle/schema/index.ts
@@ -29,3 +29,4 @@ export * from './admin-login-challenge.schema';
 export * from './campaigns.schema';
 export * from './evergreen.schema';
 export * from './admin-audit-logs.schema';
+export * from './whatsapp-templates.schema';

--- a/src/drizzle/schema/whatsapp-templates.schema.ts
+++ b/src/drizzle/schema/whatsapp-templates.schema.ts
@@ -1,0 +1,147 @@
+import {
+  bigint,
+  index,
+  jsonb,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { workspace } from './workspace.schema';
+import { socialMediaChannels } from './channels.schema';
+
+/** Meta's full status set. Stored verbatim — the UI groups these into tones.
+ *  Meta may add values, so consumers must tolerate an unrecognized string. */
+export const WHATSAPP_TEMPLATE_STATUS = [
+  'APPROVED',
+  'PENDING',
+  'REJECTED',
+  'PAUSED',
+  'DISABLED',
+  'FLAGGED',
+  'ARCHIVED',
+  'UNARCHIVED',
+  'DELETED',
+  'IN_APPEAL',
+  'LIMIT_EXCEEDED',
+  'LOCKED',
+  'REINSTATED',
+  'PENDING_DELETION',
+] as const;
+export type WhatsAppTemplateStatus = (typeof WHATSAPP_TEMPLATE_STATUS)[number];
+
+export const WHATSAPP_TEMPLATE_CATEGORY = [
+  'MARKETING',
+  'UTILITY',
+  'AUTHENTICATION',
+] as const;
+export type WhatsAppTemplateCategory =
+  (typeof WHATSAPP_TEMPLATE_CATEGORY)[number];
+
+export const WHATSAPP_TEMPLATE_REJECTION_REASON = [
+  'ABUSIVE_CONTENT',
+  'CATEGORY_NOT_AVAILABLE',
+  'INCORRECT_CATEGORY',
+  'INVALID_FORMAT',
+  'NONE',
+  'PROMOTIONAL',
+  'SCAM',
+  'TAG_CONTENT_MISMATCH',
+] as const;
+
+/** One HEADER/BODY/FOOTER/BUTTONS block as Meta returns it. Kept loose on
+ *  purpose: Phase 1 only renders these, and Meta's component shape varies by
+ *  format far more than Phase 1 needs to model. */
+export interface WhatsAppTemplateComponent {
+  type: 'HEADER' | 'BODY' | 'FOOTER' | 'BUTTONS';
+  format?: 'TEXT' | 'IMAGE' | 'VIDEO' | 'DOCUMENT' | 'LOCATION';
+  text?: string;
+  buttons?: Array<Record<string, any>>;
+  example?: Record<string, any>;
+}
+
+export const whatsappMessageTemplates = pgTable(
+  'whatsapp_message_templates',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    workspaceId: uuid('workspace_id')
+      .notNull()
+      .references(() => workspace.id, { onDelete: 'cascade' }),
+
+    /** The channel whose token synced this row. `social_media_channels.id` is
+     *  a bigserial, so this is a bigint — NOT a uuid like the other FKs. */
+    channelId: bigint('channel_id', { mode: 'number' })
+      .notNull()
+      .references(() => socialMediaChannels.id, { onDelete: 'cascade' }),
+
+    /** Denormalized from channel.metadata.wabaId so webhook lookups, which
+     *  arrive keyed by WABA, do not have to join through channels. */
+    wabaId: varchar('waba_id', { length: 64 }).notNull(),
+
+    /** Meta's own id. The upsert key. */
+    metaTemplateId: varchar('meta_template_id', { length: 64 }).notNull(),
+
+    name: varchar('name', { length: 512 }).notNull(),
+    language: varchar('language', { length: 32 }).notNull(),
+
+    /** Meta's RETURNED category, never the requested one — Meta silently
+     *  overrides UTILITY to MARKETING, and category drives pricing. */
+    category: varchar('category', { length: 32 })
+      .$type<WhatsAppTemplateCategory>()
+      .notNull(),
+
+    status: varchar('status', { length: 32 })
+      .$type<WhatsAppTemplateStatus>()
+      .notNull(),
+
+    rejectionReason: varchar('rejection_reason', { length: 64 }),
+
+    components: jsonb('components')
+      .$type<WhatsAppTemplateComponent[]>()
+      .notNull()
+      .default([]),
+
+    lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Meta's identity for a template is (name, language) within a WABA.
+    uniqueIndex('whatsapp_templates_channel_name_lang_uq').on(
+      table.channelId,
+      table.name,
+      table.language,
+    ),
+    index('whatsapp_templates_meta_id_idx').on(table.metaTemplateId),
+    index('whatsapp_templates_waba_id_idx').on(table.wabaId),
+    index('whatsapp_templates_workspace_id_idx').on(table.workspaceId),
+    index('whatsapp_templates_channel_id_idx').on(table.channelId),
+  ],
+);
+
+export const whatsappMessageTemplatesRelations = relations(
+  whatsappMessageTemplates,
+  ({ one }) => ({
+    workspace: one(workspace, {
+      fields: [whatsappMessageTemplates.workspaceId],
+      references: [workspace.id],
+    }),
+    channel: one(socialMediaChannels, {
+      fields: [whatsappMessageTemplates.channelId],
+      references: [socialMediaChannels.id],
+    }),
+  }),
+);
+
+export type WhatsAppMessageTemplate =
+  typeof whatsappMessageTemplates.$inferSelect;
+export type NewWhatsAppMessageTemplate =
+  typeof whatsappMessageTemplates.$inferInsert;

--- a/src/inbox/adapters/inbox-adapter.interface.ts
+++ b/src/inbox/adapters/inbox-adapter.interface.ts
@@ -274,6 +274,19 @@ export interface PlatformDmAdapter {
     text: string,
     attachments: DmAttachmentInput[],
   ): Promise<CreatedDm>;
+
+  /**
+   * Send a pre-approved message template. Valid outside the 24-hour reply
+   * window — this is what reopens a conversation the customer has gone quiet
+   * on. Only WhatsApp implements this today.
+   */
+  sendTemplateDm?(
+    channel: ResolvedChannel,
+    conversationId: string,
+    name: string,
+    language: string,
+    components?: Array<Record<string, any>>,
+  ): Promise<CreatedDm>;
 }
 
 /**

--- a/src/inbox/adapters/whatsapp-dm.adapter.ts
+++ b/src/inbox/adapters/whatsapp-dm.adapter.ts
@@ -127,6 +127,37 @@ export class WhatsAppDmAdapter implements PlatformDmAdapter {
     };
   }
 
+  /**
+   * Send an approved template. Valid outside the 24-hour window — this is what
+   * reopens a conversation the customer has gone quiet on.
+   */
+  async sendTemplateDm(
+    channel: ResolvedChannel,
+    conversationId: string,
+    name: string,
+    language: string,
+    components?: Array<Record<string, any>>,
+  ): Promise<CreatedDm> {
+    const phoneNumberId = String(
+      channel.metadata?.phoneNumberId ?? channel.platformAccountId,
+    );
+    const toWaId = conversationId.slice(conversationId.lastIndexOf(':') + 1);
+    const { messageId } = await this.whatsapp.sendTemplate(
+      channel.accessToken,
+      phoneNumberId,
+      toWaId,
+      name,
+      language,
+      components,
+    );
+    return {
+      conversationId,
+      platformItemId: messageId,
+      text: `[template] ${name}`,
+      platformCreatedAt: new Date(),
+    };
+  }
+
   async getReplyWindowState(
     _channel: ResolvedChannel,
     _conversationId: string,
@@ -144,7 +175,7 @@ export class WhatsAppDmAdapter implements PlatformDmAdapter {
       return {
         canReply: false,
         reason:
-          'The 24-hour reply window has closed. A pre-approved template is required (coming soon).',
+          'The 24-hour reply window has closed. Send an approved template to reopen the conversation.',
         windowExpiresAt: expires,
       };
     }

--- a/src/inbox/dto/send-dm-template.dto.ts
+++ b/src/inbox/dto/send-dm-template.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, MaxLength } from 'class-validator';
+
+export class SendDmTemplateDto {
+  @IsString()
+  @MaxLength(512)
+  name: string;
+
+  @IsString()
+  @MaxLength(32)
+  language: string;
+}

--- a/src/inbox/inbox.controller.ts
+++ b/src/inbox/inbox.controller.ts
@@ -26,6 +26,7 @@ import { UpdateScheduledMessageDto } from './dto/update-scheduled-message.dto';
 import { ListScheduledMessagesDto } from './dto/list-scheduled-messages.dto';
 import { CreateInboxUploadUrlDto } from './dto/create-upload-url.dto';
 import { SendDmDto } from './dto/send-dm.dto';
+import { SendDmTemplateDto } from './dto/send-dm-template.dto';
 
 interface AuthUser {
   userId: string;
@@ -252,6 +253,22 @@ export class InboxController {
         url: a.url,
         contentType: a.contentType,
       })),
+    );
+  }
+
+  @Post('dms/:threadKey/template')
+  async sendDmTemplate(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: string,
+    @Param('threadKey') threadKey: string,
+    @Body() dto: SendDmTemplateDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    return this.inboxService.sendDmTemplate(
+      workspaceId,
+      user.userId,
+      threadKey,
+      dto.name,
+      dto.language,
     );
   }
 

--- a/src/inbox/inbox.module.ts
+++ b/src/inbox/inbox.module.ts
@@ -36,6 +36,7 @@ import { RedisClientProvider } from '../channels/analytics/redis-client.provider
 import { ChannelsModule } from '../channels/channels.module';
 import { MediaModule } from '../media/media.module';
 import { CalendarSyncModule } from '../calendar-sync/calendar-sync.module';
+import { WhatsAppTemplatesModule } from '../whatsapp-templates/whatsapp-templates.module';
 import { QUEUES } from '../queue/queue.module';
 
 @Module({
@@ -50,6 +51,10 @@ import { QUEUES } from '../queue/queue.module';
     // (CalendarPullSyncService → ScheduledMessagesService). Same shape as
     // PostsModule ↔ CalendarSyncModule.
     forwardRef(() => CalendarSyncModule),
+    // WebhooksController (registered below) needs WhatsAppTemplatesService.
+    // WhatsAppTemplatesModule imports ChannelsModule, which forwardRef's this
+    // module back → forwardRef on this edge too, same pattern as ChannelsModule.
+    forwardRef(() => WhatsAppTemplatesModule),
     BullModule.registerQueue(
       { name: QUEUES.INBOX_POLLING },
       { name: QUEUES.SCHEDULED_INBOX },

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -30,7 +30,6 @@ import { ChannelService } from '../channels/services/channel.service';
 import { FacebookService } from '../channels/services/facebook.service';
 import { InstagramService } from '../channels/services/instagram.service';
 import { InboxDispatcher } from './services/inbox-dispatcher.service';
-import { WhatsAppTemplatesService } from '../whatsapp-templates/whatsapp-templates.service';
 import { whatsappMessageTemplates } from '../drizzle/schema/whatsapp-templates.schema';
 import type {
   ResolvedChannel,
@@ -266,7 +265,6 @@ export class InboxService {
     private readonly channelService: ChannelService,
     private readonly facebookService: FacebookService,
     private readonly instagramService: InstagramService,
-    private readonly whatsappTemplatesService: WhatsAppTemplatesService,
     @InjectQueue(QUEUES.INBOX_POLLING) private readonly pollQueue: Queue,
   ) {}
 

--- a/src/inbox/inbox.service.ts
+++ b/src/inbox/inbox.service.ts
@@ -30,6 +30,8 @@ import { ChannelService } from '../channels/services/channel.service';
 import { FacebookService } from '../channels/services/facebook.service';
 import { InstagramService } from '../channels/services/instagram.service';
 import { InboxDispatcher } from './services/inbox-dispatcher.service';
+import { WhatsAppTemplatesService } from '../whatsapp-templates/whatsapp-templates.service';
+import { whatsappMessageTemplates } from '../drizzle/schema/whatsapp-templates.schema';
 import type {
   ResolvedChannel,
   DmConversationSummary as AdapterDmConversationSummary,
@@ -264,6 +266,7 @@ export class InboxService {
     private readonly channelService: ChannelService,
     private readonly facebookService: FacebookService,
     private readonly instagramService: InstagramService,
+    private readonly whatsappTemplatesService: WhatsAppTemplatesService,
     @InjectQueue(QUEUES.INBOX_POLLING) private readonly pollQueue: Queue,
   ) {}
 
@@ -2492,6 +2495,102 @@ export class InboxService {
         },
       });
     }
+
+    void this.emitCounts(workspaceId);
+
+    const row =
+      newRow ??
+      (await db.query.inboxItems.findFirst({
+        where: and(
+          eq(inboxItems.channelId, channelId),
+          eq(inboxItems.platformItemId, created.platformItemId),
+        ),
+      }));
+    if (!row) throw new Error('Failed to persist DM');
+    return this.dmItemToDto(row);
+  }
+
+  /**
+   * Send a pre-approved WhatsApp template. This is the only way to reopen a
+   * conversation once the 24-hour reply window has closed, so unlike `sendDm`
+   * it does NOT check `getReplyWindowState` — that's exactly the state this
+   * exists to escape. Only WhatsApp implements template sends today.
+   */
+  async sendDmTemplate(
+    workspaceId: string,
+    userId: string,
+    threadKey: string,
+    name: string,
+    language: string,
+  ): Promise<DmMessageDto> {
+    await this.assertWorkspaceAccess(workspaceId, userId);
+    const { channelId, conversationId } = this.decodeDmThreadKey(threadKey);
+
+    const channelRow = await db.query.socialMediaChannels.findFirst({
+      where: eq(socialMediaChannels.id, channelId),
+    });
+    if (!channelRow || channelRow.workspaceId !== workspaceId) {
+      throw new NotFoundException('Channel not found in workspace');
+    }
+
+    const platform = channelRow.platform as SupportedPlatform;
+    if (platform !== 'whatsapp') {
+      throw new BadRequestException(
+        `Platform '${platform}' doesn't support template sends`,
+      );
+    }
+
+    const adapter = this.dispatcher.getDm(platform);
+    if (!adapter.sendTemplateDm) {
+      throw new BadRequestException(
+        `Platform '${platform}' doesn't support template sends`,
+      );
+    }
+
+    // Guard against sending an unapproved template — Meta rejects these
+    // anyway, but failing early here beats a raw Graph API error surfacing.
+    const template = await db.query.whatsappMessageTemplates.findFirst({
+      where: and(
+        eq(whatsappMessageTemplates.workspaceId, workspaceId),
+        eq(whatsappMessageTemplates.channelId, channelId),
+        eq(whatsappMessageTemplates.name, name),
+        eq(whatsappMessageTemplates.language, language),
+      ),
+    });
+    if (!template) {
+      throw new BadRequestException(
+        `Template '${name}' (${language}) not found for this channel`,
+      );
+    }
+    if (template.status !== 'APPROVED') {
+      throw new BadRequestException(
+        `Template '${name}' (${language}) is not approved (status: ${template.status})`,
+      );
+    }
+
+    const channel = await this.resolveChannel(channelId, workspaceId);
+    const created = await adapter.sendTemplateDm(
+      channel,
+      conversationId,
+      name,
+      language,
+    );
+    const myIdentity = await this.loadMyDmIdentity(channelId);
+
+    const newRow = await this.upsertDm({
+      workspaceId,
+      channelId,
+      platform,
+      conversationId: created.conversationId,
+      platformItemId: created.platformItemId,
+      authorPlatformId: myIdentity.platformId,
+      authorHandle: myIdentity.handle,
+      authorDisplayName: myIdentity.displayName,
+      authorAvatarUrl: myIdentity.avatarUrl,
+      text: created.text,
+      fromMe: true,
+      platformCreatedAt: created.platformCreatedAt,
+    });
 
     void this.emitCounts(workspaceId);
 

--- a/src/whatsapp-templates/whatsapp-templates.controller.ts
+++ b/src/whatsapp-templates/whatsapp-templates.controller.ts
@@ -1,5 +1,44 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { WorkspaceRoleGuard } from '../workspace-members/workspace-role.guard';
+import { RequireCapability } from '../workspace-members/require-capability.decorator';
+import { WhatsAppTemplatesService } from './whatsapp-templates.service';
 
-/** Endpoints arrive in Task 5. This stub exists so the module compiles now. */
-@Controller('whatsapp-templates')
-export class WhatsAppTemplatesController {}
+@Controller('workspaces/:workspaceId/whatsapp-templates')
+@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)
+export class WhatsAppTemplatesController {
+  constructor(private readonly service: WhatsAppTemplatesService) {}
+
+  @Get()
+  @RequireCapability('inbox:view')
+  async list(@Param('workspaceId') workspaceId: string) {
+    return this.service.listForWorkspace(workspaceId);
+  }
+
+  @Post('sync')
+  @RequireCapability('inbox:view')
+  @HttpCode(HttpStatus.OK)
+  async sync(@Param('workspaceId') workspaceId: string) {
+    // Explicit user action — bypass the per-channel throttle.
+    return this.service.syncWorkspace(workspaceId, { force: true });
+  }
+
+  @Delete(':id')
+  @RequireCapability('channels:manage')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('workspaceId') workspaceId: string,
+    @Param('id') id: string,
+  ) {
+    await this.service.deleteTemplate(workspaceId, id);
+  }
+}

--- a/src/whatsapp-templates/whatsapp-templates.controller.ts
+++ b/src/whatsapp-templates/whatsapp-templates.controller.ts
@@ -1,0 +1,5 @@
+import { Controller } from '@nestjs/common';
+
+/** Endpoints arrive in Task 5. This stub exists so the module compiles now. */
+@Controller('whatsapp-templates')
+export class WhatsAppTemplatesController {}

--- a/src/whatsapp-templates/whatsapp-templates.module.ts
+++ b/src/whatsapp-templates/whatsapp-templates.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ChannelsModule } from '../channels/channels.module';
+import { WorkspaceRoleModule } from '../workspace-members/workspace-role.module';
 import { WhatsAppTemplatesService } from './whatsapp-templates.service';
 import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
 
@@ -7,8 +8,14 @@ import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
 // needed here (unlike CalendarSyncModule <-> ChannelsModule). If Task 5's
 // controller work introduces a back-reference, wrap this in forwardRef(() =>
 // ChannelsModule) the way channels.module.ts does for CalendarSyncModule.
+//
+// WorkspaceRoleModule (not the full WorkspaceMembersModule) supplies
+// WorkspaceRoleGuard's dependencies. Pulling in WorkspaceMembersModule here
+// would drag in BillingModule and re-create the same
+// NotificationsModule -> ChannelsModule -> WorkspaceMembers -> Billing ->
+// NotificationsModule cycle that channels.module.ts documents avoiding.
 @Module({
-  imports: [ChannelsModule],
+  imports: [ChannelsModule, WorkspaceRoleModule],
   controllers: [WhatsAppTemplatesController],
   providers: [WhatsAppTemplatesService],
   exports: [WhatsAppTemplatesService],

--- a/src/whatsapp-templates/whatsapp-templates.module.ts
+++ b/src/whatsapp-templates/whatsapp-templates.module.ts
@@ -1,13 +1,17 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ChannelsModule } from '../channels/channels.module';
 import { WorkspaceRoleModule } from '../workspace-members/workspace-role.module';
 import { WhatsAppTemplatesService } from './whatsapp-templates.service';
 import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
 
-// ChannelsModule does not import this module back, so no forwardRef is
-// needed here (unlike CalendarSyncModule <-> ChannelsModule). If Task 5's
-// controller work introduces a back-reference, wrap this in forwardRef(() =>
-// ChannelsModule) the way channels.module.ts does for CalendarSyncModule.
+// Task 6 (webhook routing) made this circular: WebhooksController lives in
+// InboxModule and now needs WhatsAppTemplatesService, so InboxModule imports
+// this module (forwardRef'd on that side). InboxModule -> ChannelsModule is
+// already forwardRef'd both ways, which means the ChannelsModule import
+// below now sits on a real cycle (InboxModule -> WhatsAppTemplatesModule ->
+// ChannelsModule -> ... -> InboxModule) and resolves to undefined at scan
+// time without forwardRef here too. Same pattern as channels.module.ts's
+// CalendarSyncModule import.
 //
 // WorkspaceRoleModule (not the full WorkspaceMembersModule) supplies
 // WorkspaceRoleGuard's dependencies. Pulling in WorkspaceMembersModule here
@@ -15,7 +19,7 @@ import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
 // NotificationsModule -> ChannelsModule -> WorkspaceMembers -> Billing ->
 // NotificationsModule cycle that channels.module.ts documents avoiding.
 @Module({
-  imports: [ChannelsModule, WorkspaceRoleModule],
+  imports: [forwardRef(() => ChannelsModule), WorkspaceRoleModule],
   controllers: [WhatsAppTemplatesController],
   providers: [WhatsAppTemplatesService],
   exports: [WhatsAppTemplatesService],

--- a/src/whatsapp-templates/whatsapp-templates.module.ts
+++ b/src/whatsapp-templates/whatsapp-templates.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ChannelsModule } from '../channels/channels.module';
+import { WhatsAppTemplatesService } from './whatsapp-templates.service';
+import { WhatsAppTemplatesController } from './whatsapp-templates.controller';
+
+// ChannelsModule does not import this module back, so no forwardRef is
+// needed here (unlike CalendarSyncModule <-> ChannelsModule). If Task 5's
+// controller work introduces a back-reference, wrap this in forwardRef(() =>
+// ChannelsModule) the way channels.module.ts does for CalendarSyncModule.
+@Module({
+  imports: [ChannelsModule],
+  controllers: [WhatsAppTemplatesController],
+  providers: [WhatsAppTemplatesService],
+  exports: [WhatsAppTemplatesService],
+})
+export class WhatsAppTemplatesModule {}

--- a/src/whatsapp-templates/whatsapp-templates.service.spec.ts
+++ b/src/whatsapp-templates/whatsapp-templates.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   reconcile,
+  resolveRejectionReason,
   shouldSyncChannel,
   SYNC_MIN_INTERVAL_MS,
 } from './whatsapp-templates.service';
@@ -94,5 +95,25 @@ describe('shouldSyncChannel', () => {
   it('force overrides a fresh sync', () => {
     const justNow = new Date(now.getTime() - 30_000);
     expect(shouldSyncChannel(justNow, now, true)).toBe(true);
+  });
+});
+
+describe('resolveRejectionReason', () => {
+  it('leaves an absent reason untouched (does not write the column)', () => {
+    expect(resolveRejectionReason(undefined)).toBeUndefined();
+  });
+
+  it('persists an explicit null as null, not as "no change"', () => {
+    expect(resolveRejectionReason(null)).toBeNull();
+  });
+
+  it('normalizes the NONE sentinel to null', () => {
+    expect(resolveRejectionReason('NONE')).toBeNull();
+  });
+
+  it('passes a real reason through unchanged', () => {
+    expect(resolveRejectionReason('INCORRECT_CATEGORY')).toBe(
+      'INCORRECT_CATEGORY',
+    );
   });
 });

--- a/src/whatsapp-templates/whatsapp-templates.service.spec.ts
+++ b/src/whatsapp-templates/whatsapp-templates.service.spec.ts
@@ -1,0 +1,98 @@
+import {
+  reconcile,
+  shouldSyncChannel,
+  SYNC_MIN_INTERVAL_MS,
+} from './whatsapp-templates.service';
+
+const meta = (id: string, status = 'APPROVED') => ({
+  metaTemplateId: id,
+  name: `t_${id}`,
+  language: 'en_US',
+  category: 'UTILITY',
+  status,
+  components: [],
+});
+
+describe('reconcile', () => {
+  it('inserts templates Meta has and we do not', () => {
+    const r = reconcile([], [meta('1'), meta('2')]);
+    expect(r.toInsert.map((x) => x.metaTemplateId)).toEqual(['1', '2']);
+    expect(r.toUpdate).toEqual([]);
+    expect(r.toDeleteIds).toEqual([]);
+  });
+
+  it('updates templates both sides have', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'PENDING' }];
+    const r = reconcile(existing, [meta('1', 'APPROVED')]);
+    expect(r.toInsert).toEqual([]);
+    expect(r.toUpdate).toHaveLength(1);
+    expect(r.toUpdate[0].id).toBe('row-1');
+    expect(r.toUpdate[0].row.status).toBe('APPROVED');
+    expect(r.toDeleteIds).toEqual([]);
+  });
+
+  it('prunes rows Meta no longer has', () => {
+    const existing = [
+      { id: 'row-1', metaTemplateId: '1', status: 'APPROVED' },
+      { id: 'row-2', metaTemplateId: '2', status: 'APPROVED' },
+    ];
+    const r = reconcile(existing, [meta('1')]);
+    expect(r.toDeleteIds).toEqual(['row-2']);
+  });
+
+  it('handles all three operations at once', () => {
+    const existing = [
+      { id: 'row-1', metaTemplateId: '1', status: 'PENDING' },
+      { id: 'row-gone', metaTemplateId: '99', status: 'APPROVED' },
+    ];
+    const r = reconcile(existing, [meta('1', 'APPROVED'), meta('2')]);
+    expect(r.toInsert.map((x) => x.metaTemplateId)).toEqual(['2']);
+    expect(r.toUpdate.map((x) => x.id)).toEqual(['row-1']);
+    expect(r.toDeleteIds).toEqual(['row-gone']);
+  });
+
+  it('prunes everything when Meta returns nothing', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'APPROVED' }];
+    const r = reconcile(existing, []);
+    expect(r.toDeleteIds).toEqual(['row-1']);
+    expect(r.toInsert).toEqual([]);
+  });
+
+  it('is a no-op when both sides already agree', () => {
+    const existing = [{ id: 'row-1', metaTemplateId: '1', status: 'APPROVED' }];
+    const r = reconcile(existing, [meta('1', 'APPROVED')]);
+    expect(r.toInsert).toEqual([]);
+    expect(r.toDeleteIds).toEqual([]);
+    // Still emitted as an update: components or category may have changed even
+    // when status did not, and re-writing is cheaper than diffing every field.
+    expect(r.toUpdate).toHaveLength(1);
+  });
+});
+
+describe('shouldSyncChannel', () => {
+  const now = new Date('2026-08-26T12:00:00Z');
+
+  it('syncs a channel that has never synced', () => {
+    expect(shouldSyncChannel(null, now)).toBe(true);
+  });
+
+  it('skips a channel synced moments ago', () => {
+    const justNow = new Date(now.getTime() - 30_000);
+    expect(shouldSyncChannel(justNow, now)).toBe(false);
+  });
+
+  it('syncs again once the interval has passed', () => {
+    const stale = new Date(now.getTime() - SYNC_MIN_INTERVAL_MS - 1);
+    expect(shouldSyncChannel(stale, now)).toBe(true);
+  });
+
+  it('syncs at exactly the interval boundary', () => {
+    const boundary = new Date(now.getTime() - SYNC_MIN_INTERVAL_MS);
+    expect(shouldSyncChannel(boundary, now)).toBe(true);
+  });
+
+  it('force overrides a fresh sync', () => {
+    const justNow = new Date(now.getTime() - 30_000);
+    expect(shouldSyncChannel(justNow, now, true)).toBe(true);
+  });
+});

--- a/src/whatsapp-templates/whatsapp-templates.service.ts
+++ b/src/whatsapp-templates/whatsapp-templates.service.ts
@@ -1,0 +1,289 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { and, asc, eq } from 'drizzle-orm';
+import { db } from '../drizzle/db';
+import {
+  whatsappMessageTemplates,
+  type WhatsAppMessageTemplate,
+  type WhatsAppTemplateCategory,
+  type WhatsAppTemplateStatus,
+} from '../drizzle/schema/whatsapp-templates.schema';
+import { WhatsAppService } from '../channels/services/whatsapp.service';
+import { ChannelService } from '../channels/services/channel.service';
+import {
+  mapMetaTemplateRow,
+  type MappedMetaTemplate,
+  type ParsedTemplateEvent,
+} from '../channels/services/whatsapp-template.util';
+
+export interface ExistingRow {
+  id: string;
+  metaTemplateId: string;
+  status: string;
+}
+
+export interface ReconcileResult {
+  toInsert: MappedMetaTemplate[];
+  toUpdate: Array<{ id: string; row: MappedMetaTemplate }>;
+  toDeleteIds: string[];
+}
+
+/**
+ * Diff what we have against what Meta returned.
+ *
+ * Pure and exported so the reconciliation rules — the part with real risk —
+ * are testable without a database. Rows Meta no longer returns are deleted
+ * outright rather than soft-deleted: Meta deletion is permanent, and keeping a
+ * ghost row would offer a restore that cannot work.
+ */
+export function reconcile(
+  existing: ExistingRow[],
+  incoming: MappedMetaTemplate[],
+): ReconcileResult {
+  const byMetaId = new Map(existing.map((e) => [e.metaTemplateId, e]));
+  const seen = new Set<string>();
+  const toInsert: MappedMetaTemplate[] = [];
+  const toUpdate: Array<{ id: string; row: MappedMetaTemplate }> = [];
+
+  for (const row of incoming) {
+    const match = byMetaId.get(row.metaTemplateId);
+    if (match) {
+      seen.add(match.id);
+      toUpdate.push({ id: match.id, row });
+    } else {
+      toInsert.push(row);
+    }
+  }
+
+  const toDeleteIds = existing.filter((e) => !seen.has(e.id)).map((e) => e.id);
+  return { toInsert, toUpdate, toDeleteIds };
+}
+
+/** Fetch-on-load is a backstop for missed webhooks, not a live feed — once
+ *  every few minutes per channel is ample, and Meta rate-limits per WABA. */
+export const SYNC_MIN_INTERVAL_MS = 5 * 60 * 1000;
+
+export function shouldSyncChannel(
+  lastSyncedAt: Date | null,
+  now: Date,
+  force = false,
+): boolean {
+  if (force) return true;
+  if (!lastSyncedAt) return true;
+  return now.getTime() - lastSyncedAt.getTime() >= SYNC_MIN_INTERVAL_MS;
+}
+
+@Injectable()
+export class WhatsAppTemplatesService {
+  private readonly logger = new Logger(WhatsAppTemplatesService.name);
+
+  constructor(
+    private readonly whatsapp: WhatsAppService,
+    private readonly channels: ChannelService,
+  ) {}
+
+  async listForWorkspace(
+    workspaceId: string,
+  ): Promise<WhatsAppMessageTemplate[]> {
+    return db
+      .select()
+      .from(whatsappMessageTemplates)
+      .where(eq(whatsappMessageTemplates.workspaceId, workspaceId))
+      .orderBy(asc(whatsappMessageTemplates.name));
+  }
+
+  /**
+   * Pull every WhatsApp channel's templates from Meta and reconcile them
+   * against our mirror. One broken channel (expired token, Graph outage) is
+   * logged and skipped rather than failing the whole workspace sync.
+   */
+  async syncWorkspace(
+    workspaceId: string,
+    opts?: { force?: boolean },
+  ): Promise<{ synced: number }> {
+    const channels = await this.channels.getWorkspaceChannels(workspaceId, {
+      platform: 'whatsapp',
+      isActive: true,
+    });
+
+    let synced = 0;
+    for (const channel of channels) {
+      const rawWabaId: unknown = channel.metadata?.wabaId;
+      const wabaId = typeof rawWabaId === 'string' ? rawWabaId : undefined;
+      if (!wabaId) {
+        this.logger.warn(
+          `Channel ${channel.id} has no metadata.wabaId; skipping sync`,
+        );
+        continue;
+      }
+
+      const existingForChannel = await db
+        .select({
+          id: whatsappMessageTemplates.id,
+          metaTemplateId: whatsappMessageTemplates.metaTemplateId,
+          status: whatsappMessageTemplates.status,
+          lastSyncedAt: whatsappMessageTemplates.lastSyncedAt,
+        })
+        .from(whatsappMessageTemplates)
+        .where(eq(whatsappMessageTemplates.channelId, channel.id));
+
+      const newestSync = existingForChannel.reduce<Date | null>(
+        (latest, row) => {
+          if (!row.lastSyncedAt) return latest;
+          if (!latest || row.lastSyncedAt > latest) return row.lastSyncedAt;
+          return latest;
+        },
+        null,
+      );
+
+      if (!shouldSyncChannel(newestSync, new Date(), opts?.force)) {
+        continue;
+      }
+
+      try {
+        const accessToken = await this.channels.getAccessToken(
+          channel.id,
+          workspaceId,
+        );
+        const rows = await this.whatsapp.listMessageTemplates(
+          accessToken,
+          wabaId,
+        );
+        const incoming = rows.map((row) => mapMetaTemplateRow(row));
+        const result = reconcile(existingForChannel, incoming);
+
+        await db.transaction(async (tx) => {
+          const now = new Date();
+
+          if (result.toInsert.length > 0) {
+            await tx.insert(whatsappMessageTemplates).values(
+              result.toInsert.map((row) => ({
+                workspaceId,
+                channelId: channel.id,
+                wabaId,
+                metaTemplateId: row.metaTemplateId,
+                name: row.name,
+                language: row.language,
+                category: row.category as WhatsAppTemplateCategory,
+                status: row.status as WhatsAppTemplateStatus,
+                components: row.components,
+                lastSyncedAt: now,
+              })),
+            );
+          }
+
+          for (const { id, row } of result.toUpdate) {
+            await tx
+              .update(whatsappMessageTemplates)
+              .set({
+                name: row.name,
+                language: row.language,
+                category: row.category as WhatsAppTemplateCategory,
+                status: row.status as WhatsAppTemplateStatus,
+                components: row.components,
+                lastSyncedAt: now,
+                updatedAt: now,
+              })
+              .where(eq(whatsappMessageTemplates.id, id));
+          }
+
+          if (result.toDeleteIds.length > 0) {
+            for (const id of result.toDeleteIds) {
+              await tx
+                .delete(whatsappMessageTemplates)
+                .where(eq(whatsappMessageTemplates.id, id));
+            }
+          }
+        });
+
+        synced += incoming.length;
+      } catch (err) {
+        this.logger.warn(
+          `Template sync failed for channel ${channel.id}: ${(err as Error).message}`,
+        );
+        continue;
+      }
+    }
+
+    return { synced };
+  }
+
+  /**
+   * Apply a webhook status event to EVERY row matching (wabaId,
+   * metaTemplateId) — plural on purpose. One WABA can be connected to more
+   * than one workspace, and updating only the first row is precisely the
+   * fan-out bug this team has shipped before.
+   */
+  async applyStatusEvents(events: ParsedTemplateEvent[]): Promise<void> {
+    for (const event of events) {
+      const reason =
+        event.reason === 'NONE' ? null : (event.reason ?? undefined);
+
+      const updateValues: Partial<
+        typeof whatsappMessageTemplates.$inferInsert
+      > = {
+        status: event.status as WhatsAppTemplateStatus,
+        updatedAt: new Date(),
+      };
+      if (reason !== undefined) {
+        updateValues.rejectionReason = reason;
+      }
+      if (event.category) {
+        updateValues.category = event.category as WhatsAppTemplateCategory;
+      }
+
+      const updated = await db
+        .update(whatsappMessageTemplates)
+        .set(updateValues)
+        .where(
+          and(
+            eq(whatsappMessageTemplates.wabaId, event.wabaId),
+            eq(whatsappMessageTemplates.metaTemplateId, event.metaTemplateId),
+          ),
+        )
+        .returning({ id: whatsappMessageTemplates.id });
+
+      if (updated.length === 0) {
+        this.logger.debug(
+          `No local template row for waba=${event.wabaId} metaTemplateId=${event.metaTemplateId}; ignoring event`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Meta first: delete at Meta, and only remove the local row if that
+   * succeeds. If Meta rejects, the local row must survive so the list does
+   * not lie about what still exists.
+   */
+  async deleteTemplate(workspaceId: string, id: string): Promise<void> {
+    const [row] = await db
+      .select()
+      .from(whatsappMessageTemplates)
+      .where(
+        and(
+          eq(whatsappMessageTemplates.id, id),
+          eq(whatsappMessageTemplates.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      throw new NotFoundException('Template not found');
+    }
+
+    const accessToken = await this.channels.getAccessToken(
+      row.channelId,
+      workspaceId,
+    );
+    await this.whatsapp.deleteMessageTemplate(
+      accessToken,
+      row.wabaId,
+      row.name,
+      row.metaTemplateId,
+    );
+
+    await db
+      .delete(whatsappMessageTemplates)
+      .where(eq(whatsappMessageTemplates.id, id));
+  }
+}

--- a/src/whatsapp-templates/whatsapp-templates.service.ts
+++ b/src/whatsapp-templates/whatsapp-templates.service.ts
@@ -72,6 +72,27 @@ export function shouldSyncChannel(
   return now.getTime() - lastSyncedAt.getTime() >= SYNC_MIN_INTERVAL_MS;
 }
 
+/**
+ * Map a webhook event's `reason` onto what we persist.
+ *
+ * Three distinct inputs, three distinct outcomes:
+ * - `undefined` (field omitted entirely) → `undefined`: don't touch the column.
+ * - `null` (Meta explicitly cleared it, e.g. on a delete-scheduled transition)
+ *   → `null`: write the clear.
+ * - `'NONE'` (Meta's sentinel for "no reason") → `null`: same as an explicit clear.
+ *
+ * `null` and `undefined` look identical after `?.`/`??` collapse them, which is
+ * exactly the bug this function exists to prevent: a webhook that explicitly
+ * clears a rejection reason must not be silently treated as "said nothing."
+ */
+export function resolveRejectionReason(
+  reason: string | null | undefined,
+): string | null | undefined {
+  if (reason === undefined) return undefined;
+  if (reason === null || reason === 'NONE') return null;
+  return reason;
+}
+
 @Injectable()
 export class WhatsAppTemplatesService {
   private readonly logger = new Logger(WhatsAppTemplatesService.name);
@@ -215,8 +236,7 @@ export class WhatsAppTemplatesService {
    */
   async applyStatusEvents(events: ParsedTemplateEvent[]): Promise<void> {
     for (const event of events) {
-      const reason =
-        event.reason === 'NONE' ? null : (event.reason ?? undefined);
+      const reason = resolveRejectionReason(event.reason);
 
       const updateValues: Partial<
         typeof whatsappMessageTemplates.$inferInsert
@@ -227,7 +247,7 @@ export class WhatsAppTemplatesService {
       if (reason !== undefined) {
         updateValues.rejectionReason = reason;
       }
-      if (event.category) {
+      if (event.category !== undefined) {
         updateValues.category = event.category as WhatsAppTemplateCategory;
       }
 


### PR DESCRIPTION
Phase 1 of WhatsApp message templates. Mirrors the customer's templates from their WhatsApp Business Account at Meta, keeps approval status live via webhook, and lets an operator send an approved template to reopen a conversation whose 24-hour reply window has closed.

`whatsapp-dm.adapter.ts` used to tell the user *"A pre-approved template is required (coming soon)"* — that dead end is now a real feature.

## What's here

- `whatsapp_message_templates` table — separate from `media_templates`, which is **not modified**. The two share only the word "template": WhatsApp templates live on the customer's WABA, are reviewed asynchronously, delete permanently, and can have their category overridden by Meta.
- Sync service — list from Meta, upsert, prune. Fans out across workspaces (one WABA can be connected to two).
- Webhook parser for `message_template_status_update`, routed **before** inbox ingest. `parseWhatsAppMessages` is **not modified** — inbox ingest and the Maestro bridge depend on it, and a regression test proves it still behaves identically.
- `GET` / `POST /sync` / `DELETE` endpoints, plus `POST /inbox/workspaces/:id/dms/:threadKey/template` with a server-side APPROVED guard.

## Notable

- **Store Meta's returned category, never the requested one** — Meta silently overrides `UTILITY`→`MARKETING`, and category drives pricing.
- **No soft delete.** Meta deletion is permanent; a recycle bin would be a lie.
- **14 status values**, not 3. Unknown values tolerated.
- Pagination throws on truncation rather than returning a partial list — otherwise a WABA with >2000 templates would have had its tail pruned on every sync.

## Migration

`0027_whatsapp_templates.sql` — **already applied to production manually** via `psql` (journal drift means `db:generate`/`db:migrate` are unusable here). Fully idempotent.

## Verification

- Build passes; suite 1027/1031. The 4 failures (`billing.controller`, `evergreen.service`, `pool-config`, `price-provisioning`) are pre-existing and reproduce on unrelated branches.
- Boots with no circular-dependency warning.
- `git diff main` on `media-library.schema.ts` and `whatsapp-webhook.util.ts`: both empty.

Frontend counterpart: `feat/whatsapp-templates` in socialmedia-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)