### PR TITLE
test(maestro): cover the event sequence, tenant isolation, and confirm gate

### DIFF
--- a/docs/maestro-todo.md
+++ b/docs/maestro-todo.md
@@ -1,0 +1,81 @@
+# Maestro — Development TODO
+
+Running backlog for the Maestro agent. Items here are agreed but not yet
+scheduled; each one gets a spec before it gets code.
+
+> Not to be confused with `ai-assistant-todo.md`, which tracks the older
+> `src/chatbot/` module.
+
+---
+
+## Backlog
+
+### Inline source attribution in replies
+
+**Status:** captured 2026-08-26 — needs discussion before any work starts.
+
+Today sources are a list *underneath* the reply (`web-sources.tsx`): a
+"Sources from the web" heading with one bordered row per link. It works, but it
+sits apart from the text, so the reader cannot tell **which claim** came from
+**which source**.
+
+What is wanted instead:
+
+- **Inline citation chips** placed at the point of the claim — a small
+  favicon + domain pill sitting in the sentence itself, not in a list below it.
+- **A collapsed source summary** on the actions row — overlapping favicons plus
+  a count ("10 sources"), sitting alongside copy / regenerate / thumbs, rather
+  than a separate titled block.
+- So a reply reads as prose with attribution woven through it, and the full
+  list is available on demand instead of always expanded.
+
+**Open questions — to settle in discussion:**
+
+- Where do citation positions come from? The model must mark them in its output
+  (some inline token the frontend parses), because the current `web_search`
+  tool returns a flat result list with no mapping back to spans of text. This
+  is the part that decides whether the rest is cheap or expensive.
+- Do non-web tools get attribution too — a Slack read, a workspace lookup — or
+  is this web-search only?
+- What does the expanded view look like when the count is clicked?
+- Favicon fetching: from the source domain at render time, or resolved and
+  cached server-side? (Render-time is simpler but leaks the reader's IP to
+  every cited domain.)
+
+**Where it lands:** `src/maestro/tools/web.tools.ts` (source shape),
+`system-prompt.ts` (citation instructions), and frontend `web-sources.tsx` +
+`rich-text.tsx` (inline parsing and chips).
+
+---
+
+## Next up
+
+### Tests for the Maestro core
+
+24 source files, 3 spec files — and 2 of those 3 were written during the auth
+work. Meanwhile the repo overall has 141 spec files, so Maestro is the outlier,
+not the norm.
+
+Priority order, highest payoff first:
+
+1. **`maestro.service.ts` SSE event sequence** (779 lines, untested). The whole
+   frontend activity row is built on the order of `thinking` →
+   `tool_executing` → `message_stream` → `message_complete` → `done`. Change
+   that order and the UI breaks, with no signal until someone opens a chat.
+2. **`build-mcp-server.ts` tenant isolation** (64 lines). Each request builds an
+   MCP server closing over a `ToolContext`. If that context ever leaks or is
+   shared, one workspace sees another's data. Small file, security-critical.
+3. **`confirm.ts` approval gate** (50 lines). If the gate is bypassed, the agent
+   sends real messages without asking.
+
+Tool wrappers are deliberately excluded — they mostly wrap external APIs, so
+their tests would lean on mocks and prove little.
+
+---
+
+## Deferred (from the original review)
+
+- **Platform tools** — Maestro can do messaging and posts, but not analytics,
+  campaigns, or inbox.
+- **Cost tracking** — `costUsd` is discarded, so per-model billing is not
+  currently possible.

--- a/docs/maestro-todo.md
+++ b/docs/maestro-todo.md
@@ -52,6 +52,10 @@ What is wanted instead:
 
 ### Tests for the Maestro core
 
+**Spec:** `docs/superpowers/specs/2026-08-26-maestro-core-tests-design.md`
+**Plan:** `docs/superpowers/plans/2026-08-26-maestro-core-tests.md`
+**Status:** planned 2026-08-26, coding scheduled for 2026-08-27.
+
 24 source files, 3 spec files — and 2 of those 3 were written during the auth
 work. Meanwhile the repo overall has 141 spec files, so Maestro is the outlier,
 not the norm.

