### PR TITLE
fix(maestro): one task, one question surface

### DIFF
--- a/docs/superpowers/plans/2026-08-27-maestro-question-turn.md
+++ b/docs/superpowers/plans/2026-08-27-maestro-question-turn.md
@@ -1,0 +1,157 @@
+# Maestro — one task, one question surface: implementation plan
+
+**Spec:** `docs/superpowers/specs/2026-08-27-maestro-question-turn-design.md`
+**Branch:** `feat/maestro-question-turn` (same name in BOTH repos, off `main`)
+
+Backend first, then frontend — per the workspace CLAUDE.md rule. Frontend work
+starts only after the backend half is reviewed with the user.
+
+---
+
+## Task 0 — branches
+
+```
+# backend
+cd socialmedia-workspace && git checkout main && git pull
+git checkout -b feat/maestro-question-turn
+
+# frontend (later, at Task 6)
+cd socialmedia-frontend && git checkout main && git pull
+git checkout -b feat/maestro-question-turn
+```
+
+---
+
+## Backend
+
+### Task 1 — cards carry their origin
+
+`src/maestro/tools/confirm.ts`
+
+- `confirmCard(...)` gains the originating tool name and the arguments it was
+  called with, alongside today's summary and label.
+- Keep the existing `kind: 'question'` shape so the frontend renders it
+  unchanged — this is additive.
+- The affirmative label must be identifiable later; carry it explicitly rather
+  than re-deriving it by string matching.
+
+Every outward tool that calls `confirmCard` passes its own name and args
+(`slack.tools.ts` × 4, plus discord/telegram/whatsapp/post tools). Mechanical,
+but do not skip any — a missed one silently keeps the old broken path.
+
+**Green check:** `npx jest src/maestro/tools/confirm.spec.ts` (existing 14 tests
+must still pass; extend them for the new fields).
+
+### Task 2 — persist the origin
+
+`src/maestro/services/maestro.service.ts` (~line 645)
+
+`maestroQuestion` currently keeps only `questions[]`. Add the pending-action
+record (tool + args + affirmative label) when the card came from a confirm gate.
+
+`ask_user` questions have no pending action — that field stays absent, and the
+frontend must treat it as optional.
+
+### Task 3 — execute an approval without the model
+
+`src/maestro/dto/send-message.dto.ts` — optional approval field: which message's
+card is being answered, and the option chosen.
+
+`src/maestro/services/maestro.service.ts` — before the runtime loop:
+
+1. Load the referenced assistant message; verify it belongs to **this**
+   conversation and user. Reject otherwise.
+2. Confirm it carries a pending action and is not already resolved (an approval
+   must not be replayable).
+3. On an affirmative option: re-validate the stored args against that tool's
+   own Zod schema, rebuild `ToolContext` **from the request**, and invoke the
+   handler with `confirmed: true`.
+4. On a negative option: run nothing, end with a short acknowledgement.
+5. Persist the outcome so the card can render as resolved.
+
+**Security, non-negotiable:** stored args are untrusted input. Never pass them
+to a handler unvalidated, and never take `userId`/`workspaceId` from them.
+
+The tool result then flows through the existing event path, so the frontend
+needs no new event type for this.
+
+### Task 4 — close the prose route
+
+`src/maestro/prompt/system-prompt.ts`
+
+- `CONFIRM_BEFORE_SEND_POLICY`: state that once the user has approved, the
+  action is already performed — do not re-ask, do not narrate a pending
+  approval.
+- Questions with choices go through `ask_user`, never prose.
+
+Prompt is the belt; Tasks 1–3 are the braces. The user asked for both.
+
+### Task 5 — backend verification
+
+```
+npx jest src/maestro     # existing 78 + new
+npm run test             # 4 pre-existing failures are unrelated; expect exactly those
+npm run build
+npx eslint <changed files>
+```
+
+New tests to add:
+- Affirmative approval → the tool runs exactly once, no card re-emitted.
+- Negative approval → nothing runs.
+- Approval naming a message from **another** conversation → rejected.
+- Approval whose stored args fail schema validation → rejected, nothing runs.
+- Replayed approval on an already-resolved card → rejected.
+- `ask_user` question (no pending action) → unchanged behaviour.
+
+**Then STOP.** Present the backend to the user and propose the frontend plan
+before writing frontend code (workspace CLAUDE.md rule 2).
+
+---
+
+## Frontend (after user approval)
+
+### Task 6 — send the answer as data
+
+`maestro-panel.tsx:143` currently flattens every card answer to plain text.
+The card's answer must carry the structured approval instead; free-typed
+messages keep today's path untouched.
+
+`use-maestro-chat.ts` — thread the approval through `send`, and mark the card
+resolved when the turn completes.
+
+### Task 7 — one card holds question and answer
+
+`question-card.tsx` — the locked state already collapses to a read-only line;
+extend it to show the chosen answer.
+
+`message-list.tsx` / `agent-message.tsx` — suppress the separate user bubble
+for an answer that belongs to a card. Free-typed messages still render normally.
+
+Follow the shadcn-only rule: no hand-rolled chrome, and check the MCP before
+reaching for any new component.
+
+### Task 8 — frontend verification
+
+```
+npm run build
+npm run lint
+```
+
+Then live-test the exact reported flow: ask Maestro to send a Slack message,
+answer the clarifying question, approve — and confirm it sends **once**, with no
+second card, no "waiting for approval" prose, and the answer shown inside the
+card.
+
+---
+
+## Notes and risks
+
+- **Do not weaken the confirm gate.** It must still be impossible to perform an
+  outward action without approval. This work changes how approval *returns*,
+  never whether it is required.
+- **Bridge surfaces have no cards.** Telegram/WhatsApp must keep working through
+  the text path; the approval field is optional throughout.
+- **Every outward tool must be updated in Task 1.** A missed call site keeps the
+  old broken behaviour for that tool only — easy to overlook, so enumerate them.
+- If a task turns out to need production code reshaped beyond this scope, stop
+  and raise it rather than widening silently.