--- a/docs/superpowers/plans/2026-08-26-maestro-core-tests.md
+++ b/docs/superpowers/plans/2026-08-26-maestro-core-tests.md
@@ -1,0 +1,143 @@
+# Maestro core tests — implementation plan
+
+**Spec:** `docs/superpowers/specs/2026-08-26-maestro-core-tests-design.md`
+**Branch:** `test/maestro-core` (off `main`, backend only)
+**Scheduled:** 2026-08-27
+
+Ordered cheapest-first, so each task lands green before the next begins. Tasks 1
+and 2 are quick and build the habit; task 3 is the bulk of the work.
+
+---
+
+## Task 0 — branch
+
+```
+cd socialmedia-workspace
+git checkout main && git pull
+git checkout -b test/maestro-core
+```
+
+Frontend is untouched — no test framework there, and nothing in this effort
+changes its contract.
+
+---
+
+## Task 1 — `src/maestro/tools/confirm.spec.ts`
+
+Smallest surface, clearest guarantee. Pure functions, no fakes needed.
+
+1. `isConfirmed` truth table: setting off → true; setting on with no flag →
+   false; setting on with `confirmed: true` → true.
+2. **Strict-equality cases**: `'true'`, `1`, `'yes'`, `{}`, `[]` each → false.
+   Name the test so the intent survives — the guarantee is that only a real
+   boolean `true` opens the gate.
+3. `confirmCard` shape: `kind: 'question'`, `shown: true`, one question, exactly
+   `[yesLabel, 'No, cancel']`, `multiSelect: false`.
+4. `confirmCard` instruction mentions the yes label (the model is told to
+   re-call with `confirmed:true`).
+
+**Green check:** `npx jest src/maestro/tools/confirm.spec.ts`
+
+---
+
+## Task 2 — `src/maestro/tools/build-mcp-server.spec.ts`
+
+Needs a small SDK stub. No real SDK import — it is ESM-only and slow to load.
+
+1. Build the stub: `tool(name, desc, schema, handler)` records the handler and
+   returns a marker; `createSdkMcpServer` returns its argument.
+2. **Isolation test** (the reason this file exists): build two servers with
+   different `ctx` objects, invoke both handlers, assert each received its own
+   context. Assert on the identity of the object passed through, not a field
+   copy.
+3. Success wrapping: handler return → `{ content: [{ type:'text', text: JSON }] }`.
+4. Error wrapping: handler throws `Error('boom')` → `isError: true` and `boom`
+   in the payload; the call itself does not reject.
+5. Non-`Error` throw (e.g. a string) → `'Tool failed'` fallback.
+6. Name helpers round-trip; `stripQualifiedToolName('plain')` → `'plain'`.
+
+**Green check:** `npx jest src/maestro/tools/build-mcp-server.spec.ts`
+
+---
+
+## Task 3 — `src/maestro/services/maestro.service.spec.ts`
+
+The bulk. Build the harness first, then add cases against it.
+
+### 3a — harness
+
+- `fakeRuntime(events: AgentEvent[])` → `{ run: async function* () { yield* events } }`.
+- `collect(gen)` → drains an async generator into an array.
+- Stubs: `conversations.addMessage` → `{ id: 'msg-1' }`; `tokens.checkBudget` →
+  not exceeded; `tokens.recordUsage` → jest.fn recording its args;
+  `keys.getDecryptedKey` → null by default (platform key path).
+- Set `process.env.ANTHROPIC_API_KEY` in `beforeEach` so auth resolves; restore
+  `process.env` in `afterAll`, matching `maestro-key.service.spec.ts`.
+
+Construct the service directly with `new MaestroService(...)` and fakes — no
+`@nestjs/testing`, per the existing spec style.
+
+### 3b — ordering
+
+- Plain turn: `thinking` → `message_stream` → `message_complete` → `done`.
+- Tool turn: `tool_executing` and `tool_result` appear before the text events.
+- `done` is the final event; `message_complete` precedes it.
+- Runtime `error` event → an `error` is yielded and **nothing follows it**.
+
+### 3c — followups marker (highest value in this task)
+
+- Whole marker in one delta → text before it streams; nothing after it does.
+- **Marker split across two deltas** (`__FOLL` + `OWUPS__`) → no partial marker
+  ever appears in any `message_stream` token. Assert by concatenating all
+  emitted tokens and checking neither the marker nor a prefix of it is present.
+- No marker → concatenated tokens equal the full raw text exactly (no
+  truncation from the held-back tail, no duplication from the final flush).
+- Followups parsing: split on `|`, bullets/numbering stripped, capped at 4.
+
+### 3d — persistence, metering, abort
+
+- `message_complete.messageId` is the id from `addMessage`.
+- Metadata-only turn (media/question/web, empty text) still persists and
+  completes.
+- Billing: 100:1, `Math.ceil`, minimum 1. Include a small-usage case that must
+  bill 1, not 0.
+- **BYOK**: `keys.getDecryptedKey` returns a key → `recordUsage` called with
+  `{ billable: false }`. Platform key → `{ billable: true }`.
+- Abort mid-stream → loop breaks, no `error` yielded.
+
+**Green check:** `npx jest src/maestro`
+
+---
+
+## Task 4 — full verification
+
+```
+npm run test     # all 141+ specs
+npm run build
+npm run lint
+```
+
+All three green before any commit is pushed.
+
+---
+
+## Task 5 — commit and PR
+
+- One commit per task (`test(maestro): …`), so each target is reviewable alone.
+- **If a test uncovers a real defect**, fix it in a SEPARATE commit from the
+  tests, so the behaviour change is visible on its own rather than buried in a
+  test diff.
+- PR against `main` on the backend repo (`gh auth switch --user Asad00713`
+  first — the backend uses that account).
+
+---
+
+## Notes and risks
+
+- **`streamMessage` is long (779 lines).** If a case turns out to be unreachable
+  without heavy mocking, stop and report it rather than reshaping production
+  code to be testable. Any such refactor is its own decision, made with the
+  user.
+- **Do not weaken assertions to force green.** A failing test here likely means
+  a real bug — that is the entire point of the effort.
+- The frontend need not run for any of this.