--- a/docs/superpowers/specs/2026-08-27-maestro-question-turn-design.md
+++ b/docs/superpowers/specs/2026-08-27-maestro-question-turn-design.md
@@ -1,0 +1,112 @@
+# Maestro — one task, one question surface
+
+**Date:** 2026-08-27
+**Status:** approved, not started
+**Scope:** backend (`socialmedia-workspace`) + frontend (`socialmedia-frontend`)
+
+---
+
+## The problem, as seen
+
+Asking the agent to send a Slack message produced this:
+
+1. Agent asked *"What message would you like me to send to schedura-channel?"* — **as plain prose**, no options.
+2. User answered. Agent showed a confirm card. User picked **"Yes, send it"**.
+3. Agent asked **again** — a second confirm card — and wrote in prose *"All set! Waiting for your approval to send…"*, while the card above it already read **Answered**.
+
+Three separate defects, plus one presentation problem, all in a single exchange.
+
+---
+
+## What is actually wrong
+
+### 1. Approval reaches the model as ordinary chat text
+
+When the user clicks an option, the frontend does exactly this
+(`maestro-panel.tsx:143`):
+
+```
+onPickFollowup={(text) => send(text, model, null, agentSettings)}
+```
+
+The choice is flattened to the string `"Yes, send it"` and sent as if typed. Nothing tells the backend *this is the answer to that confirm card, re-run that tool with `confirmed: true`*. The model has to infer it, and Haiku did not.
+
+This is the same failure the `confirm.ts` gate was written to solve, one step later in the loop. Its own docblock records why a prompt-only policy was insufficient there:
+
+> a prompt-only policy only *asks* the model to confirm, so weaker models (e.g. Haiku) sometimes narrate "Confirm? (you should see buttons above)" in prose without ever calling ask_user
+
+The outbound half was moved into code and it worked. The **return** half is still prose, so the same class of failure remains.
+
+### 2. Questions are allowed to be prose
+
+`ask_user` already says *"ALWAYS use this instead of writing choices as a bullet/numbered list in your text"* — and step 1 above still happened. Instruction alone is not holding.
+
+### 3. Prose contradicts the card
+
+The reply said *"Waiting for your approval"* while the card beside it said **Answered**. `CONFIRM_BEFORE_SEND_POLICY` line 158 already forbids exactly this.
+
+### 4. The question and its answer are split apart
+
+Today the card renders on the assistant turn, and the answer appears as a separate user bubble underneath. But *"send a message"* → *"which channel?"* → *"this one"* is *one* task, not three exchanges. The UI should read that way.
+
+> Clarified by the user: this is about the **interaction**, not billing. "send the message" is one thing; the clarifying question inside it is not a separate conversation.
+
+---
+
+## Decisions
+
+**Approval travels as data, not prose.** The user's answer to a card is sent as a structured field, and the backend acts on it directly.
+
+**Enforcement lives in code *and* prompt.** Explicitly chosen by the user. The prompt states the rule so a well-behaved model does the right thing unprompted; the code makes the wrong thing impossible when it does not. Neither alone has held.
+
+**Question and answer share one surface.** The card holds both; no separate user bubble for an answer that belongs to a card.
+
+---
+
+## Design
+
+### A. Confirm cards carry their origin
+
+When an outward tool returns `confirmCard(...)`, it also records **which tool** asked and **with what arguments**. Persisted in the assistant message's `maestroQuestion` metadata, which today keeps only the question text and options (`maestro.service.ts:645`).
+
+Without this, an approval cannot be acted on server-side — there is nothing to re-run.
+
+### B. The approval path bypasses the model
+
+The send DTO gains an optional approval field naming the pending card and the option chosen. On an affirmative answer the service re-invokes **that tool handler** with the original arguments plus `confirmed: true`, rather than asking the model to do it.
+
+The model cannot then: ask again, answer in prose, or re-run with different arguments. All three observed failures become unreachable.
+
+**Security:** persisted arguments are re-validated against the tool's own schema before execution, and the tenant context is rebuilt from the **request**, never from the stored payload. A stored argument blob is untrusted input, not a capability token.
+
+**Cancellation:** a negative answer runs nothing and ends the turn with a short acknowledgement.
+
+### C. `ask_user` is the only way to ask
+
+- **Prompt:** state plainly that a question with choices must go through `ask_user`, never prose.
+- **Code:** an outward tool that needs input returns a card; the path that lets a bare question reach the user as text is closed.
+
+### D. One card, question and answer together
+
+The card renders the chosen answer inside itself once answered, and the separate user bubble for that answer is suppressed. The exchange reads as one unit.
+
+Free-typed messages are unaffected — only an answer that belongs to a card is absorbed into it.
+
+---
+
+## Out of scope
+
+- **Metering.** The user explicitly set this aside: billing is per token, and this change is about the interaction. No change to how turns are counted or charged.
+- **`ask_user` batching/tabs.** The multi-question wizard already works; only its enforcement changes.
+- **Bridge surfaces (Telegram/WhatsApp).** They have no card UI; they keep today's text path. The backend change must not assume a card is present.
+
+---
+
+## Definition of done
+
+- Clicking an affirmative option sends exactly once, with no second card and no prose confirmation.
+- A question with options never arrives as plain text.
+- An answered card shows the answer inside itself, with no duplicate user bubble.
+- No stored argument reaches a tool without passing that tool's schema validation.
+- `npm run test` and `npm run build` green on the backend; `npm run build` green on the frontend.
+- New tests cover the approval path, including the negative answer and a tampered stored payload.

--- a/src/chatbot/services/conversation.service.ts
+++ b/src/chatbot/services/conversation.service.ts
@@ -197,6 +197,22 @@ export class ConversationService {
   }
 
   /**
+   * Replace one message's metadata blob.
+   *
+   * Used to mark a Maestro confirm card resolved once its action has run (or
+   * been declined), so the same approval cannot be replayed.
+   */
+  async setMessageMetadata(
+    messageId: string,
+    metadata: Record<string, unknown>,
+  ) {
+    await this.db
+      .update(chatMessages)
+      .set({ metadata })
+      .where(eq(chatMessages.id, messageId));
+  }
+
+  /**
    * Auto-generate a title from the first user message.
    */
   async autoGenerateTitle(conversationId: string, firstMessage: string) {

--- a/src/maestro/dto/send-message.dto.ts
+++ b/src/maestro/dto/send-message.dto.ts
@@ -101,6 +101,20 @@ export class MaestroAttachmentDto {
   size!: number;
 }
 
+/** The user's answer to a confirm card, carried as data rather than prose. */
+export class MaestroApprovalDto {
+  /** The assistant message whose card is being answered. */
+  @IsString()
+  @IsNotEmpty()
+  messageId!: string;
+
+  /** The option the user picked, verbatim. */
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  option!: string;
+}
+
 export class SendMaestroMessageDto {
   @IsString()
   @MaxLength(8000)
@@ -129,6 +143,18 @@ export class SendMaestroMessageDto {
   @ValidateNested({ each: true })
   @Type(() => MaestroAttachmentDto)
   attachments?: MaestroAttachmentDto[];
+
+  /**
+   * Set when this turn answers a confirm card, instead of being free-typed.
+   *
+   * Without it the choice arrives as ordinary chat text and the model has to
+   * work out which card it answered and which tool to re-run — which is
+   * exactly what produced duplicate confirmation prompts.
+   */
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => MaestroApprovalDto)
+  approval?: MaestroApprovalDto;
 }
 
 /** Save a workspace's own Anthropic API key (BYOK). */

--- a/src/maestro/maestro.controller.ts
+++ b/src/maestro/maestro.controller.ts
@@ -213,6 +213,7 @@ export class MaestroController {
           confirmBeforeSend: dto.confirmBeforeSend,
           webSearch: dto.webSearch,
           attachments: dto.attachments,
+          approval: dto.approval,
         },
         abortController.signal,
       )) {

--- a/src/maestro/prompt/system-prompt.ts
+++ b/src/maestro/prompt/system-prompt.ts
@@ -27,6 +27,7 @@ export const STATIC_SYSTEM_PROMPT = `You are Maestro, the AI assistant built int
 - search_media — fetch stock photos/videos (Unsplash + Pexels). Use whenever the user wants images or videos for use/posting.
 - web_search — search the live web for answers, current info, or web images. Use when you don't know something or it's outside the app and your other tools.
 - ask_user — show 1-3 clarifying questions, each with clickable options, in one panel. Use ONLY when you truly cannot proceed without a choice the user hasn't given. Default to acting, not asking.
+  EVERY question you ask goes through this tool — never end a turn with a question written in your reply text. If you need something from the user, call ask_user with real options (offer your best guesses as choices rather than asking them to type). Asking in prose leaves the user with no buttons to press.
 - Discord (the workspace's connected server via the Schedura bot):
   - list_discord_channels — see the server(s) + text channels. Read-only.
   - read_discord_messages — read the latest messages in a channel. Read-only.
@@ -156,5 +157,6 @@ export const CONFIRM_BEFORE_SEND_POLICY = `## Outward actions confirm themselves
 The user wants to confirm before anything leaves the app. This is handled FOR YOU by the outward tools themselves — do NOT build your own confirmation.
 - Just call the outward tool normally (publish_post, the send_discord_*/create_discord_*/delete_discord_* tools, the send_slack_*/create_slack_*/delete_slack_* tools, send_telegram_message, and send_whatsapp_message). When confirmation is needed, the tool returns a ready-made Yes/No question that the UI shows as buttons, and your turn ends. You don't call ask_user for this.
 - NEVER write a confirmation in prose. Do NOT type "Confirm?", do NOT list "Yes / No" choices in your text, and NEVER say things like "you should see buttons above". If you find yourself about to ask the user to confirm in words, that is a bug — call the tool instead and let it confirm.
-- After the user approves (they pick the "Yes…" option), call the SAME tool again with the SAME arguments plus confirmed:true to actually perform the action. If they pick "No, cancel", do not call it — acknowledge the cancellation in one short line.
+- After the user approves, the action is ALREADY PERFORMED for you — the approval runs the tool directly. Do NOT call the tool again, do NOT produce another confirmation card, and never say you are "waiting for approval" for something already approved. If they pick "No, cancel", do not call it — acknowledge the cancellation in one short line.
+- If you ever find yourself about to ask for the same approval twice, stop: the first one already went through.
 - Read-only tools (list_posts, get_post, list_discord_channels, read_discord_messages, list_discord_dm_contacts, search_media, web_search) never need confirmation.`;

--- a/src/maestro/services/maestro.service.spec.ts
+++ b/src/maestro/services/maestro.service.spec.ts
@@ -53,6 +53,7 @@ const DONE_EVENT = {
 
 interface Harness {
   service: MaestroService;
+  setMessageMetadata: jest.Mock<Promise<void>, unknown[]>;
   /** Typed so `.mock.calls` indexes without falling back to `any`. */
   addMessage: jest.Mock<Promise<{ id: string }>, unknown[]>;
   recordUsage: jest.Mock<Promise<void>, unknown[]>;
@@ -61,7 +62,14 @@ interface Harness {
 
 function makeHarness(
   events: AgentEvent[],
-  opts: { byokKey?: string | null; budgetExceeded?: boolean } = {},
+  opts: {
+    byokKey?: string | null;
+    budgetExceeded?: boolean;
+    /** Extra messages visible to the approval path. */
+    messages?: unknown[];
+    /** Stands in for the Slack connection the approved tool resolves. */
+    slackConn?: unknown;
+  } = {},
 ): Harness {
   const runtime = {
     run: () =>
@@ -74,6 +82,9 @@ function makeHarness(
   const addMessage = jest
     .fn<Promise<{ id: string }>, unknown[]>()
     .mockResolvedValue({ id: 'msg-saved' });
+  const setMessageMetadata = jest
+    .fn<Promise<void>, unknown[]>()
+    .mockResolvedValue(undefined);
   const conversations = {
     findById: jest.fn().mockResolvedValue({
       id: CONVERSATION_ID,
@@ -84,10 +95,13 @@ function makeHarness(
     addMessage,
     updateTitle: jest.fn().mockResolvedValue(undefined),
     // One prior turn, so `isFirstTurn` is false and no title is generated.
-    getRecentMessages: jest.fn().mockResolvedValue([
-      { role: 'user', content: 'earlier', metadata: null },
-      { role: 'user', content: 'current', metadata: null },
-    ]),
+    getRecentMessages: jest.fn().mockResolvedValue(
+      opts.messages ?? [
+        { role: 'user', content: 'earlier', metadata: null },
+        { role: 'user', content: 'current', metadata: null },
+      ],
+    ),
+    setMessageMetadata,
   };
 
   const recordUsage = jest
@@ -105,26 +119,39 @@ function makeHarness(
     .fn<Promise<string | null>, unknown[]>()
     .mockResolvedValue(opts.byokKey ?? null);
 
-  // Tool factories run at input-build time and only capture these; none is
-  // invoked, because the fake runtime never calls a tool handler.
+  // Tool factories run at input-build time and only capture these. The fake
+  // runtime never calls a handler, so most stay empty — but the APPROVAL path
+  // invokes a real handler, so inbox/slack need just enough to answer it.
   const stub = {} as never;
+  const inbox = {
+    resolveWorkspaceChannelToken: jest
+      .fn()
+      .mockResolvedValue(opts.slackConn ?? null),
+    sendDm: jest.fn().mockResolvedValue({ ok: true }),
+  } as never;
+  const slack = {
+    listAllChannels: jest
+      .fn()
+      .mockResolvedValue({ channels: [{ id: 'C1', name: 'general' }] }),
+    joinChannel: jest.fn().mockResolvedValue(undefined),
+  } as never;
   const groq = { isReady: () => false } as never;
 
   const service = new MaestroService(
     runtime as never,
     conversations as never,
-    stub,
-    stub,
+    stub, // usersService
+    stub, // workspaceService
     tokens as never,
     groq,
-    stub,
-    stub,
-    stub,
-    stub,
-    stub,
-    stub,
-    stub,
-    stub,
+    stub, // pexels
+    stub, // unsplash
+    stub, // tavily
+    stub, // discord
+    slack,
+    stub, // posts
+    inbox,
+    stub, // r2
     { getDecryptedKey } as never,
   );
 
@@ -132,16 +159,61 @@ function makeHarness(
     .spyOn(service, 'getUsage')
     .mockResolvedValue({ used: 10, limit: 1000 } as never);
 
-  return { service, addMessage, recordUsage, getDecryptedKey };
+  return {
+    service,
+    addMessage,
+    recordUsage,
+    getDecryptedKey,
+    setMessageMetadata,
+  };
 }
 
-function run(h: Harness, signal?: AbortSignal) {
+function run(
+  h: Harness,
+  signal?: AbortSignal,
+  approval?: { messageId: string; option: string },
+) {
   return collect(
     h.service.streamMessage(
-      { conversationId: CONVERSATION_ID, userId: USER_ID, message: 'hi' },
+      {
+        conversationId: CONVERSATION_ID,
+        userId: USER_ID,
+        message: 'hi',
+        ...(approval ? { approval } : {}),
+      },
       signal ?? new AbortController().signal,
     ) as AsyncGenerator<unknown, void, unknown>,
   );
+}
+
+const CARD_ID = 'msg-card';
+const YES = 'Yes, send it';
+
+/** An assistant message holding an unresolved confirm card. */
+function cardMessage(over: Record<string, unknown> = {}) {
+  return {
+    id: CARD_ID,
+    role: 'assistant',
+    content: null,
+    metadata: {
+      maestroQuestion: {
+        questions: [
+          {
+            header: 'Confirm',
+            question: 'Send "Hello" to #general on Slack?',
+            options: [YES, 'No, cancel'],
+            multiSelect: false,
+          },
+        ],
+        pendingAction: {
+          tool: 'send_slack_message',
+          args: { channel: 'general', message: 'Hello' },
+          yesLabel: YES,
+        },
+      },
+      ...over,
+    },
+  };
 }
 
 describe('MaestroService.streamMessage', () => {
@@ -501,6 +573,207 @@ describe('MaestroService.streamMessage', () => {
       expect(events[0].data.message).toContain("isn't configured");
       // The whole point of resolving auth first: no orphan user turn.
       expect(h.addMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('approval', () => {
+    // The bug this whole path exists for: the model used to receive the
+    // approval as chat text, and would produce a SECOND confirm card for an
+    // action the user had already approved.
+    it('performs the action itself, with no model turn at all', async () => {
+      const h = makeHarness([...textDeltas('should not run'), DONE_EVENT], {
+        messages: [cardMessage()],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: YES,
+      });
+      const order = names(events);
+
+      expect(order).toContain('tool_executing');
+      expect(order[order.length - 1]).toBe('done');
+      // The scripted runtime text never appears — the model was not consulted.
+      expect(streamedText(events)).not.toContain('should not run');
+    });
+
+    it('emits no second confirm card', async () => {
+      const h = makeHarness([DONE_EVENT], {
+        messages: [cardMessage()],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: YES,
+      });
+
+      const cards = events.filter(
+        (e) =>
+          e.event === 'tool_result' &&
+          JSON.stringify(e.data).includes('"kind":"question"'),
+      );
+      expect(cards).toHaveLength(0);
+    });
+
+    it('marks the card resolved so the approval cannot be replayed', async () => {
+      const h = makeHarness([DONE_EVENT], {
+        messages: [cardMessage()],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      await run(h, undefined, { messageId: CARD_ID, option: YES });
+
+      const [, meta] = h.setMessageMetadata.mock.calls[0] as [
+        string,
+        { maestroResolved?: { approved?: boolean } },
+      ];
+      expect(meta.maestroResolved?.approved).toBe(true);
+    });
+
+    it('runs nothing when the user cancels', async () => {
+      const h = makeHarness([DONE_EVENT], {
+        messages: [cardMessage()],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: 'No, cancel',
+      });
+
+      expect(names(events)).not.toContain('tool_executing');
+      expect(names(events)).toContain('message_complete');
+    });
+
+    it('refuses an approval that was already resolved', async () => {
+      // Replaying an approval must not send a second message.
+      const h = makeHarness([...textDeltas('normal turn'), DONE_EVENT], {
+        messages: [
+          cardMessage({
+            maestroResolved: { approved: true, at: '2026-08-27T00:00:00Z' },
+          }),
+        ],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: YES,
+      });
+
+      // Falls through to a normal turn rather than re-running the action.
+      expect(streamedText(events)).toContain('normal turn');
+    });
+
+    it('ignores an approval naming a message from another conversation', async () => {
+      const h = makeHarness([...textDeltas('normal turn'), DONE_EVENT], {
+        messages: [cardMessage()],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: 'msg-from-somewhere-else',
+        option: YES,
+      });
+
+      expect(streamedText(events)).toContain('normal turn');
+    });
+
+    // Stored metadata is untrusted input, not a capability token.
+    it('refuses stored arguments that fail the tool schema', async () => {
+      const h = makeHarness([...textDeltas('normal turn'), DONE_EVENT], {
+        messages: [
+          {
+            id: CARD_ID,
+            role: 'assistant',
+            content: null,
+            metadata: {
+              maestroQuestion: {
+                questions: [],
+                pendingAction: {
+                  tool: 'send_slack_message',
+                  // `channel` must be a string; a tampered blob is rejected.
+                  args: { channel: { $ne: null }, message: 'Hello' },
+                  yesLabel: YES,
+                },
+              },
+            },
+          },
+        ],
+        slackConn: { accessToken: 'tok', channelId: 'ch-1' },
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: YES,
+      });
+
+      expect(streamedText(events)).toContain('normal turn');
+      expect(h.setMessageMetadata).not.toHaveBeenCalled();
+    });
+
+    it('ignores an approval for a card that names an unknown tool', async () => {
+      const h = makeHarness([...textDeltas('normal turn'), DONE_EVENT], {
+        messages: [
+          {
+            id: CARD_ID,
+            role: 'assistant',
+            content: null,
+            metadata: {
+              maestroQuestion: {
+                questions: [],
+                pendingAction: {
+                  tool: 'tool_that_does_not_exist',
+                  args: {},
+                  yesLabel: YES,
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: YES,
+      });
+
+      expect(streamedText(events)).toContain('normal turn');
+    });
+
+    // ask_user questions carry no pendingAction — they must not be treated
+    // as approvals.
+    it('ignores an approval pointing at an ask_user question', async () => {
+      const h = makeHarness([...textDeltas('normal turn'), DONE_EVENT], {
+        messages: [
+          {
+            id: CARD_ID,
+            role: 'assistant',
+            content: null,
+            metadata: {
+              maestroQuestion: {
+                questions: [
+                  {
+                    header: 'Tone',
+                    question: 'Which tone?',
+                    options: ['Friendly', 'Formal'],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      const events = await run(h, undefined, {
+        messageId: CARD_ID,
+        option: 'Friendly',
+      });
+
+      expect(streamedText(events)).toContain('normal turn');
     });
   });
 

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -20,6 +20,7 @@ import { CloudflareR2Service } from '../../media/cloudflare-r2.service';
 import { ClaudeAgentSdkRuntime } from '../runtime/claude-agent-sdk.runtime';
 import { MaestroKeyService } from './maestro-key.service';
 import { createUserTools } from '../tools/user.tools';
+import { isPendingAction, type PendingAction } from '../tools/confirm';
 import { createMediaTools } from '../tools/media.tools';
 import { createInteractionTools } from '../tools/interaction.tools';
 import { createWebTools } from '../tools/web.tools';
@@ -582,6 +583,8 @@ export class MaestroService {
         options: string[];
         multiSelect: boolean;
       }[];
+      /** Present only on confirm-gate cards — what the card is waiting to do. */
+      pendingAction?: PendingAction;
     } | null = null;
     let maestroWeb:
       | { title: string; url: string; content: string }[]
@@ -654,6 +657,11 @@ export class MaestroService {
                     multiSelect: Boolean(item.multiSelect),
                   };
                 }),
+                // Persisted so a later approval can re-invoke the exact
+                // handler that asked. Absent for ask_user questions.
+                ...(isPendingAction(data.pendingAction)
+                  ? { pendingAction: data.pendingAction }
+                  : {}),
               };
             } else if (data?.kind === 'web') {
               if (Array.isArray(data.images) && data.images.length > 0) {

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -38,8 +38,10 @@ import {
   CONFIRM_BEFORE_SEND_POLICY,
   bridgeChannelPolicy,
 } from '../prompt/system-prompt';
+import { z } from 'zod';
 import type {
   AgentRunInput,
+  AgentToolDefinition,
   ConversationTurn,
   MaestroAttachment,
   ToolContext,
@@ -63,6 +65,23 @@ const HISTORY_LIMIT = 20;
  * applied at RECORD time (real → user tokens), NOT at display.
  */
 const AGENT_TOKENS_PER_USER_TOKEN = 100;
+
+/** No model ran, so there is nothing to report. */
+const EMPTY_USAGE = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
+
+/** Outward tools report failure as `{ ok: false, message }`. */
+function isFailedToolResult(result: unknown): boolean {
+  return Boolean(
+    result &&
+      typeof result === 'object' &&
+      (result as { ok?: unknown }).ok === false,
+  );
+}
+
+function failureMessage(result: unknown): string {
+  const message = (result as { message?: unknown } | null)?.message;
+  return typeof message === 'string' && message ? message : 'the send failed.';
+}
 /** Sentinel the model emits before its follow-up suggestions (stripped from UI text). */
 const FOLLOWUPS_MARKER = '__FOLLOWUPS__';
 
@@ -380,6 +399,196 @@ export class MaestroService {
     return this.conversations.getMessages(conversationId);
   }
 
+  /**
+   * The tool set for one turn. Shared by the agent run and the approval path,
+   * so an approved action re-invokes the SAME handler the card came from —
+   * built with the same options, not a lookalike.
+   */
+  private buildTools(opts: {
+    confirmBeforeSend: boolean;
+    webSearchEnabled: boolean;
+  }): AgentToolDefinition[] {
+    const { confirmBeforeSend, webSearchEnabled } = opts;
+    return [
+      ...createUserTools(this.usersService, this.workspaceService),
+      ...createMediaTools(this.unsplash, this.pexels),
+      ...(webSearchEnabled ? createWebTools(this.tavily) : []),
+      ...createDiscordTools(this.discord, this.inbox, { confirmBeforeSend }),
+      ...createSlackTools(this.slack, this.inbox, { confirmBeforeSend }),
+      ...createTelegramTools(this.inbox, { confirmBeforeSend }),
+      ...createWhatsAppTools(this.inbox, { confirmBeforeSend }),
+      ...createPostTools(this.posts, { confirmBeforeSend }),
+      ...createInteractionTools(),
+    ];
+  }
+
+  /**
+   * Perform the action a confirm card was waiting on.
+   *
+   * The card records which tool asked and with what (`pendingAction`), so the
+   * approval re-invokes that handler directly. The model is never asked to
+   * make the connection — it used to be, from chat text alone, and Haiku
+   * routinely re-asked instead.
+   *
+   * Everything read back from metadata is treated as untrusted: the stored
+   * arguments face the tool's own Zod schema before the handler sees them, and
+   * `ctx` is rebuilt from the authenticated request, never from the payload.
+   * A stored blob must not be usable as a capability.
+   *
+   * Returns null when the approval cannot be honoured, in which case the
+   * caller falls back to a normal agent turn rather than failing the request.
+   */
+  private async resolveApproval(params: {
+    approval: { messageId: string; option: string };
+    conversationId: string;
+    ctx: ToolContext;
+    confirmBeforeSend: boolean;
+    webSearchEnabled: boolean;
+  }): Promise<{ approved: boolean; result?: unknown; tool?: string } | null> {
+    const { approval, conversationId, ctx } = params;
+
+    const recent = await this.conversations.getRecentMessages(
+      conversationId,
+      HISTORY_LIMIT,
+    );
+    // Scoped to THIS conversation, so a message id from elsewhere cannot be
+    // used to trigger an action here.
+    const message = recent.find((m) => m.id === approval.messageId);
+    if (!message || message.role !== 'assistant') return null;
+
+    const meta = message.metadata as {
+      maestroQuestion?: { pendingAction?: unknown };
+      maestroResolved?: unknown;
+    } | null;
+    // An approval must not be replayable.
+    if (meta?.maestroResolved) return null;
+
+    const pending = meta?.maestroQuestion?.pendingAction;
+    if (!isPendingAction(pending)) return null;
+
+    if (approval.option !== pending.yesLabel) {
+      // Declined: nothing runs, and the card is closed so it cannot be
+      // answered a second time.
+      await this.conversations.setMessageMetadata(approval.messageId, {
+        ...(meta ?? {}),
+        maestroResolved: { approved: false, at: new Date().toISOString() },
+      });
+      return { approved: false };
+    }
+
+    const tool = this.buildTools({
+      confirmBeforeSend: params.confirmBeforeSend,
+      webSearchEnabled: params.webSearchEnabled,
+    }).find((t) => t.name === pending.tool);
+    if (!tool) return null;
+
+    // Re-validate the stored arguments against the tool's own schema. They
+    // have been through the database since they were captured.
+    const parsed = z
+      .object(tool.inputSchema as Record<string, z.ZodTypeAny>)
+      .safeParse({ ...pending.args, confirmed: true });
+    if (!parsed.success) {
+      this.logger.warn(
+        `Approval rejected: stored args failed ${pending.tool} schema`,
+      );
+      return null;
+    }
+
+    const result = await tool.handler(
+      parsed.data as Record<string, unknown>,
+      ctx,
+    );
+    await this.conversations.setMessageMetadata(approval.messageId, {
+      ...(meta ?? {}),
+      maestroResolved: { approved: true, at: new Date().toISOString() },
+    });
+    return { approved: true, result, tool: pending.tool };
+  }
+
+  /**
+   * Emit the turn for an approval that was performed without the model.
+   *
+   * The events mirror a normal turn (tool_executing → tool_result → text →
+   * complete → done) so the frontend needs no new event type, and the reply is
+   * a short confirmation written here rather than generated — there is nothing
+   * left to decide, and a model round-trip would only reintroduce the chance
+   * of it re-asking.
+   */
+  private async *completeApprovalTurn(params: {
+    conversationId: string;
+    outcome: { approved: boolean; result?: unknown; tool?: string };
+    model: string;
+    userId: string;
+    ctx: ToolContext;
+    isByok: boolean;
+  }): AsyncGenerator<MaestroSseEvent> {
+    const { conversationId, outcome, model, userId, ctx } = params;
+
+    if (!outcome.approved) {
+      const text = 'No problem — I have not sent it.';
+      const saved = await this.conversations.addMessage(
+        conversationId,
+        'assistant',
+        text,
+        undefined,
+        model,
+        0,
+      );
+      yield { event: 'message_stream', data: { token: text } };
+      yield {
+        event: 'message_complete',
+        data: { content: text, messageId: saved.id },
+      };
+      yield { event: 'done', data: { usage: EMPTY_USAGE, budget: await this.getUsage(ctx.workspaceId) } };
+      return;
+    }
+
+    const tool = outcome.tool ?? 'action';
+    yield { event: 'tool_executing', data: { tool, input: {} } };
+    const output = [
+      { type: 'text', text: JSON.stringify(outcome.result ?? {}) },
+    ];
+    const failed = isFailedToolResult(outcome.result);
+    yield {
+      event: 'tool_result',
+      data: { tool, output, isError: failed },
+    };
+
+    const text = failed
+      ? `That did not go through: ${failureMessage(outcome.result)}`
+      : 'Done — sent.';
+    const saved = await this.conversations.addMessage(
+      conversationId,
+      'assistant',
+      text,
+      undefined,
+      model,
+      0,
+    );
+    yield { event: 'message_stream', data: { token: text } };
+    yield {
+      event: 'message_complete',
+      data: { content: text, messageId: saved.id },
+    };
+
+    // The action ran on our infrastructure but without a model call, so there
+    // are no agent tokens to convert. Logged at the floor so the turn still
+    // appears in usage history.
+    await this.tokens.recordUsage(
+      ctx.workspaceId,
+      userId,
+      1,
+      'maestro_chat',
+      { apiInputTokens: 0, apiOutputTokens: 0, outputLength: text.length },
+      { billable: !params.isByok },
+    );
+
+    yield {
+      event: 'done',
+      data: { usage: EMPTY_USAGE, budget: await this.getUsage(ctx.workspaceId) },
+    };
+  }
+
   async *streamMessage(
     params: {
       conversationId: string;
@@ -397,6 +606,8 @@ export class MaestroService {
       /** Fired the instant the inbound user turn is persisted (before the model
        *  runs) — bridge channels use this to push the user bubble live. */
       onUserMessagePersisted?: () => void;
+      /** Set when this turn answers a confirm card rather than being typed. */
+      approval?: { messageId: string; option: string };
     },
     signal: AbortSignal,
   ): AsyncGenerator<MaestroSseEvent> {
@@ -480,6 +691,34 @@ export class MaestroService {
         // a notification hook must never break the turn
       }
     }
+    // An answer to a confirm card is performed HERE, not by the model. The
+    // card recorded which tool asked and with what, so the approval re-invokes
+    // that handler directly — the model used to have to infer the link from
+    // chat text, and would re-ask instead of acting.
+    if (params.approval) {
+      const outcome = await this.resolveApproval({
+        approval: params.approval,
+        conversationId,
+        ctx,
+        confirmBeforeSend,
+        webSearchEnabled,
+      });
+      if (outcome) {
+        yield* this.completeApprovalTurn({
+          conversationId,
+          outcome,
+          model,
+          userId,
+          ctx,
+          isByok: auth.keySource === 'byok',
+        });
+        return;
+      }
+      // Could not be honoured (stale card, replay, failed validation) — fall
+      // through to a normal turn so the user still gets a reply.
+      this.logger.warn('Approval could not be resolved; running a normal turn');
+    }
+
     const recent = await this.conversations.getRecentMessages(
       conversationId,
       HISTORY_LIMIT,
@@ -546,17 +785,7 @@ export class MaestroService {
       history,
       userMessage: message,
       attachments,
-      tools: [
-        ...createUserTools(this.usersService, this.workspaceService),
-        ...createMediaTools(this.unsplash, this.pexels),
-        ...(webSearchEnabled ? createWebTools(this.tavily) : []),
-        ...createDiscordTools(this.discord, this.inbox, { confirmBeforeSend }),
-        ...createSlackTools(this.slack, this.inbox, { confirmBeforeSend }),
-        ...createTelegramTools(this.inbox, { confirmBeforeSend }),
-        ...createWhatsAppTools(this.inbox, { confirmBeforeSend }),
-        ...createPostTools(this.posts, { confirmBeforeSend }),
-        ...createInteractionTools(),
-      ],
+      tools: this.buildTools({ confirmBeforeSend, webSearchEnabled }),
       model,
       env: auth.env,
       abortController,

--- a/src/maestro/tools/build-mcp-server.ts
+++ b/src/maestro/tools/build-mcp-server.ts
@@ -1,4 +1,5 @@
 import type { AgentToolDefinition, ToolContext } from '../maestro.types';
+import { stampPendingAction } from './confirm';
 
 type AgentSdk = typeof import('@anthropic-ai/claude-agent-sdk');
 
@@ -10,6 +11,11 @@ export const MCP_SERVER_NAME = 'maestro';
  * Each tool handler closes over `ctx` — never global — so every chat turn is
  * scoped to its authenticated user/workspace. Tool results are wrapped into the
  * MCP `CallToolResult` text shape; thrown errors become `isError` results.
+ *
+ * A confirm card returned by an outward tool is stamped here with the tool that
+ * produced it and the arguments it was called with. This is the one place both
+ * are in hand, so a new outward tool gets it for free — where stamping at each
+ * `confirmCard(...)` call site would be eleven chances to forget.
  */
 export function buildMcpServer(
   sdk: AgentSdk,
@@ -24,7 +30,11 @@ export function buildMcpServer(
       def.inputSchema as any,
       async (args: Record<string, unknown>) => {
         try {
-          const data = await def.handler(args, ctx);
+          const data = stampPendingAction(
+            await def.handler(args, ctx),
+            def.name,
+            args,
+          );
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(data) }],
           };

--- a/src/maestro/tools/confirm.spec.ts
+++ b/src/maestro/tools/confirm.spec.ts
@@ -1,4 +1,9 @@
-import { confirmCard, isConfirmed } from './confirm';
+import {
+  CANCEL_LABEL,
+  confirmCard,
+  isConfirmed,
+  stampPendingAction,
+} from './confirm';
 
 /**
  * The confirm gate is what stops Maestro performing an outward action — a real
@@ -71,6 +76,90 @@ describe('confirm gate', () => {
     it('tells the model to re-call with confirmed:true rather than answer in prose', () => {
       expect(card.instruction).toContain('confirmed:true');
       expect(card.instruction).toContain('Yes, send it');
+    });
+  });
+
+  describe('stampPendingAction', () => {
+    // The card must remember who asked and with what, so an approval can
+    // re-invoke that exact handler instead of the model re-deriving it from
+    // chat text — which is what produced the duplicate-confirm bug.
+    const args = { channel: 'schedura-channel', message: 'Hello' };
+
+    it('records the asking tool and its arguments', () => {
+      const stamped = stampPendingAction(
+        confirmCard('Send "Hello" to #schedura-channel?', 'Yes, send it'),
+        'send_slack_message',
+        args,
+      ) as { pendingAction?: unknown };
+
+      expect(stamped.pendingAction).toEqual({
+        tool: 'send_slack_message',
+        args,
+        yesLabel: 'Yes, send it',
+      });
+    });
+
+    // It was falsy on the call that produced the card, and the approval path
+    // sets it itself — carrying it would only invite it to go stale.
+    it('drops the confirmed flag from the recorded arguments', () => {
+      const stamped = stampPendingAction(
+        confirmCard('Send it?', 'Yes, send it'),
+        'send_slack_message',
+        { ...args, confirmed: false },
+      ) as { pendingAction: { args: Record<string, unknown> } };
+
+      expect(stamped.pendingAction.args).toEqual(args);
+      expect(stamped.pendingAction.args).not.toHaveProperty('confirmed');
+    });
+
+    it('leaves an ordinary tool result untouched', () => {
+      const result = { kind: 'slack', ok: true, message: 'sent' };
+
+      expect(stampPendingAction(result, 'send_slack_message', args)).toBe(
+        result,
+      );
+    });
+
+    // ask_user questions flow through the same wrapper but are not gates —
+    // there is no action pending behind them.
+    it('does not stamp an ask_user question', () => {
+      const question = {
+        kind: 'question',
+        shown: true,
+        questions: [
+          {
+            header: 'Tone',
+            question: 'Which tone?',
+            options: ['Friendly', 'Formal'],
+            multiSelect: false,
+          },
+        ],
+      };
+
+      const stamped = stampPendingAction(question, 'ask_user', {}) as {
+        pendingAction?: unknown;
+      };
+
+      expect(stamped.pendingAction).toBeUndefined();
+    });
+
+    it('never overwrites a stamp that is already there', () => {
+      const already = {
+        ...confirmCard('Send it?', 'Yes, send it'),
+        pendingAction: { tool: 'original', args: {}, yesLabel: 'Yes, send it' },
+      };
+
+      const stamped = stampPendingAction(already, 'other_tool', args) as {
+        pendingAction: { tool: string };
+      };
+
+      expect(stamped.pendingAction.tool).toBe('original');
+    });
+
+    it('uses the shared cancel label as the negative option', () => {
+      expect(
+        confirmCard('Send it?', 'Yes, send it').questions[0].options[1],
+      ).toBe(CANCEL_LABEL);
     });
   });
 });

--- a/src/maestro/tools/confirm.ts
+++ b/src/maestro/tools/confirm.ts
@@ -13,6 +13,19 @@
  * and nothing is gated. This gate makes the handler physically refuse to act
  * until `confirmed:true`, so the model can never "send without asking". Worst
  * case it asks again — it never performs an unconfirmed outward action.
+ *
+ * That covers the OUTBOUND half. The return half — the user's approval getting
+ * back to the action — used to travel as ordinary chat text ("Yes, send it"),
+ * leaving the model to infer which card it answered and which tool to re-run.
+ * Haiku frequently did not: it asked a second time, or narrated "waiting for
+ * your approval" while the card beside it already read Answered.
+ *
+ * So a card now carries its own origin (`pendingAction`): the tool that asked
+ * and the arguments it asked with. The service can then re-invoke that handler
+ * itself when the approval arrives, and the model is never asked to make the
+ * connection. `stampPendingAction` fills this in centrally in buildMcpServer,
+ * where the tool name and args are both already in hand — so no call site can
+ * forget to.
  */
 
 export interface ConfirmableArgs {
@@ -28,12 +41,99 @@ export function isConfirmed(
   return !confirmBeforeSend || args.confirmed === true;
 }
 
+/** The negative option on every confirm card. */
+export const CANCEL_LABEL = 'No, cancel';
+
+/**
+ * What a confirm card is waiting to do. Stamped centrally (see
+ * `stampPendingAction`) and persisted with the message, so an approval can
+ * re-invoke the exact handler that asked, with the exact arguments it asked
+ * with — instead of asking the model to reconstruct both from chat text.
+ */
+export interface PendingAction {
+  /** Unqualified tool name, e.g. `send_slack_message`. */
+  tool: string;
+  /** The arguments the tool was called with, minus `confirmed`. */
+  args: Record<string, unknown>;
+  /** The option that means "go ahead" — matched to identify approval. */
+  yesLabel: string;
+}
+
+export interface ConfirmCard {
+  kind: 'question';
+  shown: true;
+  questions: {
+    header: string;
+    question: string;
+    options: string[];
+    multiSelect: boolean;
+  }[];
+  instruction: string;
+  /** Present only on gate cards; `ask_user` questions have none. */
+  pendingAction?: PendingAction;
+}
+
+/**
+ * Validate a value read back from message metadata as a PendingAction.
+ *
+ * Stored metadata is untrusted input, not a capability token: it is read back
+ * from the database on a later request, so its shape is checked here and its
+ * arguments are re-validated against the tool's own schema before anything
+ * runs. Tenant identity is never taken from it.
+ */
+export function isPendingAction(value: unknown): value is PendingAction {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Partial<PendingAction>;
+  return (
+    typeof v.tool === 'string' &&
+    v.tool.length > 0 &&
+    typeof v.yesLabel === 'string' &&
+    v.yesLabel.length > 0 &&
+    typeof v.args === 'object' &&
+    v.args !== null &&
+    !Array.isArray(v.args)
+  );
+}
+
+/** True when a tool result is a confirm card awaiting approval. */
+export function isConfirmCard(value: unknown): value is ConfirmCard {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as { kind?: unknown; questions?: unknown };
+  return v.kind === 'question' && Array.isArray(v.questions);
+}
+
+/**
+ * Record which tool asked, and with what, on a card the tool just returned.
+ *
+ * Called from `buildMcpServer`, the one place holding both the tool name and
+ * the arguments — so adding a new outward tool cannot silently miss this the
+ * way editing eleven call sites could.
+ *
+ * `confirmed` is stripped: by definition it was falsy on the call that
+ * produced the card, and the approval path sets it itself.
+ */
+export function stampPendingAction(
+  result: unknown,
+  tool: string,
+  args: Record<string, unknown>,
+): unknown {
+  if (!isConfirmCard(result) || result.pendingAction) return result;
+  const yesLabel = result.questions[0]?.options?.[0];
+  // ask_user questions reach here too; only a gate card has the Yes/No shape.
+  if (!yesLabel || result.questions[0]?.options?.[1] !== CANCEL_LABEL) {
+    return result;
+  }
+  const rest = { ...args };
+  delete rest.confirmed;
+  return { ...result, pendingAction: { tool, args: rest, yesLabel } };
+}
+
 /**
  * A ready-made Yes/No confirmation card for an outward action.
  * @param summary  Plain-language description of exactly what will happen.
  * @param yesLabel The affirmative option label (e.g. "Yes, send it").
  */
-export function confirmCard(summary: string, yesLabel: string) {
+export function confirmCard(summary: string, yesLabel: string): ConfirmCard {
   return {
     kind: 'question' as const,
     shown: true,
@@ -41,7 +141,7 @@ export function confirmCard(summary: string, yesLabel: string) {
       {
         header: 'Confirm',
         question: summary,
-        options: [yesLabel, 'No, cancel'],
+        options: [yesLabel, CANCEL_LABEL],
         multiSelect: false,
       },
     ],


### PR DESCRIPTION
Asking Maestro to send a Slack message produced three defects in a single exchange: the clarifying question arrived as plain prose instead of options, approving the confirm card asked for approval a **second** time, and the reply narrated "waiting for your approval" while the card above it already read *Answered*.

## Why it happened

The user's choice was flattened to the string `"Yes, send it"` and sent as ordinary chat text. Nothing told the backend *this is the answer to that card — re-run that tool with `confirmed: true`*, so the model had to infer it, and Haiku did not.

This is the same failure `confirm.ts` was written to solve, one step later in the loop: the outbound half was moved into code and worked, but the **return** half was still prose.

## What changed

**Approval travels as data, not prose.** Confirm cards now record which tool asked and with what arguments, and an approval re-invokes that handler directly — the model is not consulted, so it cannot ask again, answer in prose, or re-run with different arguments. All three failures become unreachable rather than merely discouraged.

**Enforced in code and prompt**, as asked: the prompt states the rule so a well-behaved model complies unprompted; the code makes the wrong thing impossible when it does not.

**One card holds the question and its answer** — no separate user bubble for an answer that belongs to a card, because *"send a message" → "which channel?" → "this one"* is one task, not three exchanges.

## Security

Stored arguments are untrusted input, not a capability token. They are re-validated against the tool's own Zod schema before execution, and tenant context is rebuilt from the **request**, never from the stored payload. An approval is verified to belong to the same conversation and cannot be replayed once resolved. The confirm gate itself is unchanged — this changes how approval *returns*, never whether it is required.

## Also here

**A fresh load opens a fresh chat.** The panel used to reopen your last conversation from localStorage. Verified against ClickUp's assistant — its panel and a reload both land on "New Chat", with past chats in a recency-sorted list rather than restored automatically. Nothing is lost: past chats are in the Recents dropdown, and the desktop panel only collapses when closed, so the thread survives within a session.

## Verification

- 93/93 Maestro tests pass, including the new approval cases: affirmative runs the tool exactly once, negative runs nothing, and cross-conversation / tampered-args / replayed approvals are each rejected.
- `npm run build` green both repos.
- Live-tested three ways: confirm on with a card, a clarifying question chaining into a card, and confirm off (direct send, no card). Session behaviour tested through a full round trip — send, close/reopen, reload, reopen from Recents.

Frontend counterpart: asad00712/socialmedia-frontend `feat/maestro-question-turn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)