--- a/docs/superpowers/specs/2026-08-26-maestro-core-tests-design.md
+++ b/docs/superpowers/specs/2026-08-26-maestro-core-tests-design.md
@@ -1,0 +1,156 @@
+# Maestro core tests — design
+
+**Date:** 2026-08-26
+**Status:** approved, not started (coding scheduled for 2026-08-27)
+**Scope:** backend only (`socialmedia-workspace`)
+
+---
+
+## Why
+
+Maestro has **24 source files and 3 spec files**, and two of those three were
+written during the BYOK work. The repo overall has **141 spec files**, so
+Maestro is the outlier, not the norm.
+
+The practical cost is already visible: during the activity-row work a shimmer
+regression came back twice, and a tool row that should have disappeared was
+"fixed" in the wrong branch twice — because the only way to check behaviour was
+to open a chat and watch it. Every Maestro change currently ends in manual
+verification.
+
+These tests are not about a coverage number. They target the three places where
+a break is **invisible until production**.
+
+---
+
+## What is NOT in scope
+
+- **Tool wrappers** (`slack.tools.ts`, `discord.tools.ts`, …). They mostly
+  forward to external APIs; tests would assert against mocks and prove little.
+- **The runtime adapter** (`claude-agent-sdk.runtime.ts`). It maps SDK messages
+  to our `AgentEvent` union. Worth testing eventually, but it is exercised
+  indirectly by the service tests, so it stays second-tier.
+- **E2E / HTTP-level tests.** These are unit tests against the service and its
+  helpers, using the fake-runtime seam described below.
+- **Frontend tests.** No test framework is configured there.
+
+---
+
+## Target 1 — `maestro.service.ts` SSE event sequence
+
+779 lines, zero tests. This is the highest-value target because the **entire
+frontend activity row is built on the order and shape of these events**.
+
+### The seam
+
+`streamMessage` is an async generator that consumes `this.runtime.run(input)`,
+itself an async iterable of `AgentEvent`. That makes the runtime a clean
+injection point: a fake runtime yielding a scripted `AgentEvent[]` lets us drive
+any scenario without the SDK, the network, or an API key.
+
+Collaborators to stub: `conversations` (addMessage/updateTitle), `tokens`
+(checkBudget/recordUsage), `keys` (getDecryptedKey), and the db handle.
+
+### Cases
+
+**Event ordering**
+- A plain turn yields `thinking` → `message_stream`* → `message_complete` →
+  `done`, in that order.
+- A tool turn interleaves `tool_executing` → `tool_result` before the text.
+- `message_complete` always precedes `done`, and `done` is last.
+- An `error` event from the runtime **terminates the stream** — nothing is
+  yielded after it.
+
+**The followups marker** — the subtlest logic in the file, and the most likely
+to break silently.
+
+`FOLLOWUPS_MARKER = '__FOLLOWUPS__'` splits display text from suggestions. The
+streaming loop holds back the last `markerLength - 1` characters so a marker
+split across two deltas is never emitted as visible text. Cases:
+
+- Marker arriving whole in one delta: text before it streams, nothing after it does.
+- Marker **split across deltas** (e.g. `__FOLL` + `OWUPS__`) — the partial must
+  never reach the client. This is the case the held-back buffer exists for.
+- No marker at all: the held-back tail is flushed exactly once at the end, and
+  the full text is emitted with no truncation and no duplication.
+- Text after the marker is parsed into at most 4 followups, split on `|`, with
+  list bullets/numbering stripped.
+
+**Persistence and metering**
+- `message_complete` carries the id returned by `conversations.addMessage`.
+- A turn with no display text but with media/question/web metadata **still**
+  persists and completes.
+- Billing converts real tokens at 100:1, rounded up, minimum 1.
+- **BYOK turns are logged with `billable: false`** — the workspace already paid
+  Anthropic directly. A regression here silently double-charges customers.
+
+**Abort**
+- When the signal aborts mid-stream, the loop breaks and no `error` is yielded.
+
+---
+
+## Target 2 — `build-mcp-server.ts` tenant isolation
+
+64 lines, security-critical.
+
+Every request builds a fresh MCP server whose tool handlers **close over that
+request's `ToolContext`**. If a context were ever hoisted, shared, or captured
+by reference across requests, one workspace would act with another's
+credentials. Nothing currently proves it doesn't.
+
+### Cases
+
+- Each `buildMcpServer` call passes **its own** `ctx` to handlers; two servers
+  built with different contexts never cross over.
+- Handler results are wrapped as `{ content: [{ type:'text', text: <json> }] }`.
+- A **thrown** handler error becomes `isError: true` with the message in the
+  payload — it must not escape and kill the turn.
+- A non-`Error` throw still yields the `'Tool failed'` fallback.
+- `toQualifiedToolName` / `stripQualifiedToolName` round-trip, and stripping a
+  name without the prefix returns it unchanged.
+
+The SDK is stubbed: `sdk.tool` records its handler, `createSdkMcpServer` returns
+a marker. No SDK import is needed, so these tests stay fast.
+
+---
+
+## Target 3 — `confirm.ts` approval gate
+
+50 lines. If this gate opens when it shouldn't, **Maestro sends real messages
+to real channels without asking**.
+
+The file's own docblock explains why the gate is code and not a prompt rule:
+weaker models narrate "Confirm?" in prose without ever calling `ask_user`, so a
+prompt-only policy gates nothing. That reasoning is exactly what the tests
+should pin down.
+
+### Cases
+
+- `isConfirmed(false, {})` → true (setting off, proceed).
+- `isConfirmed(true, {})` → false (setting on, first call, refuse).
+- `isConfirmed(true, { confirmed: true })` → true.
+- **Strict `true` only**: `'true'`, `1`, `'yes'`, `{}` must all be rejected.
+  This is the actual guarantee — a truthy check here would be the bug.
+- `confirmCard` returns `kind:'question'` with exactly the two options, the
+  affirmative label first, and `multiSelect: false`.
+
+---
+
+## Approach
+
+- Plain Jest, matching `maestro-key.service.spec.ts`: hand-written fakes, no
+  `@nestjs/testing` module compilation, no DB.
+- Specs co-located as `*.spec.ts`, per repo convention.
+- A shared `collect(gen)` helper drains the generator into an array so ordering
+  can be asserted directly.
+- Fakes stay minimal and local to each spec — no shared fixture package for
+  three files.
+
+## Definition of done
+
+- `npm run test` green, including the 141 existing specs.
+- `npm run build` green.
+- Each of the three targets has its listed cases covered.
+- No production code changed **unless a test finds a real defect** — in which
+  case the fix is a separate commit from the tests, so the fix is reviewable on
+  its own.

--- a/src/maestro/services/maestro.service.spec.ts
+++ b/src/maestro/services/maestro.service.spec.ts
@@ -1,0 +1,518 @@
+import { MaestroService } from './maestro.service';
+import type { AgentEvent } from '../maestro.types';
+
+/**
+ * The whole frontend activity row is built on the order and shape of the
+ * events `streamMessage` yields, and none of it was covered. These tests drive
+ * the generator through a fake runtime, so any scenario can be scripted without
+ * the SDK, the network, or an API key.
+ */
+
+const CONVERSATION_ID = 'conv-1';
+const USER_ID = 'user-1';
+const WORKSPACE_ID = 'ws-1';
+
+type Emitted = { event: string; data: Record<string, unknown> };
+
+/** Drain the generator so ordering can be asserted directly. */
+async function collect(
+  gen: AsyncGenerator<unknown, void, unknown>,
+): Promise<Emitted[]> {
+  const out: Emitted[] = [];
+  for await (const ev of gen) out.push(ev as Emitted);
+  return out;
+}
+
+/** Every `message_stream` token concatenated — what the reader actually sees. */
+function streamedText(events: Emitted[]): string {
+  return events
+    .filter((e) => e.event === 'message_stream')
+    .map((e) => e.data.token as string)
+    .join('');
+}
+
+function names(events: Emitted[]): string[] {
+  return events.map((e) => e.event);
+}
+
+function textDeltas(...chunks: string[]): AgentEvent[] {
+  return chunks.map((text) => ({ type: 'text_delta', text }) as AgentEvent);
+}
+
+/** Split a string into fixed-size chunks, to script a choppy stream. */
+function chunked(text: string, size: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += size) out.push(text.slice(i, i + size));
+  return out;
+}
+
+const DONE_EVENT = {
+  type: 'done',
+  usage: { inputTokens: 500, outputTokens: 500, costUsd: 0.01 },
+} as AgentEvent;
+
+interface Harness {
+  service: MaestroService;
+  /** Typed so `.mock.calls` indexes without falling back to `any`. */
+  addMessage: jest.Mock<Promise<{ id: string }>, unknown[]>;
+  recordUsage: jest.Mock<Promise<void>, unknown[]>;
+  getDecryptedKey: jest.Mock<Promise<string | null>, unknown[]>;
+}
+
+function makeHarness(
+  events: AgentEvent[],
+  opts: { byokKey?: string | null; budgetExceeded?: boolean } = {},
+): Harness {
+  const runtime = {
+    run: () =>
+      // eslint-disable-next-line @typescript-eslint/require-await -- scripted events, nothing to await
+      (async function* () {
+        for (const ev of events) yield ev;
+      })(),
+  };
+
+  const addMessage = jest
+    .fn<Promise<{ id: string }>, unknown[]>()
+    .mockResolvedValue({ id: 'msg-saved' });
+  const conversations = {
+    findById: jest.fn().mockResolvedValue({
+      id: CONVERSATION_ID,
+      userId: USER_ID,
+      workspaceId: WORKSPACE_ID,
+      title: 'Existing title',
+    }),
+    addMessage,
+    updateTitle: jest.fn().mockResolvedValue(undefined),
+    // One prior turn, so `isFirstTurn` is false and no title is generated.
+    getRecentMessages: jest.fn().mockResolvedValue([
+      { role: 'user', content: 'earlier', metadata: null },
+      { role: 'user', content: 'current', metadata: null },
+    ]),
+  };
+
+  const recordUsage = jest
+    .fn<Promise<void>, unknown[]>()
+    .mockResolvedValue(undefined);
+  const tokens = {
+    checkBudget: jest
+      .fn()
+      .mockResolvedValue({ exceeded: Boolean(opts.budgetExceeded) }),
+    recordUsage,
+    getUsage: jest.fn().mockResolvedValue({ used: 10, limit: 1000 }),
+  };
+
+  const getDecryptedKey = jest
+    .fn<Promise<string | null>, unknown[]>()
+    .mockResolvedValue(opts.byokKey ?? null);
+
+  // Tool factories run at input-build time and only capture these; none is
+  // invoked, because the fake runtime never calls a tool handler.
+  const stub = {} as never;
+  const groq = { isReady: () => false } as never;
+
+  const service = new MaestroService(
+    runtime as never,
+    conversations as never,
+    stub,
+    stub,
+    tokens as never,
+    groq,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    { getDecryptedKey } as never,
+  );
+
+  jest
+    .spyOn(service, 'getUsage')
+    .mockResolvedValue({ used: 10, limit: 1000 } as never);
+
+  return { service, addMessage, recordUsage, getDecryptedKey };
+}
+
+function run(h: Harness, signal?: AbortSignal) {
+  return collect(
+    h.service.streamMessage(
+      { conversationId: CONVERSATION_ID, userId: USER_ID, message: 'hi' },
+      signal ?? new AbortController().signal,
+    ) as AsyncGenerator<unknown, void, unknown>,
+  );
+}
+
+describe('MaestroService.streamMessage', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-platform-key';
+    delete process.env.MAESTRO_AUTH_MODE;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('event ordering', () => {
+    it('runs thinking, then text, then completion, then done', async () => {
+      const h = makeHarness([
+        { type: 'thinking_delta', text: 'considering' } as AgentEvent,
+        ...textDeltas('Hello there'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+
+      expect(names(events)).toEqual([
+        'thinking',
+        'message_stream',
+        'message_complete',
+        'done',
+      ]);
+    });
+
+    it('reports a tool call and its result before any answer text', async () => {
+      const h = makeHarness([
+        {
+          type: 'tool_call',
+          name: 'send_slack_message',
+          input: {},
+        } as AgentEvent,
+        {
+          type: 'tool_result',
+          name: 'send_slack_message',
+          output: [{ type: 'text', text: '{"sent":true}' }],
+          isError: false,
+        } as AgentEvent,
+        ...textDeltas('Sent.'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+      const order = names(events);
+
+      expect(order.indexOf('tool_executing')).toBeLessThan(
+        order.indexOf('tool_result'),
+      );
+      expect(order.indexOf('tool_result')).toBeLessThan(
+        order.indexOf('message_stream'),
+      );
+      expect(events[0].data).toEqual({
+        tool: 'send_slack_message',
+        input: {},
+      });
+    });
+
+    it('always ends with done, after message_complete', async () => {
+      const h = makeHarness([...textDeltas('Answer'), DONE_EVENT]);
+
+      const events = await run(h);
+      const order = names(events);
+
+      expect(order[order.length - 1]).toBe('done');
+      expect(order.indexOf('message_complete')).toBeLessThan(
+        order.indexOf('done'),
+      );
+    });
+
+    it('stops the stream dead on a runtime error', async () => {
+      // Long enough to clear the marker-length tail hold-back, so some text
+      // has genuinely been emitted before the error arrives.
+      const h = makeHarness([
+        ...textDeltas('A partial answer that was already streaming'),
+        { type: 'error', message: 'model exploded' } as AgentEvent,
+        // Nothing after an error may be emitted.
+        ...textDeltas(' more'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+
+      expect(names(events)).toEqual(['message_stream', 'error']);
+      expect(events[1].data).toEqual({ message: 'model exploded' });
+    });
+
+    it('emits no partial text when the error lands before the hold-back clears', async () => {
+      // Under the marker length, so the tail hold-back is still holding it all
+      // — the turn ends with the error and nothing visible.
+      const h = makeHarness([
+        ...textDeltas('short'),
+        { type: 'error', message: 'model exploded' } as AgentEvent,
+      ]);
+
+      const events = await run(h);
+
+      expect(names(events)).toEqual(['error']);
+    });
+  });
+
+  describe('followups marker', () => {
+    // The subtlest logic in the file: the marker separates the reply from its
+    // suggestions, and a partial marker must never reach the reader.
+    it('keeps the marker and everything after it out of the visible text', async () => {
+      const h = makeHarness([
+        ...textDeltas('The answer.__FOLLOWUPS__ one | two'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+
+      expect(streamedText(events)).toBe('The answer.');
+      expect(streamedText(events)).not.toContain('__FOLLOWUPS__');
+    });
+
+    it('never leaks a marker split across two deltas', async () => {
+      // This is why the loop holds back the tail: without it, `__FOLL` would
+      // flash on screen before the rest of the marker arrived.
+      const h = makeHarness([
+        ...textDeltas('The answer.__FOLL', 'OWUPS__ one | two'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+      const visible = streamedText(events);
+
+      expect(visible).toBe('The answer.');
+      expect(visible).not.toContain('__FOLL');
+    });
+
+    it('leaks nothing even when the marker arrives one character at a time', async () => {
+      const h = makeHarness([
+        ...textDeltas('Answer.', ...'__FOLLOWUPS__ a | b'.split('')),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+      const visible = streamedText(events);
+
+      expect(visible).toBe('Answer.');
+      // Not even a leading underscore of the marker may survive.
+      expect(visible).not.toContain('_');
+    });
+
+    it('flushes the held-back tail when no marker ever arrives', async () => {
+      // The tail hold-back must not silently truncate an ordinary reply.
+      const full = 'A perfectly ordinary reply with no marker at all.';
+      const h = makeHarness([...textDeltas(full), DONE_EVENT]);
+
+      const events = await run(h);
+
+      expect(streamedText(events)).toBe(full);
+    });
+
+    it('emits each character exactly once across many deltas', async () => {
+      const full = 'Streamed in many small pieces, none duplicated.';
+      const h = makeHarness([...textDeltas(...chunked(full, 3)), DONE_EVENT]);
+
+      const events = await run(h);
+
+      expect(streamedText(events)).toBe(full);
+    });
+
+    it('parses suggestions, strips bullets, and caps them at four', async () => {
+      const h = makeHarness([
+        ...textDeltas(
+          'Done.__FOLLOWUPS__ - one | 2. two | three | four | five',
+        ),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+      const followups = events.find((e) => e.event === 'followups');
+
+      expect(followups?.data.suggestions).toEqual([
+        'one',
+        'two',
+        'three',
+        'four',
+      ]);
+    });
+
+    it('emits no followups event when there are none', async () => {
+      const h = makeHarness([...textDeltas('Just an answer.'), DONE_EVENT]);
+
+      const events = await run(h);
+
+      expect(names(events)).not.toContain('followups');
+    });
+
+    it('persists only the display text, never the marker line', async () => {
+      const h = makeHarness([
+        ...textDeltas('Visible part.__FOLLOWUPS__ a | b'),
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+      const complete = events.find((e) => e.event === 'message_complete');
+
+      expect(complete?.data.content).toBe('Visible part.');
+      expect(h.addMessage).toHaveBeenLastCalledWith(
+        CONVERSATION_ID,
+        'assistant',
+        'Visible part.',
+        undefined,
+        expect.any(String),
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('persistence', () => {
+    it('reports the id the conversation store assigned', async () => {
+      const h = makeHarness([...textDeltas('Saved.'), DONE_EVENT]);
+
+      const events = await run(h);
+      const complete = events.find((e) => e.event === 'message_complete');
+
+      expect(complete?.data.messageId).toBe('msg-saved');
+    });
+
+    it('still completes a turn that produced only media', async () => {
+      // An image search with no prose must not vanish — the metadata is the
+      // whole reply.
+      const h = makeHarness([
+        {
+          type: 'tool_result',
+          name: 'search_media',
+          output: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                kind: 'media',
+                items: [{ url: 'https://example.test/a.jpg' }],
+                selectable: true,
+                maxSelect: 1,
+              }),
+            },
+          ],
+          isError: false,
+        } as AgentEvent,
+        DONE_EVENT,
+      ]);
+
+      const events = await run(h);
+
+      expect(names(events)).toContain('message_complete');
+      const meta = h.addMessage.mock.calls[1][3] as {
+        maestroMedia: { items: unknown[] };
+      };
+      expect(meta.maestroMedia.items).toHaveLength(1);
+    });
+
+    it('saves nothing extra when the turn produced no output at all', async () => {
+      const h = makeHarness([DONE_EVENT]);
+
+      const events = await run(h);
+
+      // Only the inbound user turn was persisted.
+      expect(h.addMessage).toHaveBeenCalledTimes(1);
+      expect(names(events)).not.toContain('message_complete');
+      expect(names(events)).toContain('done');
+    });
+  });
+
+  describe('metering', () => {
+    it('converts agent tokens to user tokens at 100:1, rounding up', async () => {
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT]);
+
+      await run(h);
+
+      // 500 in + 500 out = 1000 real → 10 user tokens.
+      expect(h.recordUsage).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        USER_ID,
+        10,
+        'maestro_chat',
+        expect.any(Object),
+        { billable: true },
+      );
+    });
+
+    it('never bills zero for a tiny turn', async () => {
+      const h = makeHarness([
+        ...textDeltas('ok'),
+        {
+          type: 'done',
+          usage: { inputTokens: 1, outputTokens: 1, costUsd: 0 },
+        } as AgentEvent,
+      ]);
+
+      await run(h);
+
+      expect(h.recordUsage.mock.calls[0][2]).toBe(1);
+    });
+
+    // A regression here silently double-charges: the workspace already paid
+    // Anthropic directly with its own key.
+    it('logs a BYOK turn without billing it', async () => {
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT], {
+        byokKey: 'sk-ant-workspace-key',
+      });
+
+      await run(h);
+
+      expect(h.recordUsage).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        USER_ID,
+        expect.any(Number),
+        'maestro_chat',
+        expect.any(Object),
+        { billable: false },
+      );
+    });
+
+    it('lets a BYOK workspace keep working past its plan allowance', async () => {
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT], {
+        byokKey: 'sk-ant-workspace-key',
+        budgetExceeded: true,
+      });
+
+      const events = await run(h);
+
+      expect(names(events)).not.toContain('error');
+      expect(names(events)).toContain('message_complete');
+    });
+
+    it('blocks a platform-key workspace that is out of tokens', async () => {
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT], {
+        budgetExceeded: true,
+      });
+
+      const events = await run(h);
+
+      expect(names(events)).toEqual(['error']);
+      // The turn is refused before anything is persisted.
+      expect(h.addMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auth failure', () => {
+    it('reports a clean error and saves nothing when no key is configured', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT]);
+
+      const events = await run(h);
+
+      expect(names(events)).toEqual(['error']);
+      expect(events[0].data.message).toContain("isn't configured");
+      // The whole point of resolving auth first: no orphan user turn.
+      expect(h.addMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('abort', () => {
+    it('ends quietly, without an error event', async () => {
+      const controller = new AbortController();
+      const h = makeHarness([...textDeltas('Hi'), DONE_EVENT]);
+      controller.abort();
+
+      const events = await run(h, controller.signal);
+
+      expect(names(events)).not.toContain('error');
+    });
+  });
+});

--- a/src/maestro/tools/build-mcp-server.spec.ts
+++ b/src/maestro/tools/build-mcp-server.spec.ts
@@ -1,0 +1,187 @@
+import {
+  buildMcpServer,
+  MCP_SERVER_NAME,
+  stripQualifiedToolName,
+  toQualifiedToolName,
+} from './build-mcp-server';
+import type { AgentToolDefinition, ToolContext } from '../maestro.types';
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+/**
+ * Stands in for the Agent SDK. The real module is ESM-only and slow to load,
+ * and none of its behaviour is under test here — what matters is which handler
+ * and which context `buildMcpServer` wires together, so the stub just records
+ * the handler it is handed.
+ */
+function makeSdk() {
+  const handlers = new Map<string, Handler>();
+  const sdk = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: Handler) => {
+      handlers.set(name, handler);
+      return { name };
+    },
+    createSdkMcpServer: (cfg: unknown) => ({ created: cfg }),
+  };
+  return { sdk: sdk as never, handlers };
+}
+
+function def(
+  name: string,
+  handler: AgentToolDefinition['handler'],
+): AgentToolDefinition {
+  return { name, description: `${name} tool`, inputSchema: {}, handler };
+}
+
+describe('buildMcpServer', () => {
+  describe('tenant isolation', () => {
+    // The reason this file exists. Every request builds its own server whose
+    // handlers close over THAT request's context. If a context were ever
+    // hoisted or shared, one workspace would act with another's identity.
+    it('gives each handler the context its own server was built with', async () => {
+      const seen: ToolContext[] = [];
+      const capture = def('whoami', async (_args, ctx) => {
+        seen.push(ctx);
+        return { ok: true };
+      });
+
+      const alice: ToolContext = { userId: 'u-alice', workspaceId: 'ws-alice' };
+      const bob: ToolContext = { userId: 'u-bob', workspaceId: 'ws-bob' };
+
+      const a = makeSdk();
+      buildMcpServer(a.sdk, [capture], alice);
+      const b = makeSdk();
+      buildMcpServer(b.sdk, [capture], bob);
+
+      await a.handlers.get('whoami')!({});
+      await b.handlers.get('whoami')!({});
+
+      expect(seen).toHaveLength(2);
+      // Identity, not a field comparison: this fails if the closure captured a
+      // shared reference even when the field values happen to match.
+      expect(seen[0]).toBe(alice);
+      expect(seen[1]).toBe(bob);
+    });
+
+    it('does not let a later build change an earlier context', async () => {
+      const seen: ToolContext[] = [];
+      const capture = def('whoami', async (_args, ctx) => {
+        seen.push(ctx);
+        return {};
+      });
+
+      const first: ToolContext = { userId: 'u-1', workspaceId: 'ws-1' };
+      const a = makeSdk();
+      buildMcpServer(a.sdk, [capture], first);
+
+      // A second request comes in before the first server's tool is called.
+      const b = makeSdk();
+      buildMcpServer(b.sdk, [capture], {
+        userId: 'u-2',
+        workspaceId: 'ws-2',
+      });
+
+      await a.handlers.get('whoami')!({});
+
+      expect(seen[0]).toBe(first);
+    });
+
+    it('passes the caller arguments through untouched', async () => {
+      let received: Record<string, unknown> | null = null;
+      const echo = def('echo', async (args) => {
+        received = args;
+        return {};
+      });
+      const { sdk, handlers } = makeSdk();
+      buildMcpServer(sdk, [echo], { userId: 'u', workspaceId: 'ws' });
+
+      await handlers.get('echo')!({ channel: '#general', text: 'hi' });
+
+      expect(received).toEqual({ channel: '#general', text: 'hi' });
+    });
+  });
+
+  describe('result wrapping', () => {
+    it('wraps a handler return as MCP text content', async () => {
+      const ok = def('ok', async () => ({ sent: true, id: 42 }));
+      const { sdk, handlers } = makeSdk();
+      buildMcpServer(sdk, [ok], { userId: 'u', workspaceId: 'ws' });
+
+      const result = await handlers.get('ok')!({});
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: JSON.stringify({ sent: true, id: 42 }) },
+      ]);
+    });
+
+    // A throwing tool must not escape and kill the turn — the model should see
+    // the failure as a result it can react to.
+    it('turns a thrown Error into an isError result rather than rejecting', async () => {
+      const boom = def('boom', async () => {
+        throw new Error('slack channel not found');
+      });
+      const { sdk, handlers } = makeSdk();
+      buildMcpServer(sdk, [boom], { userId: 'u', workspaceId: 'ws' });
+
+      const result = await handlers.get('boom')!({});
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'slack channel not found',
+      });
+    });
+
+    it('falls back to a generic message when a non-Error is thrown', async () => {
+      const odd = def('odd', async () => {
+        throw 'just a string';
+      });
+      const { sdk, handlers } = makeSdk();
+      buildMcpServer(sdk, [odd], { userId: 'u', workspaceId: 'ws' });
+
+      const result = await handlers.get('odd')!({});
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tool failed',
+      });
+    });
+
+    it('registers every tool it is given', () => {
+      const { sdk, handlers } = makeSdk();
+      buildMcpServer(
+        sdk,
+        [
+          def('one', async () => ({})),
+          def('two', async () => ({})),
+          def('three', async () => ({})),
+        ],
+        { userId: 'u', workspaceId: 'ws' },
+      );
+
+      expect([...handlers.keys()]).toEqual(['one', 'two', 'three']);
+    });
+  });
+
+  describe('tool name qualification', () => {
+    it('round-trips a qualified name', () => {
+      const qualified = toQualifiedToolName('send_slack_message');
+      expect(qualified).toBe(`mcp__${MCP_SERVER_NAME}__send_slack_message`);
+      expect(stripQualifiedToolName(qualified)).toBe('send_slack_message');
+    });
+
+    it('leaves an unqualified name alone', () => {
+      expect(stripQualifiedToolName('send_slack_message')).toBe(
+        'send_slack_message',
+      );
+    });
+
+    it('only strips the prefix at the start', () => {
+      const odd = `tool__mcp__${MCP_SERVER_NAME}__x`;
+      expect(stripQualifiedToolName(odd)).toBe(odd);
+    });
+  });
+});

--- a/src/maestro/tools/build-mcp-server.spec.ts
+++ b/src/maestro/tools/build-mcp-server.spec.ts
@@ -43,9 +43,9 @@ describe('buildMcpServer', () => {
     // hoisted or shared, one workspace would act with another's identity.
     it('gives each handler the context its own server was built with', async () => {
       const seen: ToolContext[] = [];
-      const capture = def('whoami', async (_args, ctx) => {
+      const capture = def('whoami', (_args, ctx) => {
         seen.push(ctx);
-        return { ok: true };
+        return Promise.resolve({ ok: true });
       });
 
       const alice: ToolContext = { userId: 'u-alice', workspaceId: 'ws-alice' };
@@ -68,9 +68,9 @@ describe('buildMcpServer', () => {
 
     it('does not let a later build change an earlier context', async () => {
       const seen: ToolContext[] = [];
-      const capture = def('whoami', async (_args, ctx) => {
+      const capture = def('whoami', (_args, ctx) => {
         seen.push(ctx);
-        return {};
+        return Promise.resolve({});
       });
 
       const first: ToolContext = { userId: 'u-1', workspaceId: 'ws-1' };
@@ -91,9 +91,9 @@ describe('buildMcpServer', () => {
 
     it('passes the caller arguments through untouched', async () => {
       let received: Record<string, unknown> | null = null;
-      const echo = def('echo', async (args) => {
+      const echo = def('echo', (args) => {
         received = args;
-        return {};
+        return Promise.resolve({});
       });
       const { sdk, handlers } = makeSdk();
       buildMcpServer(sdk, [echo], { userId: 'u', workspaceId: 'ws' });
@@ -106,7 +106,7 @@ describe('buildMcpServer', () => {
 
   describe('result wrapping', () => {
     it('wraps a handler return as MCP text content', async () => {
-      const ok = def('ok', async () => ({ sent: true, id: 42 }));
+      const ok = def('ok', () => Promise.resolve({ sent: true, id: 42 }));
       const { sdk, handlers } = makeSdk();
       buildMcpServer(sdk, [ok], { userId: 'u', workspaceId: 'ws' });
 
@@ -121,9 +121,9 @@ describe('buildMcpServer', () => {
     // A throwing tool must not escape and kill the turn — the model should see
     // the failure as a result it can react to.
     it('turns a thrown Error into an isError result rather than rejecting', async () => {
-      const boom = def('boom', async () => {
-        throw new Error('slack channel not found');
-      });
+      const boom = def('boom', () =>
+        Promise.reject(new Error('slack channel not found')),
+      );
       const { sdk, handlers } = makeSdk();
       buildMcpServer(sdk, [boom], { userId: 'u', workspaceId: 'ws' });
 
@@ -136,9 +136,8 @@ describe('buildMcpServer', () => {
     });
 
     it('falls back to a generic message when a non-Error is thrown', async () => {
-      const odd = def('odd', async () => {
-        throw 'just a string';
-      });
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- a non-Error rejection is exactly what this tests
+      const odd = def('odd', () => Promise.reject('just a string'));
       const { sdk, handlers } = makeSdk();
       buildMcpServer(sdk, [odd], { userId: 'u', workspaceId: 'ws' });
 
@@ -155,9 +154,9 @@ describe('buildMcpServer', () => {
       buildMcpServer(
         sdk,
         [
-          def('one', async () => ({})),
-          def('two', async () => ({})),
-          def('three', async () => ({})),
+          def('one', () => Promise.resolve({})),
+          def('two', () => Promise.resolve({})),
+          def('three', () => Promise.resolve({})),
         ],
         { userId: 'u', workspaceId: 'ws' },
       );

--- a/src/maestro/tools/confirm.spec.ts
+++ b/src/maestro/tools/confirm.spec.ts
@@ -42,7 +42,10 @@ describe('confirm gate', () => {
   });
 
   describe('confirmCard', () => {
-    const card = confirmCard('Send "hello" to #general on Slack?', 'Yes, send it');
+    const card = confirmCard(
+      'Send "hello" to #general on Slack?',
+      'Yes, send it',
+    );
 
     it('renders through the same question path as ask_user', () => {
       // `kind: 'question'` is what makes the frontend show real Yes/No

--- a/src/maestro/tools/confirm.spec.ts
+++ b/src/maestro/tools/confirm.spec.ts
@@ -1,0 +1,73 @@
+import { confirmCard, isConfirmed } from './confirm';
+
+/**
+ * The confirm gate is what stops Maestro performing an outward action — a real
+ * Slack message, a real post — without asking first. The guarantee it makes is
+ * narrow and worth pinning down: only a literal boolean `true` opens it.
+ */
+describe('confirm gate', () => {
+  describe('isConfirmed', () => {
+    it('proceeds when the workspace has confirmation turned off', () => {
+      expect(isConfirmed(false, {})).toBe(true);
+    });
+
+    it('refuses the first call when confirmation is on', () => {
+      expect(isConfirmed(true, {})).toBe(false);
+    });
+
+    it('proceeds on the re-call the model makes after approval', () => {
+      expect(isConfirmed(true, { confirmed: true })).toBe(true);
+    });
+
+    // The gate exists because a prompt-only policy lets weaker models narrate
+    // "Confirm?" without ever showing buttons. A truthy check here would
+    // reopen that hole from the other side: a model echoing the string
+    // "true", or a stray 1, would be enough to send a real message unasked.
+    it.each([
+      ['the string "true"', 'true'],
+      ['the number 1', 1],
+      ['the string "yes"', 'yes'],
+      ['an object', {}],
+      ['an array', []],
+      ['the string "confirmed"', 'confirmed'],
+    ])('does not accept %s as approval', (_label, value) => {
+      expect(isConfirmed(true, { confirmed: value })).toBe(false);
+    });
+
+    it('does not accept falsy look-alikes either', () => {
+      expect(isConfirmed(true, { confirmed: false })).toBe(false);
+      expect(isConfirmed(true, { confirmed: null })).toBe(false);
+      expect(isConfirmed(true, { confirmed: undefined })).toBe(false);
+    });
+  });
+
+  describe('confirmCard', () => {
+    const card = confirmCard('Send "hello" to #general on Slack?', 'Yes, send it');
+
+    it('renders through the same question path as ask_user', () => {
+      // `kind: 'question'` is what makes the frontend show real Yes/No
+      // buttons with no extra wiring — the whole reason the gate returns a
+      // card rather than plain text.
+      expect(card.kind).toBe('question');
+      expect(card.shown).toBe(true);
+    });
+
+    it('offers exactly two options, affirmative first', () => {
+      expect(card.questions).toHaveLength(1);
+      expect(card.questions[0].options).toEqual(['Yes, send it', 'No, cancel']);
+      expect(card.questions[0].multiSelect).toBe(false);
+    });
+
+    it('carries the caller summary as the question', () => {
+      expect(card.questions[0].question).toBe(
+        'Send "hello" to #general on Slack?',
+      );
+      expect(card.questions[0].header).toBe('Confirm');
+    });
+
+    it('tells the model to re-call with confirmed:true rather than answer in prose', () => {
+      expect(card.instruction).toContain('confirmed:true');
+      expect(card.instruction).toContain('Yes, send it');
+    });
+  });
+});


### PR DESCRIPTION
Maestro had **24 source files and 3 spec files**, and two of those three were written during the BYOK work. The repo overall has 141 specs, so Maestro was the outlier rather than the norm.

The practical cost was already visible: during the activity-row work a shimmer regression came back twice, and a tool row that should have disappeared was "fixed" in the wrong branch twice — because the only way to check behaviour was to open a chat and watch it.

This covers the three places where a break is **invisible until production**. Not a coverage exercise.

## What is covered

**`maestro.service.ts` — the SSE event sequence** (779 lines, previously untested)

The entire frontend activity row is built on the order and shape of these events. The runtime is an async-iterable port, so a fake one scripts any scenario without the SDK, the network, or an API key.

- Event ordering, and a runtime `error` terminating the stream
- **The followups marker**, including one split across deltas — the reason the loop holds back a marker-length tail. Without it `__FOLL` flashes on screen.
- Metadata-only turns (an image search with no prose) still persist and complete
- 100:1 metering, rounded up, minimum 1
- **BYOK turns logged but not billed** — a regression here silently double-charges
- Budget refusal and auth failure both leave no orphan user turn

**`build-mcp-server.ts` — tenant isolation** (64 lines)

Each request builds a server whose handlers close over that request's `ToolContext`. Nothing proved a context could not be hoisted or shared, which would have one workspace acting with another's identity. Assertions compare object **identity**, not field values, so they still fail when a shared reference happens to carry matching ids.

**`confirm.ts` — the approval gate** (50 lines)

If it opens when it shouldn't, Maestro sends real messages unasked. The gate is code rather than a prompt rule because a prompt-only policy lets weaker models narrate "Confirm?" without ever showing buttons; a truthy check would reopen that hole from the other side, so `'true'`, `1`, `'yes'`, `{}` are each tested explicitly.

## Verification

The two subtlest tests were checked by **injecting the bug they guard against**:

- Hoisting the context into a shared variable → both isolation tests fail
- Removing the tail hold-back → both split-marker tests fail

Both reverted cleanly (`git diff` empty) and green again. Without this the tests would only be known to pass, not known to catch anything.

`npx jest src/maestro`: **78 passed, 6 suites**. `npm run build` green, all three specs lint-clean.

## Not in scope

- **Tool wrappers** — they forward to external APIs, so tests would assert against mocks and prove little.
- **`claude-agent-sdk.runtime.ts`** — exercised indirectly by the service tests; worth its own pass later.

## Pre-existing failures

The full suite has **4 failures** (billing, evergreen, db pool). Verified they fail on `main` identically — unrelated to this branch and untouched here.

Spec: `docs/superpowers/specs/2026-08-26-maestro-core-tests-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)