### PR TITLE
feat(maestro): campaign + channel read tools, and answers you can click

### DIFF
--- a/docs/superpowers/plans/2026-08-16-campaign-messaging-channels.md
+++ b/docs/superpowers/plans/2026-08-16-campaign-messaging-channels.md
@@ -1,0 +1,670 @@
+# Campaign Messaging Channels (Slack + Discord) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let campaigns (bulk + drip) publish to Slack and Discord using a chat-style composer (one message + one optional media) with a required destination picker.
+
+**Architecture:** Backend-first. A new optional `destination` field on `PostTarget` carries the Slack/Discord channel id from composer → post → publisher. Two thin publishers wrap the existing `SlackService`/`DiscordService` (no new API clients) and register in `PublisherFactory`. Frontend adds a `'message'` post type for slack/discord, a `MessageComposer` (message box + destination picker + single media), and launch validation requiring a destination.
+
+**Tech Stack:** NestJS + Drizzle (backend, repo `socialmedia-workspace`); Vite + React 19 + TS + Tailwind 3 + shadcn + TanStack Query (frontend, worktree `socialmedia-frontend-campaigns`). Both on branch `feat/campaign-messaging-channels` off `main`.
+
+**Spec:** `socialmedia-workspace/docs/superpowers/specs/2026-08-16-campaign-messaging-channels-design.md`
+
+## Global Constraints
+
+- **Scope: Slack + Discord ONLY.** Do NOT add telegram/whatsapp to `PLATFORM_POST_TYPES.types` or `PublisherFactory` — both are deferred (WhatsApp needs message templates; Telegram bots can't enumerate chats).
+- **NO DB migration.** `posts.targets` is `jsonb().$type<PostTarget[]>()` and `PostTarget` is a plain TS interface — adding an optional nested field is a pure type change.
+- **shadcn-only UI**, theme tokens only (no hex, no arbitrary Tailwind colors like `bg-blue-500`). Use shadcn MCP to confirm any new component.
+- **Never** `git add .`/`-A`. Surgical `git add <path>` only (FE `.env` is git-tracked with secrets; BE `.env` is gitignored with secrets).
+- **Bulk behaviour for non-messaging platforms stays byte-for-byte unchanged.**
+- Slack posts to public channels without joining (`chat:write.public` already granted); the picker flags/disables private channels where `isMember === false`.
+- Discord publisher uses the shared env `DISCORD_BOT_TOKEN` (ignores `accessToken`); Slack uses the per-channel decrypted token.
+- Destination is **required** — a messaging slot without a destination blocks launch.
+- Media cap = 1 (text-only allowed; media optional; never >1).
+
+---
+
+## BACKEND (do all backend tasks before frontend)
+
+### Task 1: `destination` field on `PostTarget`
+
+**Files:**
+- Modify: `socialmedia-workspace/src/drizzle/schema/posts.schema.ts:52-61` (the `PostTarget` interface)
+
+**Interfaces:**
+- Produces: `PostTarget.destination?: { id: string; name?: string }` — consumed by Tasks 2, 3, 4, 6.
+
+- [ ] **Step 1: Add the optional field.** In the `PostTarget` interface, after `contentOverride?: PlatformContent;`, add:
+
+```ts
+  /**
+   * Sub-destination for chat/messaging platforms (Slack/Discord): which
+   * Slack channel / Discord text channel the message goes to. Absent for
+   * every social platform (they publish to the account itself). `id` is the
+   * platform channel id; `name` is a human label for display/audit.
+   */
+  destination?: {
+    id: string;
+    name?: string;
+  };
+```
+
+- [ ] **Step 2: Verify compile.**
+
+Run: `cd socialmedia-workspace && npm run build`
+Expected: exit 0 (pure type addition; no existing code references it yet).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/drizzle/schema/posts.schema.ts
+git commit -m "feat(posts): optional destination on PostTarget for messaging platforms"
+```
+
+---
+
+### Task 2: Thread `destination` into publisher metadata
+
+**Files:**
+- Modify: `socialmedia-workspace/src/posts/services/post.service.ts:795-798` (the `mergedMetadata` build)
+
+**Interfaces:**
+- Consumes: `PostTarget.destination` (Task 1).
+- Produces: `options.metadata.destination` reaching every publisher — consumed by Tasks 3 (Slack) & 4 (Discord).
+
+**Context:** `mergedMetadata` is built from `post.metadata` + `platformSpecific` and passed as `publish({ metadata: mergedMetadata, ... })` at line 810-813. It currently does NOT include `target.destination`. Add it so messaging publishers can read the destination the same way RedditPublisher reads `metadata.subreddit`.
+
+- [ ] **Step 1: Add destination to mergedMetadata.** Change the `mergedMetadata` object (currently lines 795-798) to include the target's destination:
+
+```ts
+    const mergedMetadata: Record<string, any> = {
+      ...postMetadata,
+      ...platformSpecific,
+      // Messaging platforms (Slack/Discord) read their sub-destination
+      // (which channel to post to) from here; absent for social platforms.
+      ...(target.destination ? { destination: target.destination } : {}),
+    };
+```
+
+- [ ] **Step 2: Verify compile.**
+
+Run: `cd socialmedia-workspace && npm run build`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/posts/services/post.service.ts
+git commit -m "feat(posts): pass PostTarget.destination through to publisher metadata"
+```
+
+---
+
+### Task 3: `SlackPublisher`
+
+**Files:**
+- Create: `socialmedia-workspace/src/posts/publishers/slack.publisher.ts`
+- Test: `socialmedia-workspace/src/posts/publishers/slack.publisher.spec.ts`
+
+**Interfaces:**
+- Consumes: `SlackService.postMessage(botToken, { channel, text, threadTs? })` (`src/channels/services/slack.service.ts:90`), `SlackService.uploadFile(botToken, { channelId, filename, contentType, buffer, initialComment? })` (`:352`); `options.metadata.destination` (Task 2).
+- Produces: `SlackPublisher` (registered in Task 5).
+
+**Reference:** `src/posts/publishers/reddit.publisher.ts` — same shape (constructor-inject the channel service, `validate` reads metadata, `publish` delegates).
+
+- [ ] **Step 1: Write the failing test.** `slack.publisher.spec.ts`:
+
+```ts
+import { SlackPublisher } from './slack.publisher';
+import type { PublishOptions } from './base.publisher';
+
+function baseOptions(over: Partial<PublishOptions> = {}): PublishOptions {
+  return {
+    content: 'hello team',
+    mediaItems: [],
+    metadata: { destination: { id: 'C123', name: '#general' } },
+    accessToken: 'xoxb-token',
+    platformAccountId: 'T1',
+    channelMetadata: {},
+    channelId: 7,
+    ...over,
+  };
+}
+
+describe('SlackPublisher', () => {
+  function make() {
+    const postMessage = jest.fn().mockResolvedValue({ ts: '1700000000.0001', channel: 'C123' });
+    const uploadFile = jest.fn().mockResolvedValue({ ts: '1700000000.0002' });
+    const slackService = { postMessage, uploadFile } as never;
+    return { publisher: new SlackPublisher(slackService), postMessage, uploadFile };
+  }
+
+  it('rejects a missing destination', () => {
+    const { publisher } = make();
+    expect(() => publisher.validate(baseOptions({ metadata: {} }))).toThrow(/destination/i);
+  });
+
+  it('rejects more than one media item', () => {
+    const { publisher } = make();
+    const media = [
+      { url: 'a', type: 'image' as const },
+      { url: 'b', type: 'image' as const },
+    ];
+    expect(() => publisher.validate(baseOptions({ mediaItems: media }))).toThrow(/one media/i);
+  });
+
+  it('rejects empty message with no media', () => {
+    const { publisher } = make();
+    expect(() => publisher.validate(baseOptions({ content: '', mediaItems: [] }))).toThrow(/message or media/i);
+  });
+
+  it('posts a text-only message to the destination channel', async () => {
+    const { publisher, postMessage, uploadFile } = make();
+    const res = await publisher.publish(baseOptions());
+    expect(postMessage).toHaveBeenCalledWith('xoxb-token', { channel: 'C123', text: 'hello team' });
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(res.platformPostId).toBe('1700000000.0001');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `cd socialmedia-workspace && npx jest src/posts/publishers/slack.publisher.spec.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `SlackPublisher`.** Media path uses global `fetch` (Node 18+) to download the URL into a Buffer, mirroring `twitter.publisher.ts`. `slack.publisher.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { BasePublisher, PublishOptions, PublishResult } from './base.publisher';
+import { SlackService } from '../../channels/services/slack.service';
+import { MediaItem } from '../../drizzle/schema/posts.schema';
+import { SupportedPlatform } from '../../drizzle/schema/channels.schema';
+
+interface Destination {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Slack publisher — sends a single message (text and/or one media) to a chosen
+ * Slack channel. The destination channel id comes from
+ * `metadata.destination.id` (set by the campaign composer's destination
+ * picker, threaded through PostTarget.destination). Uses the per-channel bot
+ * token (`chat:write.public` lets it post to public channels without joining).
+ */
+@Injectable()
+export class SlackPublisher extends BasePublisher {
+  readonly platform: SupportedPlatform = 'slack';
+
+  constructor(private readonly slackService: SlackService) {
+    super();
+  }
+
+  private destination(options: PublishOptions): Destination | undefined {
+    return options.metadata?.destination as Destination | undefined;
+  }
+
+  validate(options: PublishOptions): void {
+    const dest = this.destination(options);
+    if (!dest?.id) {
+      throw new Error('Slack message requires a destination channel');
+    }
+    if (options.mediaItems.length > 1) {
+      throw new Error('Slack message supports at most one media item');
+    }
+    const hasText = (options.content ?? '').trim().length > 0;
+    if (!hasText && options.mediaItems.length === 0) {
+      throw new Error('Slack message requires a message or media');
+    }
+  }
+
+  supportsMediaTypes(mediaItems: MediaItem[]): boolean {
+    return mediaItems.length <= 1;
+  }
+
+  async publish(options: PublishOptions): Promise<PublishResult> {
+    this.validate(options);
+    const dest = this.destination(options) as Destination;
+    const { content, mediaItems, accessToken } = options;
+
+    if (mediaItems.length === 0) {
+      const res = await this.slackService.postMessage(accessToken, {
+        channel: dest.id,
+        text: content ?? '',
+      });
+      this.logger.log(`Posted Slack message to ${dest.id}: ${res.ts}`);
+      return { platformPostId: res.ts };
+    }
+
+    const media = mediaItems[0];
+    const resp = await fetch(media.url);
+    if (!resp.ok) {
+      throw new Error(`Failed to download Slack media (${resp.status})`);
+    }
+    const buffer = Buffer.from(await resp.arrayBuffer());
+    const contentType = resp.headers.get('content-type') ?? 'application/octet-stream';
+    const filename = media.url.split('/').pop()?.split('?')[0] || 'attachment';
+
+    const res = await this.slackService.uploadFile(accessToken, {
+      channelId: dest.id,
+      filename,
+      contentType,
+      buffer,
+      initialComment: content || undefined,
+    });
+    this.logger.log(`Uploaded Slack file to ${dest.id}`);
+    return { platformPostId: (res as { ts?: string })?.ts ?? dest.id };
+  }
+}
+```
+
+**Note for implementer:** open `src/channels/services/slack.service.ts` and confirm the exact return shape of `postMessage` (expected `{ ts, channel }`) and `uploadFile`; adjust the `platformPostId` extraction to the real field names if they differ. Keep the test in sync.
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `cd socialmedia-workspace && npx jest src/posts/publishers/slack.publisher.spec.ts`
+Expected: PASS (all 4).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/posts/publishers/slack.publisher.ts src/posts/publishers/slack.publisher.spec.ts
+git commit -m "feat(publishers): SlackPublisher — single message + optional media to a chosen channel"
+```
+
+---
+
+### Task 4: `DiscordPublisher`
+
+**Files:**
+- Create: `socialmedia-workspace/src/posts/publishers/discord.publisher.ts`
+- Test: `socialmedia-workspace/src/posts/publishers/discord.publisher.spec.ts`
+
+**Interfaces:**
+- Consumes: `DiscordService.createMessage(channelId, { content?, files? })` (`src/channels/services/discord.service.ts:27`), `files: { name, data: Buffer, contentType? }[]`; `options.metadata.destination` (Task 2).
+- Produces: `DiscordPublisher` (registered in Task 5).
+
+- [ ] **Step 1: Write the failing test.** `discord.publisher.spec.ts`:
+
+```ts
+import { DiscordPublisher } from './discord.publisher';
+import type { PublishOptions } from './base.publisher';
+
+function baseOptions(over: Partial<PublishOptions> = {}): PublishOptions {
+  return {
+    content: 'gm',
+    mediaItems: [],
+    metadata: { destination: { id: 'D999', name: 'general' } },
+    accessToken: 'ignored',
+    platformAccountId: 'guild1',
+    channelMetadata: {},
+    channelId: 3,
+    ...over,
+  };
+}
+
+describe('DiscordPublisher', () => {
+  function make() {
+    const createMessage = jest.fn().mockResolvedValue({ id: 'msg-1' });
+    const discordService = { createMessage } as never;
+    return { publisher: new DiscordPublisher(discordService), createMessage };
+  }
+
+  it('rejects a missing destination', () => {
+    const { publisher } = make();
+    expect(() => publisher.validate(baseOptions({ metadata: {} }))).toThrow(/destination/i);
+  });
+
+  it('rejects more than one media item', () => {
+    const { publisher } = make();
+    const media = [
+      { url: 'a', type: 'image' as const },
+      { url: 'b', type: 'image' as const },
+    ];
+    expect(() => publisher.validate(baseOptions({ mediaItems: media }))).toThrow(/one media/i);
+  });
+
+  it('sends a text-only message to the destination channel', async () => {
+    const { publisher, createMessage } = make();
+    const res = await publisher.publish(baseOptions());
+    expect(createMessage).toHaveBeenCalledWith('D999', { content: 'gm', files: undefined });
+    expect(res.platformPostId).toBe('msg-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `cd socialmedia-workspace && npx jest src/posts/publishers/discord.publisher.spec.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `DiscordPublisher`.** `discord.publisher.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { BasePublisher, PublishOptions, PublishResult } from './base.publisher';
+import { DiscordService } from '../../channels/services/discord.service';
+import { MediaItem } from '../../drizzle/schema/posts.schema';
+import { SupportedPlatform } from '../../drizzle/schema/channels.schema';
+
+interface Destination {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Discord publisher — sends a single message (text and/or one media) to a
+ * chosen guild text channel. Destination channel id comes from
+ * `metadata.destination.id`. Uses the shared env DISCORD_BOT_TOKEN baked into
+ * DiscordService (ignores `options.accessToken`, unlike per-channel-token
+ * platforms).
+ */
+@Injectable()
+export class DiscordPublisher extends BasePublisher {
+  readonly platform: SupportedPlatform = 'discord';
+
+  constructor(private readonly discordService: DiscordService) {
+    super();
+  }
+
+  private destination(options: PublishOptions): Destination | undefined {
+    return options.metadata?.destination as Destination | undefined;
+  }
+
+  validate(options: PublishOptions): void {
+    const dest = this.destination(options);
+    if (!dest?.id) {
+      throw new Error('Discord message requires a destination channel');
+    }
+    if (options.mediaItems.length > 1) {
+      throw new Error('Discord message supports at most one media item');
+    }
+    const hasText = (options.content ?? '').trim().length > 0;
+    if (!hasText && options.mediaItems.length === 0) {
+      throw new Error('Discord message requires a message or media');
+    }
+  }
+
+  supportsMediaTypes(mediaItems: MediaItem[]): boolean {
+    return mediaItems.length <= 1;
+  }
+
+  async publish(options: PublishOptions): Promise<PublishResult> {
+    this.validate(options);
+    const dest = this.destination(options) as Destination;
+    const { content, mediaItems } = options;
+
+    let files: { name: string; data: Buffer; contentType?: string }[] | undefined;
+    if (mediaItems.length === 1) {
+      const media = mediaItems[0];
+      const resp = await fetch(media.url);
+      if (!resp.ok) {
+        throw new Error(`Failed to download Discord media (${resp.status})`);
+      }
+      const data = Buffer.from(await resp.arrayBuffer());
+      const contentType = resp.headers.get('content-type') ?? undefined;
+      const name = media.url.split('/').pop()?.split('?')[0] || 'attachment';
+      files = [{ name, data, contentType }];
+    }
+
+    const res = await this.discordService.createMessage(dest.id, {
+      content: content || undefined,
+      files,
+    });
+    this.logger.log(`Posted Discord message to ${dest.id}: ${res.id}`);
+    return { platformPostId: res.id };
+  }
+}
+```
+
+**Note for implementer:** confirm `DiscordService.createMessage` return shape has `.id`; confirm the `files` field name/shape matches its signature (`src/channels/services/discord.service.ts:27`). Adjust and keep the test in sync.
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `cd socialmedia-workspace && npx jest src/posts/publishers/discord.publisher.spec.ts`
+Expected: PASS (all 3).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/posts/publishers/discord.publisher.ts src/posts/publishers/discord.publisher.spec.ts
+git commit -m "feat(publishers): DiscordPublisher — single message + optional media to a chosen channel"
+```
+
+---
+
+### Task 5: Register both publishers in `PublisherFactory`
+
+**Files:**
+- Modify: `socialmedia-workspace/src/posts/publishers/publisher.factory.ts`
+- Test: `socialmedia-workspace/src/posts/publishers/publisher.factory.spec.ts` (create if absent)
+- Modify: the module that provides the factory + publishers (find via Step 1 — likely `src/posts/posts.module.ts`)
+
+**Interfaces:**
+- Consumes: `SlackPublisher` (Task 3), `DiscordPublisher` (Task 4).
+- Produces: `getPublisher('slack')` / `getPublisher('discord')` return the publishers instead of throwing.
+
+- [ ] **Step 1: Locate the provider wiring.** Find where `PublisherFactory` and the existing publishers are declared as NestJS providers (grep `PublisherFactory` and `RedditPublisher` across `src/posts/`). Note the module file and confirm `SlackService`/`DiscordService` are available there (they're in `ChannelsModule`; check that `PostsModule` imports it or the services are exported — RedditPublisher already injects `RedditService` from the same ChannelsModule, so the wiring pattern exists). Record findings in the report.
+
+- [ ] **Step 2: Write/extend the failing factory test.** Assert the two new platforms resolve. Construct the factory with mock publishers or real instances given mock services. Minimal:
+
+```ts
+// asserts getPublisher('slack') and ('discord') do not throw and return the right platform
+```
+
+Run and confirm it FAILS before wiring.
+
+- [ ] **Step 3: Register in the factory.** Add constructor params `slackPublisher: SlackPublisher`, `discordPublisher: DiscordPublisher`, and:
+
+```ts
+    this.publishers.set('slack', this.slackPublisher);
+    this.publishers.set('discord', this.discordPublisher);
+```
+
+- [ ] **Step 4: Add both to the module providers** (the file from Step 1), alongside `RedditPublisher`.
+
+- [ ] **Step 5: Verify build + tests + boot.**
+
+Run: `cd socialmedia-workspace && npm run build && npx jest src/posts/publishers`
+Expected: build exit 0; publisher tests PASS. (Boot smoke — Nest DI resolves — is covered by build + the app's existing e2e; if a quick boot check is cheap, run it.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/posts/publishers/publisher.factory.ts src/posts/publishers/publisher.factory.spec.ts src/posts/posts.module.ts
+git commit -m "feat(publishers): register Slack + Discord publishers in the factory"
+```
+
+---
+
+### Task 6: Campaign materializer carries the destination
+
+**Files:**
+- Modify: `socialmedia-workspace/src/campaigns/campaign-publishing.service.ts` (`MaterializeInput`, `buildTargets`, `materializeAndEnqueue`)
+- Modify: `socialmedia-workspace/src/campaigns/campaigns.service.ts` (the caller that builds `MaterializeInput` from a slot — in `launch`/`resume`, ~lines 942/1054)
+- Test: `socialmedia-workspace/src/campaigns/campaign-publishing.service.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: the slot's stored `ChannelDayContentJson` destination (frontend writes it — Task 9); `PostTarget.destination` (Task 1).
+- Produces: launched Slack/Discord posts whose `PostTarget.destination` is set.
+
+**Context:** `ChannelDayContentJson` is the backend jsonb type for a slot's content (`src/drizzle/schema/campaigns.schema.ts`). It must gain an optional `destination?: { id: string; name?: string }` so the composer's saved destination is stored and readable at launch. Confirm the type name in that schema file and extend it.
+
+- [ ] **Step 1: Extend the slot content type.** In `campaigns.schema.ts`, add optional `destination?: { id: string; name?: string }` to `ChannelDayContentJson` (the per-channel-day content interface). Pure type addition (jsonb column).
+
+- [ ] **Step 2: Write the failing test.** Extend `campaign-publishing.service.spec.ts`: when `materializeAndEnqueue` is called with a `destination`, the inserted post's `targets[0].destination` equals it. (Mock the db insert to capture the values, following the existing spec's mocking style; if the existing spec only tests `buildJobId`/`cancelSlotJob`, add a focused `buildTargets` test instead: `buildTargets('42','slack',{id:'C1',name:'#x'})` includes `destination`.)
+
+- [ ] **Step 3: Run test to verify it fails.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaign-publishing.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement.**
+  - `MaterializeInput` gains `destination?: { id: string; name?: string }`.
+  - `buildTargets(channelId, platform, destination?)` includes `destination` in the returned `PostTarget` when present.
+  - `materializeAndEnqueue` passes `input.destination` to `buildTargets`.
+  - In `campaigns.service.ts` `launch`/`resume`, where each slot is materialized, read `content.destination` from the slot and set it on the `MaterializeInput`.
+
+- [ ] **Step 5: Run tests + build.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/campaigns/campaign-publishing.service.ts src/campaigns/campaigns.service.ts src/campaigns/campaign-publishing.service.spec.ts src/drizzle/schema/campaigns.schema.ts
+git commit -m "feat(campaigns): carry messaging destination from slot into PostTarget at launch"
+```
+
+---
+
+## FRONTEND (only after backend tasks complete)
+
+> All frontend paths are in worktree `socialmedia-frontend-campaigns`, branch `feat/campaign-messaging-channels`. Run FE commands with `cd socialmedia-frontend-campaigns`.
+
+### Task 7: `'message'` post type + messaging platform config
+
+**Files:**
+- Modify: `src/features/campaigns/constants/post-types.tsx` (`PostType`, `ComposerKind`, `POST_TYPES`, `PLATFORM_POST_TYPES` slack/discord)
+
+**Interfaces:**
+- Produces: `PostType` includes `'message'`; `getPlatformPostConfig('slack'|'discord')` returns `{ types: ['message'], default: 'message' }` — consumed by Tasks 8, 9.
+
+- [ ] **Step 1: Add the `'message'` post type.** Extend `PostType` union with `'message'`; extend `ComposerKind` with `'message'`; add a `POST_TYPES.message` entry:
+
+```ts
+  message: {
+    id: 'message',
+    label: 'Message',
+    icon: MessageSquareText, // already imported
+    composer: 'message',
+    blurb: 'A single chat message with optional media.',
+  },
+```
+
+- [ ] **Step 2: Enable slack + discord.** In `PLATFORM_POST_TYPES`, change `slack` and `discord` to `types: ['message'], default: 'message'` (keep their `charLimit` 40000 / 2000, `usesHashtags: false`). Leave `telegram` and `whatsapp` as `types: []` (deferred). Update the comment above them to note slack/discord are now message-enabled while telegram/whatsapp stay inbox-only.
+
+- [ ] **Step 3: Verify build.**
+
+Run: `cd socialmedia-frontend-campaigns && npm run build`
+Expected: exit 0 (may surface `switch`/exhaustiveness spots on `ComposerKind` — fix any that error; the composer routing in Task 8 handles `'message'`).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/features/campaigns/constants/post-types.tsx
+git commit -m "feat(campaigns): add 'message' post type; enable Slack + Discord as messaging targets"
+```
+
+---
+
+### Task 8: Destination picker — API + hooks + component
+
+**Files:**
+- Create: `src/features/campaigns/api/messaging-destinations.api.ts`
+- Create: `src/features/campaigns/hooks/use-messaging-destinations.ts`
+- Create: `src/features/campaigns/components/create/steps/composers/destination-picker.tsx`
+
+**Interfaces:**
+- Consumes backend endpoints: `GET workspaces/:workspaceId/slack/:channelId/conversations` → `{ channels: { id, name, isMember, isPrivate, ... }[], nextCursor }`; `GET workspaces/:workspaceId/discord/:channelId/channels` → `{ channels: { id, name, type }[] }`.
+- Produces: `<DestinationPicker platform channelId workspaceId value onChange />` where `value: { id, name } | undefined` — consumed by Task 9.
+
+- [ ] **Step 1: API wrappers.** Typed `apiClient` calls (follow the existing `src/features/campaigns/api/campaigns.api.ts` style). `listSlackDestinations(workspaceId, channelId, cursor?)` and `listDiscordDestinations(workspaceId, channelId)`. Return typed `{ id: string; name: string; isMember?: boolean; isPrivate?: boolean }[]` (normalize both platforms to this shape; Discord has no isMember/isPrivate).
+
+- [ ] **Step 2: React Query hook.** `useMessagingDestinations(platform, workspaceId, channelId)` — enabled only for slack/discord and when ids present; returns `{ destinations, isLoading, isError, refetch }`. Slack pagination: fetch first page (sufficient for v1; note in a comment that further pages are TODO if a workspace has >~100 channels).
+
+- [ ] **Step 3: Component.** shadcn `Select` (confirm via shadcn MCP `view_items_in_registries` for the exact `Select` API in this project's `@basecn`/base-ui variant — `onValueChange` is string-only, so map the chosen id back to `{ id, name }` internally). Show channel name; for Slack disable/annotate private channels where `isMember === false` (public post fine without join). Loading → skeleton/spinner; empty → "No channels found"; error → inline message + retry. Theme tokens only.
+
+- [ ] **Step 4: Build.**
+
+Run: `cd socialmedia-frontend-campaigns && npm run build`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/features/campaigns/api/messaging-destinations.api.ts src/features/campaigns/hooks/use-messaging-destinations.ts src/features/campaigns/components/create/steps/composers/destination-picker.tsx
+git commit -m "feat(campaigns): destination picker (Slack channels / Discord channels) API + hook + component"
+```
+
+---
+
+### Task 9: `MessageComposer` + slot-content destination + routing
+
+**Files:**
+- Modify: `src/features/campaigns/types/slot-content.ts` (add `destination?`, update `isChannelDayFilled`, `emptyChannelDayContent` unaffected)
+- Create: `src/features/campaigns/components/create/steps/composers/message-composer.tsx`
+- Modify: `src/features/campaigns/components/create/steps/composers/channel-day-composer.tsx` (route messaging platforms to `MessageComposer`)
+- Test: `src/features/campaigns/types/slot-content.spec.ts` (extend or create — `isChannelDayFilled` for `'message'`)
+
+**Interfaces:**
+- Consumes: `<DestinationPicker>` (Task 8); `ChannelDayContent` (with new `destination`); `getPlatformPostConfig` (Task 7).
+- Produces: messaging slots authored via a chat composer; `ChannelDayContent.destination` persisted through the existing `updateEvent` save path (it already saves the whole `ChannelDayContent` patch).
+
+- [ ] **Step 1: Slot-content type + filled rule.** Add `destination?: { id: string; name?: string }` to `ChannelDayContent`. In `isChannelDayFilled`, add: if `c.postType === 'message'` → filled iff `!!c.destination?.id && (c.caption.trim().length > 0 || c.media.length > 0)`. Write the failing test for this rule first.
+
+- [ ] **Step 2: Run the filled-rule test — fails.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns/types/slot-content.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: `MessageComposer` component.** Props: `{ platform, channelId, workspaceId, value: ChannelDayContent, onChange }`. Renders:
+  - `<DestinationPicker>` (required — show a subtle "Required" hint until set).
+  - One shadcn `Textarea` for the message (char counter against `getPlatformPostConfig(platform).charLimit`), writing `caption`.
+  - One optional media attach, **max 1**: reuse the existing media path. Simplest reuse: render the builder's `EditorCard` media affordance OR the `MediaComposer` with `mediaMax: 1`; cap `media` to length 1 in `onChange`. Confirm which is least code by reading `channel-day-composer.tsx`'s flat `ManualBody` (it uses `EditorCard`). Prefer reusing `EditorCard` with media capped at 1 and text as the message.
+  - NO mode strip, NO post-type tabs, NO platform-options, NO AI/Template.
+  - Make the filled rule pass.
+
+- [ ] **Step 4: Route in `ChannelDayComposer`.** At the top of the component body, if `getPlatformPostConfig(platform).default === 'message'` (i.e. slack/discord), return `<MessageComposer platform channelId workspaceId={useWorkspaceId()} value={current} onChange={onChange} />` instead of the mode-strip/ManualBody/PlatformOptions blocks. This applies to BOTH flat (builder) and boxed (create-wizard) paths — messaging uses the same chat composer everywhere. Non-messaging platforms fall through unchanged (byte-for-byte).
+
+- [ ] **Step 5: Run tests + build.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/features/campaigns/types/slot-content.ts src/features/campaigns/types/slot-content.spec.ts src/features/campaigns/components/create/steps/composers/message-composer.tsx src/features/campaigns/components/create/steps/composers/channel-day-composer.tsx
+git commit -m "feat(campaigns): chat-style MessageComposer for Slack/Discord with required destination + single media"
+```
+
+---
+
+### Task 10: Launch validation — destination required
+
+**Files:**
+- Modify: `src/features/campaigns/components/builder/preflight-summary.tsx` (or the launch mutation guard — find where launch is blocked/validated)
+- Modify: `src/features/campaigns/components/builder/bonzo/channels-column.tsx` (card meta shows destination name for message slots)
+- Test: extend the relevant validation spec if one exists
+
+**Interfaces:**
+- Consumes: `ChannelDayContent.destination`, `isChannelDayFilled` (Task 9).
+
+- [ ] **Step 1: Find the launch gate.** Read `preflight-summary.tsx` and the launch mutation to see how "can this campaign launch" is computed (it likely aggregates `isChannelDayFilled`). Since `isChannelDayFilled` already requires a destination for message slots (Task 9), a destination-less message slot is already "unfilled" → confirm the launch gate blocks on unfilled slots. If it does, add a SPECIFIC message for the destination case ("Pick a destination for <channel> on <date>") rather than a generic "incomplete slot".
+
+- [ ] **Step 2: Card meta.** In `channels-column.tsx`, for a `content.postType === 'message'` slot, render the destination name (e.g. "→ #announcements") in the meta row instead of (or alongside) the post-type chip; show it as "No destination" (muted/italic) when unset. Keep media count. Non-message slots unchanged.
+
+- [ ] **Step 3: Build + tests.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/features/campaigns/components/builder/preflight-summary.tsx src/features/campaigns/components/builder/bonzo/channels-column.tsx
+git commit -m "feat(campaigns): require a destination for messaging slots before launch; show it on the slot card"
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Spec coverage:** Layer 1 = Tasks 1-6; Layer 2 = Tasks 7-10; Layer 3 (drip+bulk consistency) is satisfied by Task 9 Step 4 routing in the shared `ChannelDayComposer` — no separate task.
+- **Type consistency:** `destination` shape is `{ id: string; name?: string }` everywhere — `PostTarget` (BE), `ChannelDayContentJson` (BE slot), `ChannelDayContent` (FE), `DestinationPicker.value` (FE). Keep it identical across all four.
+- **Deferred, do NOT touch:** telegram, whatsapp (no publishers, `types: []`).
+- **Verify-at-implementation flags** (each noted in its task): exact return shapes of `SlackService.postMessage`/`uploadFile` and `DiscordService.createMessage`; the module that provides `PublisherFactory`; the exact `ChannelDayContentJson` type name; the shadcn `Select` API variant; and whether `EditorCard` or `MediaComposer` is the least-code single-media reuse.

--- a/docs/superpowers/plans/2026-08-16-campaign-slot-time-edit.md
+++ b/docs/superpowers/plans/2026-08-16-campaign-slot-time-edit.md
@@ -1,0 +1,948 @@
+# Campaign Slot Time Edit + Past-Due Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user change a campaign/drip slot's time before launch (content-preserving move), and surface past-due slots (time already passed) with a red badge, a launch-blocking preflight blocker, and a Days-column marker.
+
+**Architecture:** Two layers, backend-first. **Backend:** `updateEvent` gains an optional `newTime` that moves a slot's `time` column (preserving merged content), rejecting a collision or a launched campaign with a 409. **Frontend:** a new timezone-correct `isSlotPastDue` util (mirrors the backend's `wallClockToUtc`), a `TimePickerSelect` wired into the composer that calls `updateEvent` with `newTime`, a red "Past due" slot badge, a `pastDue` preflight blocker that disables Launch, and a Days-column past-due marker.
+
+**Tech Stack:** Backend — NestJS, Drizzle ORM (Postgres), class-validator, Jest. Frontend — Vite 8 + React 19 + TypeScript + Tailwind 3 + shadcn (wraps @base-ui/basecn), TanStack Query v5, Vitest, react-router.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-campaign-slot-time-edit-design.md`
+
+## Global Constraints
+
+- **NO DB migration** — `campaign_slot_content.time` (`varchar(5)` NOT NULL) and the unique index `(campaignId, date, channelId, time)` already exist; this is logic-only.
+- **shadcn-only** UI; theme tokens only. Past-due styling uses `text-destructive` / `bg-destructive/…` tokens — no hex, no arbitrary Tailwind colors (`bg-red-500` etc.).
+- **Never** `git add .` / `git add -A` — surgical `git add <path>` only (FE `.env` is git-TRACKED with secrets; BE `.env` is gitignored with live secrets — never stage/commit/expose either).
+- Commit/push only when the user explicitly asks; this plan's tasks each end with a `git add <specific paths>` + commit, but do NOT push.
+- The implementer runs **no** `db:*` / `psql` / migration commands.
+- **Draft-campaign non-time-edit behaviour must stay unchanged**; bulk/social slot rendering unchanged except the added time picker + past-due badge. Byte-for-byte for anything not touched.
+- Past-due comparison must be **timezone-correct** (mirror backend `wallClockToUtc`), never server-local-naive. A slot exactly at `now` counts as NOT past-due (`>= now → not past-due`, matching the backend's `computeSlotSchedule`).
+- Branch `feat/campaign-slot-time-edit` in both repos, off `main` (which already contains messaging + launched-slot-edit).
+
+---
+
+### Task 1: Backend — `newTime` on `UpdateEventDto`
+
+**Files:**
+- Modify: `src/campaigns/dto/campaigns.dto.ts:187-200` (the `UpdateEventDto` class)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `UpdateEventDto.newTime?: string` (optional, `HH:mm`-validated) — consumed by Task 2 (`updateEvent`) and set by the frontend (Task 7).
+
+- [ ] **Step 1: Add the `newTime` field to `UpdateEventDto`**
+
+In `src/campaigns/dto/campaigns.dto.ts`, the existing `UpdateEventDto` ends with the `time?` matcher field. Add `newTime` right after it, using the same `@Matches` pattern already used for `time`:
+
+```ts
+export class UpdateEventDto {
+  @IsDateString()
+  date: string;
+
+  @IsString()
+  channelId: string;
+
+  @IsObject()
+  patch: Partial<ChannelDayContentJson>;
+
+  @IsOptional()
+  @Matches(/^\d{2}:\d{2}$/, { message: 'time must be HH:mm' })
+  time?: string;
+
+  // Optional content-preserving time move: when present and different from the
+  // matched slot's current `time`, updateEvent moves the slot to this time.
+  @IsOptional()
+  @Matches(/^\d{2}:\d{2}$/, { message: 'newTime must be HH:mm' })
+  newTime?: string;
+}
+```
+
+(`@IsOptional`, `@Matches`, `@IsObject`, `@IsString`, `@IsDateString` are already imported in this file — the existing `time?` field uses `@IsOptional` + `@Matches`.)
+
+- [ ] **Step 2: Verify the backend compiles**
+
+Run: `npm run build`
+Expected: PASS (no type errors). Confirms the DTO change is well-formed before wiring logic.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/campaigns/dto/campaigns.dto.ts
+git commit -m "feat(campaigns): add optional newTime to UpdateEventDto for slot time move"
+```
+
+---
+
+### Task 2: Backend — `updateEvent` handles the `newTime` move
+
+**Files:**
+- Modify: `src/campaigns/campaigns.service.ts:1334-1430` (the `updateEvent` method)
+- Test: `src/campaigns/campaigns.service.spec.ts` (add cases; file already exists with the campaigns suite)
+
+**Interfaces:**
+- Consumes: `UpdateEventDto.newTime` (Task 1); existing helpers `assertLaunchedSlotEditable(campaignStatus, slotStatus)`, `cancelAndClearSlotPost({jobId, postId})`; Drizzle `campaignSlotContent` table; `ConflictException` (already imported).
+- Produces: no signature change — `updateEvent` still returns `Promise<CampaignDto>`; behaviour extended so a `newTime` differing from the slot's current time moves the slot's `time` column (content preserved) or 409s.
+
+**Design note (ordering — read before coding):** The current method (1) finds the slot by `(campaignId, date, channelId, time?)`, (2) loads campaign status, (3) `assertLaunchedSlotEditable`, (4) merges content + writes it, (5) if `active` + `scheduled`, re-materializes. The `newTime` move must be handled as a REJECTION on a launched campaign (per spec: pre-launch only) and as a pure `time`-column update otherwise. Insert the `newTime` handling **after** `assertLaunchedSlotEditable` and **before** the existing content write, so the single `.set(...)` writes both `time` and merged `content` together. The launched re-materialize block below is unaffected: a launched campaign with `newTime` is rejected before it, and a `newTime`-less update flows through unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/campaigns/campaigns.service.spec.ts`. Follow the existing spec's mocking style for `db` (the campaigns suite already mocks the Drizzle `db` query builder — reuse that harness; if the suite has a `updateEvent` describe block, add these there, otherwise add a new `describe('updateEvent — newTime move', ...)`). The four cases:
+
+```ts
+describe('updateEvent — newTime move', () => {
+  it('moves the slot to newTime and preserves merged content when the target time is free', async () => {
+    // Arrange: a draft campaign, one slot at 17:00 with content { caption: 'hi' }.
+    // No slot exists at 18:00. dto = { date, channelId, patch: { caption: 'bye' }, time: '17:00', newTime: '18:00' }.
+    // Act: await service.updateEvent(workspaceId, campaignId, dto)
+    // Assert: db.update(campaignSlotContent).set was called with an object whose
+    //   time === '18:00' and content.caption === 'bye' (merged patch preserved).
+  })
+
+  it('throws ConflictException when a slot already exists at newTime', async () => {
+    // Arrange: draft campaign, slot at 17:00, AND an existing slot at 18:00 for the same (campaign,date,channel).
+    // dto newTime = '18:00'.
+    // Act/Assert: expect(service.updateEvent(...)).rejects.toBeInstanceOf(ConflictException)
+    //   and no db.update writing time:'18:00' happened.
+  })
+
+  it('throws ConflictException when the campaign is launched (active) and newTime is set', async () => {
+    // Arrange: campaign.status = 'active', slot at 17:00 (slotStatus 'scheduled'). dto newTime = '18:00'.
+    // Act/Assert: rejects with ConflictException; the slot's time is not moved.
+  })
+
+  it('leaves content-only behaviour unchanged when newTime is absent', async () => {
+    // Arrange: draft campaign, slot at 17:00. dto = { date, channelId, patch: { caption: 'x' }, time: '17:00' } (no newTime).
+    // Act: updateEvent
+    // Assert: db.update(...).set called with content.caption === 'x' and NO `time` key in the set payload
+    //   (or time unchanged at '17:00') — i.e. same as today.
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- campaigns.service`
+Expected: the four new cases FAIL (the move/collision/launched-reject logic doesn't exist yet; the "unchanged" case may pass already — that's fine, it's a guard against regression).
+
+- [ ] **Step 3: Implement the `newTime` handling in `updateEvent`**
+
+In `src/campaigns/campaigns.service.ts`, `updateEvent`, insert a block after `this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);` (line ~1364) and before `const mergedContent = ...`. Then fold `time` into the existing content-write `.set(...)`:
+
+```ts
+    this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);
+
+    // Content-preserving time move. Pre-launch only: moving a launched slot
+    // would need a re-materialize at the new fire time (out of scope here), so
+    // reject it with a clear 409 — the picker is disabled there anyway.
+    const movingTime = !!dto.newTime && dto.newTime !== slot.time;
+    if (movingTime) {
+      if (campaignStatus === 'active') {
+        throw new ConflictException(
+          'Change this post’s time before launching the campaign.',
+        );
+      }
+      const [clash] = await db
+        .select({ id: campaignSlotContent.id })
+        .from(campaignSlotContent)
+        .where(
+          and(
+            eq(campaignSlotContent.campaignId, id),
+            eq(campaignSlotContent.date, dto.date),
+            eq(campaignSlotContent.channelId, dto.channelId),
+            eq(campaignSlotContent.time, dto.newTime!),
+          ),
+        );
+      if (clash) {
+        throw new ConflictException(
+          'A post already exists for this channel at that time on this day.',
+        );
+      }
+    }
+
+    const mergedContent: ChannelDayContentJson = { ...slot.content, ...dto.patch };
+
+    await db
+      .update(campaignSlotContent)
+      .set({
+        content: mergedContent,
+        ...(movingTime ? { time: dto.newTime! } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(campaignSlotContent.id, slot.id));
+```
+
+The existing `if (campaignStatus === 'active' && slot.slotStatus === 'scheduled')` re-materialize block that follows stays untouched — it can't run alongside a `movingTime` path because `movingTime` on an `active` campaign already threw above.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- campaigns.service`
+Expected: all four new cases PASS; the rest of the campaigns suite stays green.
+
+- [ ] **Step 5: Verify the backend compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "feat(campaigns): move a slot's time via updateEvent newTime (409 on collision/launched)"
+```
+
+---
+
+### Task 3: Frontend — thread `newTime` through the API + mutation hook
+
+**Files:**
+- Modify: `src/features/campaigns/api/campaigns.api.ts:129-142` (the `updateEvent` API wrapper)
+- Modify: `src/features/campaigns/hooks/use-campaign-event-mutations.ts:59-73` (the `updateEvent` mutation)
+
+**Interfaces:**
+- Consumes: nothing new from earlier tasks (the backend accepts `newTime`).
+- Produces: `campaignsApi.updateEvent(workspaceId, id, date, channelId, patch, time?, newTime?)` and the `updateEvent` mutation's variables gain optional `newTime?: string` — consumed by Task 7 (composer) and Task 8 (composer wiring).
+
+- [ ] **Step 1: Add `newTime` to the API wrapper**
+
+In `src/features/campaigns/api/campaigns.api.ts`, extend `updateEvent` (currently takes `time?` last):
+
+```ts
+  updateEvent: (
+    workspaceId: string,
+    id: string,
+    date: string,
+    channelId: string,
+    patch: Partial<ChannelDayContent>,
+    time?: string,
+    newTime?: string,
+  ) =>
+    apiClient.patch<Campaign>(`${base(workspaceId)}/${id}/events`, {
+      date,
+      channelId,
+      patch,
+      ...(time ? { time } : {}),
+      ...(newTime ? { newTime } : {}),
+    }),
+```
+
+- [ ] **Step 2: Add `newTime` to the mutation variables**
+
+In `src/features/campaigns/hooks/use-campaign-event-mutations.ts`, extend the `updateEvent` mutation:
+
+```ts
+  const updateEvent = useMutation({
+    mutationFn: ({
+      date,
+      channelId,
+      patch,
+      time,
+      newTime,
+    }: {
+      date: string
+      channelId: string
+      patch: Partial<ChannelDayContent>
+      time?: string
+      newTime?: string
+    }) =>
+      campaignsApi.updateEvent(workspaceId, campaignId, date, channelId, patch, time, newTime),
+    onSuccess: onDone,
+    onError: onFail,
+  })
+```
+
+- [ ] **Step 3: Verify the frontend compiles**
+
+Run: `npm run build`
+Expected: PASS (types line up; no consumer passes `newTime` yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/campaigns/api/campaigns.api.ts src/features/campaigns/hooks/use-campaign-event-mutations.ts
+git commit -m "feat(campaigns): thread optional newTime through updateEvent api + mutation"
+```
+
+---
+
+### Task 4: Frontend — `isSlotPastDue` timezone-correct util
+
+**Files:**
+- Create: `src/features/campaigns/utils/slot-timing.ts`
+- Test: `src/features/campaigns/utils/slot-timing.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `isSlotPastDue(date: string, time: string, timezone: string, now: Date): boolean` — consumed by Tasks 5 (preflight), 6 (days), 8 (badge). Returns `true` when the slot's absolute instant is strictly before `now`; a slot exactly at `now` is NOT past-due.
+
+**Design note:** Mirror the backend's `wallClockToUtc` (`campaign-schedule.util.ts:47-63`): treat the wall-clock as UTC first, measure the zone's offset at that instant via `Intl.DateTimeFormat`, then subtract the offset. This keeps FE past-due detection consistent with what the backend will actually do at launch (DST-correct, no library).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/features/campaigns/utils/slot-timing.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { isSlotPastDue } from './slot-timing'
+
+describe('isSlotPastDue', () => {
+  // Reference now: 2026-08-16T12:00:00Z
+  const now = new Date('2026-08-16T12:00:00Z')
+
+  it('is true when the slot instant is before now (UTC zone)', () => {
+    // 2026-08-16 11:00 UTC < 12:00 UTC now
+    expect(isSlotPastDue('2026-08-16', '11:00', 'UTC', now)).toBe(true)
+  })
+
+  it('is false when the slot instant is after now (UTC zone)', () => {
+    expect(isSlotPastDue('2026-08-16', '13:00', 'UTC', now)).toBe(false)
+  })
+
+  it('is false when the slot instant is exactly now', () => {
+    // 12:00 UTC === now → NOT past due (matches backend >= now → due)
+    expect(isSlotPastDue('2026-08-16', '12:00', 'UTC', now)).toBe(false)
+  })
+
+  it('respects the timezone offset (Asia/Karachi = UTC+5)', () => {
+    // 16:00 in Karachi (UTC+5) === 11:00 UTC < 12:00 UTC now → past due
+    expect(isSlotPastDue('2026-08-16', '16:00', 'Asia/Karachi', now)).toBe(true)
+    // 18:00 in Karachi === 13:00 UTC > now → not past due
+    expect(isSlotPastDue('2026-08-16', '18:00', 'Asia/Karachi', now)).toBe(false)
+  })
+
+  it('returns false for a malformed date or time (never falsely blocks)', () => {
+    expect(isSlotPastDue('not-a-date', '11:00', 'UTC', now)).toBe(false)
+    expect(isSlotPastDue('2026-08-16', 'bad', 'UTC', now)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- slot-timing`
+Expected: FAIL with "Cannot find module './slot-timing'" (the file doesn't exist yet).
+
+- [ ] **Step 3: Implement `isSlotPastDue`**
+
+Create `src/features/campaigns/utils/slot-timing.ts`:
+
+```ts
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+const TIME_RE = /^(\d{2}):(\d{2})$/
+
+/** Minutes to add to a UTC wall-clock to reach the given zone's local time at
+ *  `at` (i.e. the zone's offset from UTC in minutes). Mirrors the backend's
+ *  zoneOffsetMinutes in campaign-schedule.util.ts. */
+function zoneOffsetMinutes(timeZone: string, at: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+  const parts = dtf.formatToParts(at)
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value)
+  const asUtc = Date.UTC(
+    get('year'),
+    get('month') - 1,
+    get('day'),
+    // Intl can emit '24' for midnight in some engines — normalize to 0.
+    get('hour') % 24,
+    get('minute'),
+    get('second'),
+  )
+  return Math.round((asUtc - at.getTime()) / 60000)
+}
+
+/** Absolute UTC instant of a wall-clock `date` + `HH:mm` interpreted in
+ *  `timeZone`. Returns null for malformed input. Mirrors the backend's
+ *  wallClockToUtc so FE past-due detection matches launch behaviour. */
+function wallClockToUtc(date: string, time: string, timeZone: string): Date | null {
+  const d = DATE_RE.exec(date)
+  const t = TIME_RE.exec(time)
+  if (!d || !t) return null
+  const [, y, mo, da] = d
+  const [, hh, mm] = t
+  const naiveUtcMs = Date.UTC(+y, +mo - 1, +da, +hh, +mm, 0, 0)
+  let offsetMin = 0
+  try {
+    offsetMin = zoneOffsetMinutes(timeZone, new Date(naiveUtcMs))
+  } catch {
+    offsetMin = 0 // invalid zone → UTC fallback
+  }
+  return new Date(naiveUtcMs - offsetMin * 60000)
+}
+
+/** True when the slot's absolute instant is strictly before `now`. A slot
+ *  exactly at `now` is NOT past-due (matches backend `>= now → due`). A
+ *  malformed date/time is treated as NOT past-due so a bad value never
+ *  falsely blocks a launch. */
+export function isSlotPastDue(
+  date: string,
+  time: string,
+  timezone: string,
+  now: Date,
+): boolean {
+  const at = wallClockToUtc(date, time, timezone)
+  if (!at) return false
+  return at.getTime() < now.getTime()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- slot-timing`
+Expected: all cases PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/campaigns/utils/slot-timing.ts src/features/campaigns/utils/slot-timing.spec.ts
+git commit -m "feat(campaigns): add timezone-correct isSlotPastDue util (mirrors backend wallClockToUtc)"
+```
+
+---
+
+### Task 5: Frontend — `pastDue` preflight blocker
+
+**Files:**
+- Modify: `src/features/campaigns/utils/preflight.ts:60-127` (`computePreflight` + a new `findPastDueReadySlots` helper)
+- Modify: `src/features/campaigns/components/builder/builder-header.tsx:236` (call site)
+- Modify: `src/features/campaigns/components/builder/preflight-summary.tsx:18` (call site)
+- Test: `src/features/campaigns/utils/preflight.spec.ts` (add a `pastDue` describe block)
+
+**Interfaces:**
+- Consumes: `isSlotPastDue` (Task 4); the campaign's `schedule.timezone` (present on every schedule variant — `campaign.ts:51/70/84`); `parseSlotKey`, `isChannelDayFilled`, `parseISODate`, `format` (already imported in `preflight.ts`).
+- Produces: `computePreflight(campaign, channelNameById?, now?)` — a new optional third param `now: Date = new Date()`. When any *filled* (would-publish) slot is past-due, a `{ id: 'pastDue', label, hint }` blocker is appended. Consumed by the two call sites (they gate Launch on `blockers.length > 0` — no call-site logic change needed beyond passing `now`).
+
+**Design note:** Model `findPastDueReadySlots` on the existing `findMissingDestinationSlots` (`preflight.ts:36-49`) — same iteration over `slotContent` → `channelContent`, same `parseSlotKey(key).channelId`, but the gate is `isChannelDayFilled(content) && isSlotPastDue(date, parseSlotKey(key).time, tz, now)`. Only *filled* slots count: an empty/unfilled past-due slot wouldn't publish anyway, so it must NOT block launch (that would trap the user with an un-fixable blocker on a slot they never authored). Skip `day.skip` days.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/features/campaigns/utils/preflight.spec.ts` (the file already builds a `campaign` fixture — reuse its fixture builder / shape; the existing messaging-destination tests show the exact `slotContent` → `channelContent` shape to construct). Add:
+
+```ts
+describe('computePreflight — past-due blocker', () => {
+  // now anchored well after the past slot, before the future slot
+  const now = new Date('2026-08-16T12:00:00Z')
+
+  it('blocks launch when a filled slot is past-due', () => {
+    // Build a campaign (timezone 'UTC') with one FILLED slot at date 2026-08-16, time '11:00'
+    // (key `ch1@11:00`) — 11:00 UTC < now. Everything else valid (name, channels).
+    const blockers = computePreflight(campaign, { ch1: '#general' }, now)
+    expect(blockers.some((b) => b.id === 'pastDue')).toBe(true)
+    // label names the channel + time
+    const pd = blockers.find((b) => b.id === 'pastDue')!
+    expect(pd.label).toMatch(/#general/)
+  })
+
+  it('does not block when the only past-due slot is unfilled (empty caption + no media)', () => {
+    // Same date/time but the slot content is empty → wouldn't publish → not a blocker.
+    const blockers = computePreflight(campaign, {}, now)
+    expect(blockers.some((b) => b.id === 'pastDue')).toBe(false)
+  })
+
+  it('does not block when all filled slots are in the future', () => {
+    // Filled slot at time '13:00' (13:00 UTC > now) → no pastDue blocker.
+    const blockers = computePreflight(campaign, {}, now)
+    expect(blockers.some((b) => b.id === 'pastDue')).toBe(false)
+  })
+
+  it('summarizes extra past-due slots with a (+N more) suffix', () => {
+    // Two filled past-due slots → label ends with "(+1 more)".
+    const blockers = computePreflight(campaign, { ch1: '#general', ch2: '#random' }, now)
+    const pd = blockers.find((b) => b.id === 'pastDue')!
+    expect(pd.label).toMatch(/\+1 more/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- preflight`
+Expected: the four new cases FAIL (no `pastDue` blocker exists; `computePreflight` ignores its third arg).
+
+- [ ] **Step 3: Implement `findPastDueReadySlots` + the blocker**
+
+In `src/features/campaigns/utils/preflight.ts`:
+
+Add the import at the top (next to the existing `./slot-key` import):
+
+```ts
+import { isSlotPastDue } from './slot-timing'
+```
+
+Add the helper (after `findMissingDestinationSlots`):
+
+```ts
+interface PastDueSlot {
+  channelId: string
+  date: string
+  time: string
+}
+
+/** Every filled (would-publish) slot whose time has already passed, in
+ *  slotContent key-iteration order. Only filled slots count — an unfilled
+ *  past-due slot wouldn't publish, so it must not trap the launch. */
+function findPastDueReadySlots(campaign: Campaign, now: Date): PastDueSlot[] {
+  const tz = campaign.schedule.timezone
+  const found: PastDueSlot[] = []
+  for (const [date, day] of Object.entries(campaign.slotContent)) {
+    if (day.skip) continue
+    for (const [key, content] of Object.entries(day.channelContent)) {
+      if (!isChannelDayFilled(content)) continue
+      const { channelId, time } = parseSlotKey(key)
+      if (!time) continue // legacy/bulk-without-time key — can't evaluate
+      if (isSlotPastDue(date, time, tz, now)) {
+        found.push({ channelId, date, time })
+      }
+    }
+  }
+  return found
+}
+```
+
+Change the signature and append the blocker (before `return blockers`):
+
+```ts
+export function computePreflight(
+  campaign: Campaign,
+  channelNameById: Record<string, string> = {},
+  now: Date = new Date(),
+): PreflightBlocker[] {
+  // ...existing blockers unchanged...
+
+  const pastDueSlots = findPastDueReadySlots(campaign, now)
+  if (pastDueSlots.length > 0) {
+    const [first] = pastDueSlots
+    const channelName = channelNameById[first.channelId] ?? 'this channel'
+    const dateLabel = format(parseISODate(first.date), 'MMM d')
+    const extra = pastDueSlots.length - 1
+    blockers.push({
+      id: 'pastDue',
+      label:
+        extra > 0
+          ? `Past due: ${channelName} on ${dateLabel} (+${extra} more)`
+          : `Past due: ${channelName} on ${dateLabel}`,
+      hint: 'This post’s time has already passed. Change its time or remove it before launching.',
+    })
+  }
+
+  return blockers
+}
+```
+
+- [ ] **Step 4: Pass `now` at the two call sites**
+
+In `src/features/campaigns/components/builder/builder-header.tsx:236`, change:
+
+```ts
+  const blockers = computePreflight(campaign, channelNameById)
+```
+to:
+```ts
+  const blockers = computePreflight(campaign, channelNameById, new Date())
+```
+
+In `src/features/campaigns/components/builder/preflight-summary.tsx:18`, change:
+
+```ts
+  const blockers = computePreflight(campaign, channelNameById)
+```
+to:
+```ts
+  const blockers = computePreflight(campaign, channelNameById, new Date())
+```
+
+(Both compute `blockers` on every render, so `new Date()` re-evaluates each render — a slot ticking past its time flips the button to disabled on the next render/refetch. No timer needed for this task; the existing query invalidation already re-renders on data changes.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test -- preflight`
+Expected: the four new cases PASS; the existing preflight tests (name/channels/content/notifications/destination) stay green — they call `computePreflight` with 1-2 args, and `now` defaults to `new Date()`, which won't retroactively make their fixture slots past-due (their fixtures use far-future or unfilled slots — verify none of them use a filled past-date slot; if one does, it was already relying on time-blindness — pass an explicit future `now` there to keep it green and note it in the report).
+
+- [ ] **Step 6: Verify the frontend compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/campaigns/utils/preflight.ts src/features/campaigns/utils/preflight.spec.ts src/features/campaigns/components/builder/builder-header.tsx src/features/campaigns/components/builder/preflight-summary.tsx
+git commit -m "feat(campaigns): block launch when a filled slot is past-due (preflight blocker)"
+```
+
+---
+
+### Task 6: Frontend — Days-column past-due marker
+
+**Files:**
+- Modify: `src/features/campaigns/utils/campaign-days.ts` (`DaySummary` + `campaignDaySummaries`)
+- Modify: `src/features/campaigns/components/builder/bonzo/days-column.tsx` (render the marker)
+- Test: `src/features/campaigns/utils/campaign-days.spec.ts` (create if absent, or add a describe block if present)
+
+**Interfaces:**
+- Consumes: `isSlotPastDue` (Task 4); `campaign.schedule.timezone`; existing `parseSlotKey`, `isChannelDayFilled`.
+- Produces: `DaySummary` gains `hasPastDue: boolean`; `campaignDaySummaries(campaign, now?)` gains an optional `now: Date = new Date()`. Consumed by `days-column.tsx`.
+
+**Design note:** `campaignDaySummaries` already iterates `day.channelContent` and computes `readyCount` via `isChannelDayFilled`. Add a parallel `hasPastDue` = "any filled slot on this day whose time is past-due". Reuse the same filled gate so the marker and the preflight blocker agree.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `src/features/campaigns/utils/campaign-days.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { campaignDaySummaries } from './campaign-days'
+
+describe('campaignDaySummaries — hasPastDue', () => {
+  const now = new Date('2026-08-16T12:00:00Z')
+
+  it('marks a day with a filled past-due slot', () => {
+    // campaign timezone 'UTC', window includes 2026-08-16, a filled slot at '11:00'.
+    const [day] = campaignDaySummaries(campaign, now).filter((d) => d.date === '2026-08-16')
+    expect(day.hasPastDue).toBe(true)
+  })
+
+  it('does not mark a day whose filled slots are all in the future', () => {
+    // filled slot at '13:00'
+    const [day] = campaignDaySummaries(campaign, now).filter((d) => d.date === '2026-08-16')
+    expect(day.hasPastDue).toBe(false)
+  })
+
+  it('does not mark a day whose past-due slot is unfilled', () => {
+    const [day] = campaignDaySummaries(campaign, now).filter((d) => d.date === '2026-08-16')
+    expect(day.hasPastDue).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- campaign-days`
+Expected: FAIL (`hasPastDue` doesn't exist on `DaySummary`).
+
+- [ ] **Step 3: Implement `hasPastDue`**
+
+In `src/features/campaigns/utils/campaign-days.ts`:
+
+Add the import:
+```ts
+import { isSlotPastDue } from './slot-timing'
+```
+
+Add `hasPastDue: boolean` to the `DaySummary` interface (after `channelIds`).
+
+Change the signature and compute it inside the `.map`:
+```ts
+export function campaignDaySummaries(
+  campaign: Campaign,
+  now: Date = new Date(),
+): DaySummary[] {
+  const s = campaign.schedule
+  const tz = s.timezone
+  // ...existing days filter unchanged...
+  return days.map((date) => {
+    const day = campaign.slotContent[date]
+    // ...existing channelIds / entries / total / readyCount / skipped / status...
+    const hasPastDue = day
+      ? Object.entries(day.channelContent).some(([key, c]) => {
+          if (!isChannelDayFilled(c)) return false
+          const { time } = parseSlotKey(key)
+          return !!time && isSlotPastDue(date, time, tz, now)
+        })
+      : false
+    return { date, readyCount, total, skipped, status, channelIds, hasPastDue }
+  })
+}
+```
+
+- [ ] **Step 4: Render the marker in the Days column**
+
+In `src/features/campaigns/components/builder/bonzo/days-column.tsx`, find where each day's `readyCount`/`status` is rendered (the "N/M ready" text and status dot). Add a past-due marker for `day.hasPastDue` using theme tokens only — a small destructive dot + "past due" text alongside the existing summary. Example (adapt to the file's actual per-day markup — read it first and match its structure):
+
+```tsx
+{day.hasPastDue && (
+  <span className="inline-flex items-center gap-1 text-[10px] font-medium text-destructive">
+    <span className="size-1.5 rounded-full bg-destructive" />
+    Past due
+  </span>
+)}
+```
+
+Keep the existing ready/partial/empty/skipped states unchanged.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm run test -- campaign-days`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the frontend compiles**
+
+Run: `npm run build`
+Expected: PASS (every `campaignDaySummaries` call still type-checks — the new `now` param is optional; the new `DaySummary.hasPastDue` is populated everywhere the summaries are built).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/campaigns/utils/campaign-days.ts src/features/campaigns/utils/campaign-days.spec.ts src/features/campaigns/components/builder/bonzo/days-column.tsx
+git commit -m "feat(campaigns): mark days with a past-due filled slot in the Days column"
+```
+
+---
+
+### Task 7: Frontend — "Past due" badge on the slot card
+
+**Files:**
+- Modify: `src/features/campaigns/components/builder/bonzo/channels-column.tsx` (badge render ~line 341-350, inside the `.map` at ~line 265)
+- Test: `src/features/campaigns/components/builder/bonzo/channels-column.spec.tsx` (create if absent — a focused render test; if the project has no component-test harness for this file, cover the badge decision via a tiny exported pure helper instead — see Step 3 note)
+
+**Interfaces:**
+- Consumes: `isSlotPastDue` (Task 4); `campaign.schedule.timezone`; `isLaunched` prop (already on `ChannelsColumn`); `isChannelDayFilled`; the per-row `time` + `content` already destructured in the `.map`.
+- Produces: a red "Past due" badge rendered next to the time badge for a NON-launched campaign's filled, past-due slot.
+
+**Design note:** Only for `!isLaunched` (a launched campaign shows the real runtime badge — never touch that path). The badge appears when the slot is filled AND past-due. Place it right after the existing time badge (`channels-column.tsx:341-349`), before `{statusBadge}`. Use `text-destructive` tokens. Add a Tooltip (the file already imports `Tooltip`/`TooltipContent`/`TooltipTrigger`/`TooltipProvider`, and the row is already inside a `TooltipProvider`).
+
+- [ ] **Step 1: Compute `isPastDue` per row**
+
+Inside the `.map(([rowSlotKey, content]) => { ... })` block (~line 265), after `const mediaCount = content.media.length`, add:
+
+```ts
+              const isFilledForTiming = isChannelDayFilled(content)
+              const isPastDue =
+                !isLaunched &&
+                isFilledForTiming &&
+                !!time &&
+                isSlotPastDue(selectedDate, time, campaign.schedule.timezone, new Date())
+```
+
+`selectedDate` is the day being rendered (it's the guard on this branch — the rows belong to `selectedDate`). Add the imports at the top of the file:
+
+```ts
+import { isChannelDayFilled } from '../../../types/slot-content'
+import { isSlotPastDue } from '../../../utils/slot-timing'
+```
+
+(Verify the relative path for `slot-content` matches the file's existing imports — `channels-column.tsx` already imports from `'../../../constants/...'` and `'../../../utils/...'`, so `slot-content` is `'../../../types/slot-content'`.)
+
+- [ ] **Step 2: Render the badge**
+
+Right after the time badge block (`channels-column.tsx:341-349`, the `{!isBulk && time && (<Badge>…</Badge>)}`) and before `{statusBadge}`, add:
+
+```tsx
+                      {isPastDue && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Badge
+                                variant="secondary"
+                                className="shrink-0 gap-1 px-1.5 font-normal text-destructive"
+                              >
+                                <Clock className="size-2.5" />
+                                Past due
+                              </Badge>
+                            }
+                          />
+                          <TooltipContent side="top">
+                            This time has passed — change it or remove this post before launching.
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+```
+
+(`Badge`, `Clock`, `Tooltip`, `TooltipTrigger`, `TooltipContent` are all already imported in this file. The `TooltipTrigger render={...}` pattern is the basecn idiom already used at line 300-310.)
+
+- [ ] **Step 3: Add a test**
+
+Prefer a focused render test if `channels-column` already has a `.spec.tsx` sibling or the project renders components in Vitest with `@testing-library/react`. Assert: rendering `ChannelsColumn` with a non-launched campaign whose selected day has a filled slot at a past time shows "Past due"; a future-time slot does not; a launched campaign never shows it.
+
+If there is **no** existing component-test harness for this column (check for other `*.spec.tsx` under `components/builder/`), do NOT stand one up just for this — instead extract the badge decision into a tiny exported pure function in `slot-timing.ts` and unit-test that:
+
+```ts
+// in slot-timing.ts
+export function shouldShowPastDueBadge(
+  isLaunched: boolean,
+  isFilled: boolean,
+  date: string,
+  time: string,
+  timezone: string,
+  now: Date,
+): boolean {
+  return !isLaunched && isFilled && !!time && isSlotPastDue(date, time, timezone, now)
+}
+```
+and call it from `channels-column.tsx` (`const isPastDue = shouldShowPastDueBadge(isLaunched, isChannelDayFilled(content), selectedDate, time, campaign.schedule.timezone, new Date())`). Then test `shouldShowPastDueBadge` in `slot-timing.spec.ts` (launched → false; unfilled → false; future → false; filled past draft → true). **Ruling for the implementer:** pick whichever matches the repo's existing test conventions; record which you chose in the report.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run test -- channels-column` (or `slot-timing` if you took the pure-helper route)
+Expected: PASS.
+
+- [ ] **Step 5: Verify the frontend compiles**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/campaigns/components/builder/bonzo/channels-column.tsx src/features/campaigns/utils/slot-timing.ts src/features/campaigns/utils/slot-timing.spec.ts
+git commit -m "feat(campaigns): show a red Past due badge on filled past-due draft slots"
+```
+
+(Adjust the staged paths to exactly the files you touched — do NOT stage a `.spec.tsx` you didn't create.)
+
+---
+
+### Task 8: Frontend — time picker in the composer (the move UI)
+
+**Files:**
+- Modify: `src/features/campaigns/components/builder/event-composer.tsx` (add the `TimePickerSelect` to the editable branches' identity block + a `handleTimeChange` that calls `updateEvent` with `newTime`)
+- Test: covered by the mutation-call assertion below (or a focused render test if a composer harness exists)
+
+**Interfaces:**
+- Consumes: `TimePickerSelect` (`src/features/inbox/components/composer/time-picker-select.tsx` — `hour24`, `minute`, `onChange({hour24, minute})`); the `updateEvent` mutation's new `newTime` var (Task 3); `slotKey` (already imported); the `time` prop + `onSelectSlot` re-selection.
+- Produces: user picks a time → `updateEvent.mutate({ date, channelId, time: <old>, patch: draft, newTime: <picked HH:mm> })`; on success re-selects the moved slot; on 409 toasts the server message.
+
+**Design note (scope discipline — read carefully):** The composer has three render branches: read-only (`!editable`, ~line 180), AI-review (~line 234), and normal editable (~line 296). The time picker belongs ONLY in the **editable** branches (AI-review and normal) — never in the read-only branch (a launched/published slot's time must stay fixed). Put it in the shared `identity` block? No — `identity` is reused by the read-only branch too. Instead render the picker as a small row directly under the identity line, in the AI-review and normal branches only. Keep it OUT of the read-only branch entirely.
+
+The picker also needs the slot re-selected after a move (the slot key changes from `channelId@oldTime` to `channelId@newTime`, so the composer's `time` prop would otherwise point at a now-missing slot). Call `onSelectSlot` — but `EventComposer` doesn't currently receive it. Check `ComposerColumn` (the parent): if it already knows the selected slot key, thread an `onTimeChanged?(newKey: string)` callback down, or have `EventComposer` accept the parent's slot-selection setter. **Ruling for the implementer:** the cleanest wiring is to add an optional `onSlotMoved?: (newSlotKey: string) => void` prop to `EventComposer`, call it in the mutation's `onSuccess`, and have `ComposerColumn` pass its existing "select slot" handler. Read `composer-column.tsx` first to confirm the handler's name; if the parent selects by slot key, this is a one-line pass-through.
+
+- [ ] **Step 1: Read the parent to confirm slot-selection wiring**
+
+Read `src/features/campaigns/components/builder/composer-column.tsx` (or wherever `EventComposer` is rendered — grep `EventComposer`) to find how the selected slot key is set. Note the setter's name for Step 3.
+
+- [ ] **Step 2: Add a `parseHHmm` helper + the time-change handler in `event-composer.tsx`**
+
+Near the top of the component (after `const stored = ...`), add a local parse of the current `time` into hour/minute for the picker, and a handler:
+
+```ts
+  // Current slot time → hour24/minute for the picker. `time` is 'HH:mm'.
+  const [th, tm] = time.split(':').map(Number)
+  const hour24 = Number.isFinite(th) ? th : 9
+  const minute = Number.isFinite(tm) ? tm : 0
+
+  function handleTimeChange(next: { hour24: number; minute: number }) {
+    const newTime = `${String(next.hour24).padStart(2, '0')}:${String(next.minute).padStart(2, '0')}`
+    if (newTime === time) return
+    mutations.updateEvent.mutate(
+      { date, channelId, time, newTime, patch: { ...draft } },
+      {
+        onSuccess: () => onSlotMoved?.(slotKey(channelId, newTime)),
+        onError: (err: unknown) => {
+          // Server 409 (collision / launched) — surface its message; the picker
+          // reverts to the old time on the next render since the move didn't take.
+          const message =
+            err instanceof Error ? err.message : 'Could not change the time.'
+          toast.error(message)
+        },
+      },
+    )
+  }
+```
+
+Add the `onSlotMoved` prop to `EventComposerProps`:
+```ts
+  /** Called after a successful time move so the parent can re-select the slot
+   *  at its new key (the slot key encodes the time). */
+  onSlotMoved?: (newSlotKey: string) => void
+```
+and accept it in the destructured params (with the other props).
+
+- [ ] **Step 3: Render `TimePickerSelect` in the two editable branches**
+
+Import it at the top:
+```ts
+import { TimePickerSelect } from '@/features/inbox/components/composer/time-picker-select'
+```
+
+In the **normal editable** branch (the final `return`, ~line 296) and the **AI-review** branch (~line 234), add a compact time-picker row directly under the pinned top bar (after the `identity`/Save bar `</div>`, before the authoring surface). Example for the normal branch:
+
+```tsx
+      {/* Editable slot time — moving it reschedules where this post fires. */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-2">
+        <span className="text-[11px] font-medium text-muted-foreground">Time</span>
+        <TimePickerSelect
+          hour24={hour24}
+          minute={minute}
+          onChange={handleTimeChange}
+          className="max-w-[220px]"
+        />
+      </div>
+```
+
+Wire the parent (`composer-column.tsx`) to pass `onSlotMoved={<its slot-select setter>}` — using the setter name found in Step 1 (e.g. `onSlotMoved={setSelectedSlotKey}` or `onSlotMoved={handleSelectSlot}`).
+
+Do NOT add the picker to the read-only branch (`if (!editable)`, ~line 180).
+
+- [ ] **Step 4: Verify the frontend compiles + existing tests green**
+
+Run: `npm run build`
+Expected: PASS.
+Run: `npm run test -- campaigns`
+Expected: existing campaigns FE tests stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/campaigns/components/builder/event-composer.tsx src/features/campaigns/components/builder/composer-column.tsx
+git commit -m "feat(campaigns): edit a slot's time in the composer (time picker → newTime move)"
+```
+
+(Stage only the files you actually touched — confirm the parent file's real name from Step 1.)
+
+---
+
+### Task 9: Full build + test gate (both repos)
+
+**Files:** none (verification task).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Backend build + tests**
+
+In `socialmedia-workspace`:
+Run: `npm run build` → Expected: PASS.
+Run: `npm run test -- campaigns` → Expected: PASS (all campaigns specs, including the new `newTime` cases).
+
+- [ ] **Step 2: Frontend build + tests**
+
+In `socialmedia-frontend-campaigns`:
+Run: `npm run build` → Expected: PASS.
+Run: `npm run test` → Expected: PASS (slot-timing, preflight, campaign-days, and whatever composer/channels-column tests were added; existing suites green).
+
+- [ ] **Step 3: Ledger the result**
+
+Record both build/test outcomes in the SDD ledger. No commit (nothing changed).
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec §2 "Editable slot time (pre-launch)" → Tasks 1, 2 (backend `newTime` move + 409s), 3, 8 (FE picker + wiring). ✅
+- Spec §2 "Past-due in 3 places: red badge / preflight blocker / days indicator" → Task 7 (badge), Task 5 (preflight), Task 6 (days). ✅
+- Spec §2 "Launch rule: BLOCK until fixed" → Task 5 (the `pastDue` blocker feeds the existing `blockers.length > 0` launch gate at `builder-header.tsx:237`). ✅
+- Spec §2 "timezone-correct comparison" → Task 4 (`isSlotPastDue` mirrors `wallClockToUtc`). ✅
+- Spec §4.1a/1b (DTO + move + collision 409 + launched 409) → Tasks 1, 2. ✅
+- Spec §4.2c (past-due util), 2d (badge), 2e (blocker), 2f (days), 2a/2b (picker + api) → Tasks 4, 7, 5, 6, 8, 3. ✅
+- Spec §7 testing (backend move/collision/launched/no-newTime; FE isSlotPastDue/preflight/badge/picker) → Tasks 2, 4, 5, 6, 7. ✅
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". The two rulings-for-implementer (Task 7 test strategy, Task 8 parent-wiring name) are explicit decision points with a stated default + a "confirm from the file" instruction, not vague placeholders — they exist because the exact parent handler name can't be known without reading `composer-column.tsx`, and the plan tells the implementer to read it and which default to take.
+
+**3. Type consistency:**
+- `isSlotPastDue(date, time, timezone, now)` — same 4-arg signature in Tasks 4, 5, 6, 7. ✅
+- `computePreflight(campaign, channelNameById?, now?)` — third param added in Task 5; both call sites updated in the same task. ✅
+- `campaignDaySummaries(campaign, now?)` + `DaySummary.hasPastDue` — added and consumed within Task 6. ✅
+- `updateEvent(..., time?, newTime?)` — API (Task 3) → mutation var `newTime?` (Task 3) → composer call (Task 8). ✅
+- `UpdateEventDto.newTime?` (Task 1) consumed by `updateEvent` (Task 2). ✅
+- `onSlotMoved?: (newSlotKey: string) => void` — defined + called in Task 8, passed by the parent in the same task. ✅
+
+Plan is internally consistent and fully covers the spec.

--- a/docs/superpowers/plans/2026-08-16-launched-slot-edit.md
+++ b/docs/superpowers/plans/2026-08-16-launched-slot-edit.md
@@ -1,0 +1,461 @@
+# Launched-Campaign Slot View & Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On a launched campaign, let users open published slots read-only in the composer and truly edit still-scheduled slots (edits actually re-publish), while fixing the live bug where post-launch edits silently publish stale content.
+
+**Architecture:** Backend-first. A shared guard classifies each slot edit on a launched (`active`) campaign as read-only (409) or editable-with-re-materialize. The editable path reuses the proven `pause` primitive (cancel job → race-safe `posts` delete → re-enqueue) per single slot. Frontend makes launched slots selectable and drives the composer into read-only vs editable mode by the slot's `runtime.slotStatus`.
+
+**Tech Stack:** NestJS + Drizzle + BullMQ (backend, `socialmedia-workspace`); Vite + React 19 + TS + Tailwind 3 + shadcn + TanStack Query (frontend, worktree `socialmedia-frontend-campaigns`). Both on branch `feat/launched-slot-edit` off `main`.
+
+**Spec:** `socialmedia-workspace/docs/superpowers/specs/2026-08-16-launched-slot-edit-design.md`
+
+## Global Constraints
+
+- **NO DB migration** — all changes are logic + existing columns (`campaign_slot_content.slotStatus/postId/jobId`, `campaigns.status`).
+- **Draft-campaign behaviour byte-for-byte unchanged** — guards only engage when `campaign.status === 'active'`.
+- **Reuse the `pause` primitive's race-safe delete:** `db.delete(posts).where(and(eq(posts.id, postId), eq(posts.status, 'scheduled')))` — NEVER delete an in-flight (`publishing`) post. A 0-row delete means the post already fired → 409, abort the edit.
+- **Editable slot statuses** = `pending`, `scheduled`. **Read-only** = `publishing`, `published`, `failed`, `skipped`.
+- **shadcn-only UI**, theme tokens only (no hex, no arbitrary Tailwind colors).
+- **Never** `git add .`/`-A`. FE `.env` is git-tracked with secrets; BE `.env` gitignored with secrets. Surgical `git add <path>` only.
+- Messaging effort (`feat/campaign-messaging-channels`) is now MERGED into main and this branch was rebased onto it — so `MessageComposer` (`src/features/campaigns/components/create/steps/composers/message-composer.tsx`) and the `'message'` post type EXIST on this branch. The read-only prop must thread through `ChannelDayComposer` AND `MessageComposer` (a launched Slack/Discord slot renders read-only too: destination picker disabled, message textarea read-only, no media add/remove).
+
+---
+
+## BACKEND (all backend tasks before frontend)
+
+### Task 1: `assertSlotEditable` guard helper + reusable single-slot cancel
+
+**Files:**
+- Modify: `socialmedia-workspace/src/campaigns/campaigns.service.ts` (add private helpers)
+- Test: `socialmedia-workspace/src/campaigns/campaigns.service.spec.ts` (extend)
+
+**Interfaces:**
+- Produces:
+  - `private assertLaunchedSlotEditable(campaignStatus: string, slotStatus: string): void` — throws `ConflictException` if `campaignStatus === 'active'` AND `slotStatus ∈ {publishing, published, failed, skipped}`; no-op otherwise. Consumed by Tasks 2, 3, 4.
+  - `private async cancelAndClearSlotPost(slot: { jobId: string | null; postId: string | null }): Promise<boolean>` — cancels the job (if any) and deletes the `posts` row guarded on `status='scheduled'`; returns `true` if safe to proceed, `false` if the post already fired (0-row delete). Consumed by Tasks 2, 4.
+
+**Context:** `campaigns.service.ts` imports: `ConflictException` from `@nestjs/common` (add to the existing import), `posts` from `../drizzle/schema/posts.schema`, `and`/`eq` from `drizzle-orm` (already imported), `this.publishing.cancelSlotJob`. The `pause` method (`:975-1012`) is the exact template for `cancelAndClearSlotPost`.
+
+- [ ] **Step 1: Write the failing test.** In `campaigns.service.spec.ts`, add unit tests for `assertLaunchedSlotEditable` (call it via a tiny cast to access the private, or test through `updateEvent` in Task 2 — prefer a direct private-method test here). Cases:
+  - `assertLaunchedSlotEditable('draft', 'published')` → does NOT throw (draft unguarded).
+  - `assertLaunchedSlotEditable('active', 'scheduled')` → does NOT throw.
+  - `assertLaunchedSlotEditable('active', 'pending')` → does NOT throw.
+  - `assertLaunchedSlotEditable('active', 'published')` → throws `ConflictException`.
+  - `assertLaunchedSlotEditable('active', 'publishing')` → throws.
+  - `assertLaunchedSlotEditable('active', 'failed')` → throws.
+  - `assertLaunchedSlotEditable('active', 'skipped')` → throws.
+
+```ts
+// access private via cast
+const svc = /* constructed service */;
+const call = (cs: string, ss: string) => (svc as any).assertLaunchedSlotEditable(cs, ss);
+expect(() => call('draft', 'published')).not.toThrow();
+expect(() => call('active', 'scheduled')).not.toThrow();
+expect(() => call('active', 'published')).toThrow(ConflictException);
+// ...etc
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaigns.service.spec.ts -t assertLaunchedSlotEditable`
+Expected: FAIL (method undefined).
+
+- [ ] **Step 3: Implement both helpers.**
+
+```ts
+private assertLaunchedSlotEditable(campaignStatus: string, slotStatus: string): void {
+  if (campaignStatus !== 'active') return; // draft/scheduled/paused/etc. — unguarded
+  const readOnly = ['publishing', 'published', 'failed', 'skipped'];
+  if (readOnly.includes(slotStatus)) {
+    throw new ConflictException(
+      slotStatus === 'skipped'
+        ? 'This post was skipped and can no longer be edited.'
+        : 'This post has already been published and can no longer be edited.',
+    );
+  }
+}
+
+/** Cancels the enqueued job and deletes the not-yet-fired posts row for one
+ *  slot (mirrors `pause`, race-safe on posts.status='scheduled'). Returns
+ *  false if the post already flipped to publishing (0 rows deleted) — the
+ *  caller must abort with 409 rather than re-materialize a fired post. */
+private async cancelAndClearSlotPost(slot: {
+  jobId: string | null;
+  postId: string | null;
+}): Promise<boolean> {
+  if (slot.jobId) await this.publishing.cancelSlotJob(slot.jobId);
+  if (slot.postId) {
+    const deleted = await db
+      .delete(posts)
+      .where(and(eq(posts.id, slot.postId), eq(posts.status, 'scheduled')))
+      .returning({ id: posts.id });
+    if (deleted.length === 0) return false; // already publishing/published
+  }
+  return true;
+}
+```
+
+**Note for implementer:** confirm `ConflictException` is added to the `@nestjs/common` import; confirm `posts` schema import exists (add if missing); confirm `.returning()` is supported by this Drizzle/pg setup (it is — used elsewhere). If `db.delete(...).returning()` isn't available in this driver, use `.rowCount`-style check the project already uses; grep for an existing guarded delete to match the idiom.
+
+- [ ] **Step 4: Run tests to verify pass.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaigns.service.spec.ts -t assertLaunchedSlotEditable`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "feat(campaigns): slot-edit guard + single-slot cancel-and-clear helper (launched safety)"
+```
+
+---
+
+### Task 2: `updateEvent` — guard + re-materialize on launched scheduled slots
+
+**Files:**
+- Modify: `socialmedia-workspace/src/campaigns/campaigns.service.ts` (`updateEvent`, `:1272-1308`)
+- Test: `socialmedia-workspace/src/campaigns/campaigns.service.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: `assertLaunchedSlotEditable`, `cancelAndClearSlotPost` (Task 1); `computeSlotSchedule` (`../campaigns/campaign-schedule.util` — already imported/used in `launch`); `publishing.materializeAndEnqueue`; `resolveSlotChannels`/`loadCreatedById` (used in `launch`).
+
+**Context:** `updateEvent` currently reads the slot, merges `dto.patch` into `slot.content`, writes it back. It must now: (a) also load the campaign row's `status` (it only has `getOne` returning a DTO — read the raw `campaigns` row for `status`, or add `status` to what `getOne` exposes; simplest: a small `db.select({ status: campaigns.status }).from(campaigns).where(eq(campaigns.id, id))`); (b) call the guard with `(campaign.status, slot.slotStatus)`; (c) for a launched `scheduled` slot, after writing merged content, re-materialize.
+
+- [ ] **Step 1: Write failing tests.** Cases (mock `publishing.materializeAndEnqueue` → `{postId:'p2', jobId:'j2'}`, `cancelSlotJob`, and the db calls following the spec's existing mocking style):
+  - Draft campaign: `updateEvent` merges content, does NOT call cancel/materialize (unchanged behaviour).
+  - Active campaign + slot `published`: throws `ConflictException`, no content write.
+  - Active + slot `scheduled`, not past-due: merges content → calls `cancelAndClearSlotPost` (cancel + delete) → `materializeAndEnqueue` with the MERGED content → stores new `postId/jobId/scheduledAt`, slotStatus `scheduled`.
+  - Active + slot `scheduled` but post already publishing (cancelAndClearSlotPost returns false): throws `ConflictException`, does not re-enqueue.
+  - Active + slot `scheduled`, edited slot now past-due (computeSlotSchedule returns it in `pastDue`): sets slotStatus `skipped`, does NOT re-enqueue.
+  - Active + slot `pending`: merges content, no cancel/materialize (nothing enqueued yet).
+
+- [ ] **Step 2: Run — verify fail.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaigns.service.spec.ts -t updateEvent`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** After the existing slot lookup + before/around the content write:
+
+```ts
+// Load campaign status (raw row) for the launched-edit guard.
+const [camp] = await db
+  .select({ status: campaigns.status })
+  .from(campaigns)
+  .where(eq(campaigns.id, id));
+const campaignStatus = camp?.status ?? 'draft';
+
+this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);
+
+const mergedContent: ChannelDayContentJson = { ...slot.content, ...dto.patch };
+
+await db
+  .update(campaignSlotContent)
+  .set({ content: mergedContent, updatedAt: new Date() })
+  .where(eq(campaignSlotContent.id, slot.id));
+
+// Launched + still-scheduled: the enqueued post is stale — cancel & re-enqueue
+// from the merged content so the NEW content actually fires.
+if (campaignStatus === 'active' && slot.slotStatus === 'scheduled') {
+  const safe = await this.cancelAndClearSlotPost({ jobId: slot.jobId, postId: slot.postId });
+  if (!safe) {
+    throw new ConflictException(
+      'This post just started publishing and can no longer be edited. Reload to see its status.',
+    );
+  }
+  const createdById = await this.loadCreatedById(id);
+  const channelMap = await this.resolveSlotChannels([slot.channelId]);
+  const platform = channelMap.get(slot.channelId);
+  const { due, pastDue } = computeSlotSchedule(
+    // reload the campaign schedule for computeSlotSchedule
+    (await this.getOne(workspaceId, id)).schedule,
+    [{ date: slot.date, time: slot.time }],
+    new Date(),
+  );
+  const scheduledAt = due[0]?.scheduledAt;
+  const isPastDue = pastDue.length > 0 || !scheduledAt;
+  if (!platform || isPastDue) {
+    await db
+      .update(campaignSlotContent)
+      .set({
+        slotStatus: 'skipped',
+        postId: null,
+        jobId: null,
+        scheduledAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(campaignSlotContent.id, slot.id));
+  } else {
+    const { postId, jobId } = await this.publishing.materializeAndEnqueue({
+      workspaceId,
+      createdById,
+      campaignId: id,
+      date: slot.date,
+      channelId: slot.channelId,
+      time: slot.time,
+      content: mergedContent,
+      platform,
+      scheduledAt,
+    });
+    await db
+      .update(campaignSlotContent)
+      .set({ postId, jobId, scheduledAt, slotStatus: 'scheduled', updatedAt: new Date() })
+      .where(eq(campaignSlotContent.id, slot.id));
+  }
+}
+```
+
+**Note for implementer:** the existing `updateEvent` already touches `campaigns.updatedAt` at the end — keep that. Confirm `campaigns` schema + `computeSlotSchedule` + `loadCreatedById`/`resolveSlotChannels` imports are present (all used by `launch`). If `slot` from the initial `select()` doesn't include `slotStatus`/`postId`/`jobId`/`time`, change the select to the full row (`.select()` already returns all columns — verify). Match the exact `materializeAndEnqueue` input shape from `launch` (`:942`).
+
+- [ ] **Step 4: Run tests — pass.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns && npm run build`
+Expected: campaigns tests PASS; build exit 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "fix(campaigns): re-materialize on edit of a launched scheduled slot (was publishing stale content)"
+```
+
+---
+
+### Task 3: `addEvent` — guard on launched campaigns
+
+**Files:**
+- Modify: `socialmedia-workspace/src/campaigns/campaigns.service.ts` (`addEvent`, `:1210-1267`)
+- Test: `socialmedia-workspace/src/campaigns/campaigns.service.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: `assertLaunchedSlotEditable` (Task 1).
+
+**Context:** `addEvent` adds a NEW slot (or resets an existing one to empty content). On a launched campaign, adding a brand-new slot that never gets materialized would sit `pending` and never publish (launch already happened) — confusing. Decision: on a launched (`active`) campaign, **block adding a new slot** (409 "Add posts before launching, or edit an existing scheduled post."). Editing/re-adding over an existing slot is covered by `updateEvent`. This keeps `addEvent` simple and avoids a materialize-on-add path.
+
+- [ ] **Step 1: Write failing tests.**
+  - Draft campaign: `addEvent` works unchanged (inserts slot).
+  - Active campaign: `addEvent` throws `ConflictException` (no insert).
+
+- [ ] **Step 2: Run — verify fail.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaigns.service.spec.ts -t addEvent`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Near the top of `addEvent`, after `getOne`/campaign load, read the campaign status and block if launched:
+
+```ts
+const [camp] = await db
+  .select({ status: campaigns.status })
+  .from(campaigns)
+  .where(eq(campaigns.id, id));
+if ((camp?.status ?? 'draft') === 'active') {
+  throw new ConflictException(
+    'This campaign is already launched — you can edit scheduled posts but not add new ones.',
+  );
+}
+```
+
+(Place BEFORE any slot insert/mutation.)
+
+- [ ] **Step 4: Run tests + build.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "feat(campaigns): block adding new slots to a launched campaign"
+```
+
+---
+
+### Task 4: `removeEvent` — guard + cancel job before delete
+
+**Files:**
+- Modify: `socialmedia-workspace/src/campaigns/campaigns.service.ts` (`removeEvent`, `:1310-1335`)
+- Test: `socialmedia-workspace/src/campaigns/campaigns.service.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: `assertLaunchedSlotEditable`, `cancelAndClearSlotPost` (Task 1).
+
+**Context:** current `removeEvent` deletes the slot row with NO guard and NO job cancel → on a launched campaign it orphans the enqueued job (post still fires) and breaks status tracking. Fix: load the slot first; guard; for a launched `scheduled` slot, cancel+clear the post before deleting the slot row.
+
+- [ ] **Step 1: Write failing tests.**
+  - Draft: `removeEvent` deletes the slot (unchanged).
+  - Active + slot `published`: throws `ConflictException`, no delete.
+  - Active + slot `scheduled`: calls `cancelAndClearSlotPost` (cancel + delete post) THEN deletes the slot row.
+  - Active + slot `scheduled` but post already publishing (returns false): throws `ConflictException`, slot NOT deleted.
+
+- [ ] **Step 2: Run — verify fail.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns/campaigns.service.spec.ts -t removeEvent`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Change `removeEvent` to load the slot (currently it deletes by match without selecting). Read the slot row (with `slotStatus/postId/jobId`) + campaign status; guard; cancel+clear if launched scheduled; then delete:
+
+```ts
+async removeEvent(workspaceId: string, id: string, dto: RemoveEventDto): Promise<CampaignDto> {
+  await this.getOne(workspaceId, id);
+
+  const [slot] = await db
+    .select()
+    .from(campaignSlotContent)
+    .where(
+      and(
+        eq(campaignSlotContent.campaignId, id),
+        eq(campaignSlotContent.date, dto.date),
+        eq(campaignSlotContent.channelId, dto.channelId),
+        ...(dto.time ? [eq(campaignSlotContent.time, dto.time)] : []),
+      ),
+    );
+
+  if (slot) {
+    const [camp] = await db
+      .select({ status: campaigns.status })
+      .from(campaigns)
+      .where(eq(campaigns.id, id));
+    const campaignStatus = camp?.status ?? 'draft';
+    this.assertLaunchedSlotEditable(campaignStatus, slot.slotStatus);
+
+    if (campaignStatus === 'active' && slot.slotStatus === 'scheduled') {
+      const safe = await this.cancelAndClearSlotPost({ jobId: slot.jobId, postId: slot.postId });
+      if (!safe) {
+        throw new ConflictException(
+          'This post just started publishing and can no longer be removed.',
+        );
+      }
+    }
+
+    await db.delete(campaignSlotContent).where(eq(campaignSlotContent.id, slot.id));
+  }
+
+  await db.update(campaigns).set({ updatedAt: new Date() }).where(eq(campaigns.id, id));
+  await this.refreshChannelCache(id);
+  return this.assembleCampaign(id);
+}
+```
+
+(Preserves the "no slot found → still returns campaign" tolerance by guarding the whole block on `if (slot)`.)
+
+- [ ] **Step 4: Run tests + build.**
+
+Run: `cd socialmedia-workspace && npx jest src/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/campaigns/campaigns.service.ts src/campaigns/campaigns.service.spec.ts
+git commit -m "fix(campaigns): cancel job + guard on removing a launched scheduled slot (was orphaning the post)"
+```
+
+---
+
+## FRONTEND (after backend tasks complete)
+
+> Worktree `socialmedia-frontend-campaigns`, branch `feat/launched-slot-edit`. Run FE commands with `cd socialmedia-frontend-campaigns`.
+
+### Task 5: Make launched slots selectable + editability helper
+
+**Files:**
+- Create: `src/features/campaigns/utils/slot-editability.ts` (+ test)
+- Modify: `src/features/campaigns/components/builder/bonzo/channels-column.tsx` (launched slots clickable; delete only for editable)
+
+**Interfaces:**
+- Produces: `isSlotEditable(content: ChannelDayContent, isLaunched: boolean): boolean` — `!isLaunched || (runtime?.slotStatus ?? 'pending') ∈ {pending, scheduled}`. Consumed by Tasks 5, 6.
+
+- [ ] **Step 1: Write failing test.** `slot-editability.spec.ts`:
+  - not launched → always editable (any status).
+  - launched + no runtime → editable (treated pending).
+  - launched + `scheduled` → editable.
+  - launched + `pending` → editable.
+  - launched + `published`/`publishing`/`failed`/`skipped` → NOT editable.
+
+- [ ] **Step 2: Run — fail.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns/utils/slot-editability.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement helper.**
+
+```ts
+import type { ChannelDayContent } from '../types/slot-content'
+
+const EDITABLE_RUNTIME = new Set(['pending', 'scheduled'])
+
+/** A slot is editable when the campaign isn't launched, or (launched) the
+ *  slot hasn't fired yet (pending/scheduled). published/publishing/failed/
+ *  skipped are read-only. */
+export function isSlotEditable(content: ChannelDayContent, isLaunched: boolean): boolean {
+  if (!isLaunched) return true
+  return EDITABLE_RUNTIME.has(content.runtime?.slotStatus ?? 'pending')
+}
+```
+
+- [ ] **Step 4: Make launched slots clickable in `channels-column.tsx`.** Currently launched slots render a non-clickable `<div>` (`:408-417`) with no delete. Change: render the SAME clickable `<button onClick={onSelectSlot}>` used for draft slots for ALL slots; keep the runtime status badge + timestamp (already present) in the card. Show the delete (trash) affordance only when `isSlotEditable(content, isLaunched)` is true (draft slots: always; launched: only pending/scheduled). Do NOT change the card's status badge/timestamp rendering.
+
+- [ ] **Step 5: Run tests + build.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/features/campaigns/utils/slot-editability.ts src/features/campaigns/utils/slot-editability.spec.ts src/features/campaigns/components/builder/bonzo/channels-column.tsx
+git commit -m "feat(campaigns): launched slots open in the composer; delete only for still-editable slots"
+```
+
+---
+
+### Task 6: Read-only composer mode + editable launched slot
+
+**Files:**
+- Modify: `src/features/campaigns/components/builder/bonzo/composer-column.tsx` (pass isLaunched)
+- Modify: `src/features/campaigns/components/builder/campaign-builder-view.tsx` (pass isLaunched to ComposerColumn)
+- Modify: `src/features/campaigns/components/builder/event-composer.tsx` (read-only vs editable; status strip)
+- Modify: `src/features/campaigns/components/create/steps/composers/channel-day-composer.tsx` (thread a `readOnly` prop to disable inputs)
+
+**Interfaces:**
+- Consumes: `isSlotEditable` (Task 5); `resolveSlotBadge`/`SLOT_RUNTIME_CONFIG` (`constants/slot-runtime-config.tsx`) for the status strip.
+
+**Context:** `campaign-builder-view.tsx` already computes `isLaunched` (`isCampaignLaunched(campaign)`) and passes it to `ChannelsColumn` but NOT to `ComposerColumn`. Thread it through. `EventComposer` (`event-composer.tsx`) computes the stored slot + draft; it must switch to a read-only presentation when the slot isn't editable.
+
+- [ ] **Step 1: Thread `isLaunched` to the composer.** In `campaign-builder-view.tsx`, pass `isLaunched` to BOTH `<ComposerColumn>` instances (narrow drill-down + desktop). In `composer-column.tsx`, accept `isLaunched?: boolean` and forward to `<EventComposer>`.
+
+- [ ] **Step 2: `EventComposer` editability.** Accept `isLaunched?: boolean`. Compute `const editable = isSlotEditable(stored ?? draftAsContent, isLaunched ?? false)` (use the STORED content's runtime status — a launched published slot is read-only regardless of draft). When `!editable`:
+  - Render the composer body via `ChannelDayComposer` with a new `readOnly` prop (Step 4) so all inputs are disabled.
+  - Replace the Save row with a status strip: the runtime badge (`resolveSlotBadge(stored)`), the published-at (`stored.runtime?.publishedAt`) or scheduled-at, and `stored.runtime?.lastError` for failed (in `text-destructive`). No Save button, no AI actions, no delete.
+  - Theme tokens only.
+  When `editable` AND `isLaunched`: keep the normal editable composer + Save, and add a subtle inline note near Save: "Saving reschedules this post." (muted text). On the `updateEvent` mutation success, if the returned slot's `runtime.slotStatus === 'skipped'`, `toast("This post's time has passed — it's now skipped.")`.
+
+- [ ] **Step 3: Build the status strip + wire.** Use a shadcn `Badge` for the status; muted text for timestamps; `text-destructive` for errors. Keep it inside `EventComposer`'s existing pinned-top-bar layout so it reads consistently.
+
+- [ ] **Step 4: `readOnly` prop through `ChannelDayComposer` AND `MessageComposer`.** Add `readOnly?: boolean` to `ChannelDayComposer` props; when true, disable the mode strip, post-type tabs, and pass `disabled`/`readOnly` to the body editors (`ManualBody`'s `EditorCard`/text/media, poll, thread). The simplest robust approach: when `readOnly`, render the body but wrap it so inputs are non-interactive (e.g. `EditorCard` `readOnly` / disabled textareas, `pointer-events-none` on media pickers with an explicit disabled visual — but PREFER real `disabled`/`readOnly` attributes over `pointer-events-none` for a11y). Confirm `EditorCard` supports a read-only/disabled prop; if not, gate the interactive affordances (add-media, template, AI) off and set the textarea `readOnly`. Non-readonly path unchanged.
+  **Also thread `readOnly` into `MessageComposer`** (`create/steps/composers/message-composer.tsx`, from the merged messaging effort — `ChannelDayComposer` routes Slack/Discord slots there via its `platformCfg.default === 'message'` early-return): when `readOnly`, disable the `DestinationPicker` (Select disabled), make the message `Textarea` read-only, and hide/disable the media attach/replace/remove `Button`s — so a launched Slack/Discord published slot is inspectable but not editable. Thread the prop through the early-return call in `ChannelDayComposer` too. Non-readonly messaging path unchanged.
+
+- [ ] **Step 5: Run tests + build.**
+
+Run: `cd socialmedia-frontend-campaigns && npx vitest run src/features/campaigns && npm run build`
+Expected: PASS + exit 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/features/campaigns/components/builder/bonzo/composer-column.tsx src/features/campaigns/components/builder/campaign-builder-view.tsx src/features/campaigns/components/builder/event-composer.tsx src/features/campaigns/components/create/steps/composers/channel-day-composer.tsx
+git commit -m "feat(campaigns): read-only composer for published slots; editable + reschedule note for scheduled slots on launched campaigns"
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Spec coverage:** guard+bug-fix = Tasks 1-4 (backend); view/edit UX = Tasks 5-6 (frontend). §4 Layer 1 → Tasks 1-4; Layer 2 → Tasks 5-6.
+- **Type consistency:** editable-status set = `{pending, scheduled}` everywhere (backend `assertLaunchedSlotEditable` read-only list is the complement; frontend `isSlotEditable` uses the same two). The re-materialize `materializeAndEnqueue` input shape matches `launch` (`:942`) exactly.
+- **Draft unchanged:** every guard early-returns when `campaign.status !== 'active'`; every re-materialize block is gated on `campaignStatus === 'active'`.
+- **Race safety:** `cancelAndClearSlotPost` returns false on a 0-row `status='scheduled'` delete → caller 409s. Never re-materialize a fired post.
+- **Verify-at-implementation flags:** `ConflictException`/`posts`/`campaigns` imports present; `.returning()` support (else match existing guarded-delete idiom); `slot` select returns full row incl. `slotStatus/postId/jobId/time`; `EditorCard` read-only/disabled support (Task 6 Step 4); `MessageComposer` NOT referenced (messaging not on this branch).
+- **No migration.** No DTO shape change (responses already carry runtime).

--- a/docs/superpowers/plans/2026-08-18-unify-workspace-role-guards.md
+++ b/docs/superpowers/plans/2026-08-18-unify-workspace-role-guards.md
@@ -1,0 +1,333 @@
+# Unify Workspace Role Guards — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `workspace-members` authorization onto the shared `WorkspaceRoleGuard` + `@RequireCapability` mechanism (as `channels` already uses), with a new `team:view` capability so any member can see the roster while only ADMIN+ can manage it, making the capability map the single source of truth.
+
+**Architecture:** NestJS. A declarative `WorkspaceRoleGuard` reads `@RequireCapability(cap)` metadata, resolves the caller's workspace role via `WorkspaceRoleService.getRole`, and checks it against the rank-based `role-capabilities.ts` map. This plan (1) adds `team:view` to the map, (2) makes the guard super-admin-aware, (3) wires the guard onto the members controller's workspace-scoped routes per a fixed endpoint→capability table, keeping existing service-layer checks as defense-in-depth, and (4) mirrors the map addition on the frontend.
+
+**Tech Stack:** NestJS, Drizzle ORM, class-validator, Jest (BE) · React 19 + Vite + Vitest (FE).
+
+**Spec:** `socialmedia-workspace/docs/superpowers/specs/2026-08-18-unify-workspace-role-guards-design.md`
+
+## Global Constraints
+
+- Two repos: BE `socialmedia-workspace`, FE `socialmedia-frontend`. Both on branch `feat/unify-workspace-role-guards`.
+- The BE `role-capabilities.ts` map and FE `capabilities.ts` map MUST stay byte-identical in their `Capability` union and `CAPABILITY_MIN_ROLE` object. Any change to one is mirrored to the other in the same effort.
+- `WorkspaceRoleGuard` can ONLY guard routes that carry `:workspaceId` AND run behind `JwtAuthGuard` (it reads `req.user.userId` + `req.params.workspaceId`). Never apply `@RequireCapability` to token- or "me"-scoped routes.
+- Guard order on a method is `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` — `JwtAuthGuard` first so `req.user` exists. Method-level `@UseGuards` replaces the class-level guard for that handler, so re-list `JwtAuthGuard` explicitly.
+- The guard is ADDITIVE: existing inline service checks (`isOwner || isAdmin`, `isSelf`, `isInviter`, super-admin) stay in place. Do NOT delete them.
+- `removeMember` must remain reachable by a non-manager removing THEIR OWN row (self-removal), so it does NOT get `@RequireCapability('team:manage')`.
+- No DB migration. No new roles. `channels.controller.ts` is untouched.
+- Never `git add .` / `-A` (FE `.env` is tracked with secrets; BE `.env` gitignored with secrets). Surgical `git add <path>` only. Commit only; do not push (controller handles finishing).
+- Verify BE compiles (`npm run build` in `socialmedia-workspace`) and tests pass (`npm test`); FE tests pass (`npm test` / vitest in `socialmedia-frontend`).
+
+---
+
+### Task 1: Add `team:view` capability (BE + FE map, mirrored) + unit tests
+
+**Files:**
+- Modify: `socialmedia-workspace/src/workspace-members/role-capabilities.ts`
+- Modify: `socialmedia-workspace/src/workspace-members/role-capabilities.spec.ts`
+- Modify: `socialmedia-frontend/src/features/team/utils/capabilities.ts`
+- Modify: `socialmedia-frontend/src/features/team/utils/capabilities.test.ts`
+
+**Interfaces:**
+- Produces: `Capability` union now includes `'team:view'`; `CAPABILITY_MIN_ROLE['team:view'] === 'GUEST'`. Used by Task 3 (`@RequireCapability('team:view')` on `getMembers`) and by the guard.
+
+- [ ] **Step 1: Update the BE capability map**
+
+In `socialmedia-workspace/src/workspace-members/role-capabilities.ts`, add `'team:view'` to the `Capability` union (place it just above `'team:manage'` for readability) and add its min-role entry to `CAPABILITY_MIN_ROLE`:
+
+```ts
+export type Capability =
+  | 'billing:manage'
+  | 'workspace:delete'
+  | 'team:view'
+  | 'team:manage'
+  | 'channels:manage'
+  | 'posts:publish'
+  | 'inbox:reply'
+  | 'posts:draft'
+  | 'inbox:view'
+  | 'analytics:view';
+```
+
+```ts
+export const CAPABILITY_MIN_ROLE: Record<Capability, WorkspaceRole> = {
+  'billing:manage': 'OWNER',
+  'workspace:delete': 'OWNER',
+  'team:view': 'GUEST',
+  'team:manage': 'ADMIN',
+  'channels:manage': 'MEMBER',
+  'posts:publish': 'MEMBER',
+  'inbox:reply': 'MEMBER',
+  'posts:draft': 'GUEST',
+  'inbox:view': 'GUEST',
+  'analytics:view': 'GUEST',
+};
+```
+
+- [ ] **Step 2: Mirror the change on the FE map**
+
+In `socialmedia-frontend/src/features/team/utils/capabilities.ts`, make the identical edit to the `Capability` union and `CAPABILITY_MIN_ROLE`. The two objects must match byte-for-byte in their entries.
+
+- [ ] **Step 3: Write BE tests (add to existing spec)**
+
+Append to `socialmedia-workspace/src/workspace-members/role-capabilities.spec.ts`:
+
+```ts
+it('lets any member view the team (team:view floor is GUEST)', () => {
+  expect(roleCan('GUEST', 'team:view')).toBe(true);
+  expect(roleCan('MEMBER', 'team:view')).toBe(true);
+  expect(roleCan('ADMIN', 'team:view')).toBe(true);
+  expect(roleCan('OWNER', 'team:view')).toBe(true);
+});
+
+it('keeps team management ADMIN+ (a viewer cannot manage)', () => {
+  expect(roleCan('GUEST', 'team:manage')).toBe(false);
+  expect(roleCan('MEMBER', 'team:manage')).toBe(false);
+  expect(roleCan('ADMIN', 'team:manage')).toBe(true);
+});
+```
+
+(If `role-capabilities.spec.ts` does not exist yet, create it importing `roleCan` from `./role-capabilities` and add the two `it` blocks inside a `describe('role-capabilities', () => { ... })`.)
+
+- [ ] **Step 4: Write FE tests (add to existing spec)**
+
+Append to `socialmedia-frontend/src/features/team/utils/capabilities.test.ts` the mirrored cases (same `roleCan` import from `./capabilities`):
+
+```ts
+it('lets any member view the team (team:view floor is GUEST)', () => {
+  expect(roleCan('GUEST', 'team:view')).toBe(true)
+  expect(roleCan('ADMIN', 'team:view')).toBe(true)
+})
+
+it('keeps team management ADMIN+ (viewer cannot manage)', () => {
+  expect(roleCan('GUEST', 'team:manage')).toBe(false)
+  expect(roleCan('ADMIN', 'team:manage')).toBe(true)
+})
+```
+
+- [ ] **Step 5: Run tests**
+
+Run (BE): `cd socialmedia-workspace && npx jest role-capabilities`
+Expected: PASS.
+Run (FE): `cd socialmedia-frontend && npx vitest run capabilities`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+# in socialmedia-workspace
+git add src/workspace-members/role-capabilities.ts src/workspace-members/role-capabilities.spec.ts
+git commit -m "feat(rbac): add team:view capability (GUEST can see roster)"
+# in socialmedia-frontend
+git add src/features/team/utils/capabilities.ts src/features/team/utils/capabilities.test.ts
+git commit -m "feat(rbac): mirror team:view capability on frontend map"
+```
+
+---
+
+### Task 2: Make `WorkspaceRoleGuard` super-admin-aware (single shared `isPlatformSuperAdmin`)
+
+**Files:**
+- Modify: `socialmedia-workspace/src/workspace-members/workspace-role.service.ts`
+- Modify: `socialmedia-workspace/src/workspace-members/workspace-role.guard.ts`
+- Modify: `socialmedia-workspace/src/workspace-members/workspace-role.guard.spec.ts`
+- Modify: `socialmedia-workspace/src/workspace-members/workspace-members.service.ts` (delegate its private helper to the shared one)
+
+**Interfaces:**
+- Consumes: `WorkspaceRoleService.getRole(workspaceId, userId)` (existing).
+- Produces: `WorkspaceRoleService.isPlatformSuperAdmin(userId): Promise<boolean>` (new, public). `WorkspaceRoleGuard` passes when it returns true even if `getRole` was null/insufficient.
+
+- [ ] **Step 1: Add the failing guard test**
+
+In `socialmedia-workspace/src/workspace-members/workspace-role.guard.spec.ts`, add a test that a platform super-admin (null workspace role) passes a capability-required route. The guard constructor is `new WorkspaceRoleGuard(reflector, roleService)`. Build a `roleService` stub whose `getRole` resolves `null` and whose `isPlatformSuperAdmin` resolves `true`:
+
+```ts
+it('passes a platform super-admin even with no workspace role', async () => {
+  const reflector = { getAllAndOverride: jest.fn().mockReturnValue('team:manage') } as any;
+  const roleSvc = {
+    getRole: jest.fn().mockResolvedValue(null),
+    isPlatformSuperAdmin: jest.fn().mockResolvedValue(true),
+  } as any;
+  const guard = new WorkspaceRoleGuard(reflector, roleSvc);
+  const ctx = {
+    switchToHttp: () => ({ getRequest: () => ({ user: { userId: 'sa' }, params: { workspaceId: 'w1' } }) }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as any;
+  await expect(guard.canActivate(ctx)).resolves.toBe(true);
+});
+```
+
+Also update any EXISTING guard tests whose `roleService` stub lacks `isPlatformSuperAdmin`: give those stubs `isPlatformSuperAdmin: jest.fn().mockResolvedValue(false)` so the insufficient-role tests still reach the throw. (The guard calls `isPlatformSuperAdmin` only on the failure path, so stubs for the "role sufficient → pass" tests do not strictly need it, but add it to any stub used by a test that expects a throw.)
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd socialmedia-workspace && npx jest workspace-role.guard`
+Expected: FAIL — `isPlatformSuperAdmin is not a function` on the service, or the new test throws instead of passing.
+
+- [ ] **Step 3: Add `isPlatformSuperAdmin` to `WorkspaceRoleService`**
+
+In `workspace-role.service.ts`, import `users` from the schema (alongside `workspace, workspaceInvitation`) and add:
+
+```ts
+async isPlatformSuperAdmin(userId: string): Promise<boolean> {
+  const user = await this.db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { role: true },
+  });
+  return user?.role === 'SUPER_ADMIN';
+}
+```
+
+(Add `users` to the existing `import { workspace, workspaceInvitation } from 'src/drizzle/schema';` line → `import { users, workspace, workspaceInvitation } from 'src/drizzle/schema';`.)
+
+- [ ] **Step 4: Make the guard consult it before throwing**
+
+In `workspace-role.guard.ts`, change the final block so a super-admin passes. Replace:
+
+```ts
+    const role = await this.roleService.getRole(workspaceId, userId);
+    if (!role || !roleCan(role, cap)) {
+      throw new ForbiddenException(
+        'You do not have permission to perform this action in this workspace',
+      );
+    }
+    return true;
+```
+
+with:
+
+```ts
+    const role = await this.roleService.getRole(workspaceId, userId);
+    if (role && roleCan(role, cap)) {
+      return true;
+    }
+    // Platform super admins are not workspace members, so getRole returns null
+    // for them. Let them through anyway (support/admin tooling), mirroring the
+    // service-layer isPlatformSuperAdmin allowance. This lookup runs only on the
+    // failure path, keeping it off the hot path for normal members.
+    if (await this.roleService.isPlatformSuperAdmin(userId)) {
+      return true;
+    }
+    throw new ForbiddenException(
+      'You do not have permission to perform this action in this workspace',
+    );
+```
+
+- [ ] **Step 5: Delegate the members service's private helper to the shared one**
+
+In `workspace-members.service.ts`, the class has a private `isPlatformSuperAdmin(userId)` doing the same `users.role === 'SUPER_ADMIN'` query. Inject `WorkspaceRoleService` (it's already exported by `WorkspaceRoleModule`, which `WorkspaceMembersModule` imports) and make the private method delegate, so there is one implementation:
+
+  - Add to the constructor params: `private roleService: WorkspaceRoleService,` and import `WorkspaceRoleService` from `./workspace-role.service`.
+  - Replace the body of the existing private `isPlatformSuperAdmin` with: `return this.roleService.isPlatformSuperAdmin(userId);` (keep the method + its doc comment so call sites are unchanged).
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `cd socialmedia-workspace && npx jest workspace-role.guard workspace-members && npm run build`
+Expected: PASS + build OK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/workspace-members/workspace-role.service.ts src/workspace-members/workspace-role.guard.ts src/workspace-members/workspace-role.guard.spec.ts src/workspace-members/workspace-members.service.ts
+git commit -m "feat(rbac): make WorkspaceRoleGuard super-admin aware via shared helper"
+```
+
+---
+
+### Task 3: Wire the guard onto `WorkspaceMembersController` per the endpoint table
+
+**Files:**
+- Modify: `socialmedia-workspace/src/workspace-members/workspace-members.controller.ts`
+
+**Interfaces:**
+- Consumes: `WorkspaceRoleGuard` (from `./workspace-role.guard`), `RequireCapability` (from `./require-capability.decorator`), `JwtAuthGuard` (already imported), capabilities `'team:view'` / `'team:manage'` from Task 1.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `workspace-members.controller.ts`, add:
+
+```ts
+import { UseGuards } from '@nestjs/common'; // already imported — confirm, do not duplicate
+import { WorkspaceRoleGuard } from './workspace-role.guard';
+import { RequireCapability } from './require-capability.decorator';
+```
+
+(`UseGuards` and `JwtAuthGuard` are already imported. Add only the two new imports.)
+
+- [ ] **Step 2: Decorate the workspace-scoped routes**
+
+Apply per this exact table. For each listed method add the two decorators directly above the existing `@Post/@Get/@Patch/@Delete(...)` (method-level `@UseGuards` re-lists `JwtAuthGuard`):
+
+| Method | Decorators to add |
+|---|---|
+| `inviteMember` (`@Post(':workspaceId/invitations')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:manage')` |
+| `batchInvite` (`@Post(':workspaceId/invitations/batch')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:manage')` |
+| `getPendingInvitations` (`@Get(':workspaceId/invitations')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:manage')` |
+| `cancelInvitation` (`@Delete(':workspaceId/invitations/:invitationId')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:manage')` |
+| `getMembers` (`@Get(':workspaceId/members')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:view')` |
+| `updateMemberRole` (`@Patch(':workspaceId/members/:memberId')`) | `@UseGuards(JwtAuthGuard, WorkspaceRoleGuard)` + `@RequireCapability('team:manage')` |
+
+Example (inviteMember):
+
+```ts
+  @Post(':workspaceId/invitations')
+  @UseGuards(JwtAuthGuard, WorkspaceRoleGuard)
+  @RequireCapability('team:manage')
+  inviteMember(
+```
+
+- [ ] **Step 3: Do NOT decorate these**
+
+Leave WITHOUT `@RequireCapability` / `WorkspaceRoleGuard` (they keep only the class-level `JwtAuthGuard`):
+- `removeMember` (`@Delete(':workspaceId/members/:memberId')`) — self-removal must work; its inline `isSelf || isOwner || isAdmin || isSuperAdmin` check is the correct policy.
+- `getMyInvitations` (`@Get('invitations/me')`) — no `:workspaceId`.
+- `acceptInvitation` (`@Post('invitations/accept')`) — token-scoped, no `:workspaceId`.
+- `rejectInvitation` (`@Post('invitations/reject')`) — token-scoped, no `:workspaceId`.
+
+Add a short comment above `removeMember` noting why it is intentionally guard-free:
+
+```ts
+  // No @RequireCapability here: a member/guest must be able to remove THEIR OWN
+  // row (leave the workspace), which a team:manage gate would block. The
+  // service's isSelf || owner || admin || super-admin check is the real policy.
+```
+
+- [ ] **Step 4: Build + run the module's tests**
+
+Run: `cd socialmedia-workspace && npm run build && npx jest workspace-members workspace-role`
+Expected: build OK, tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workspace-members/workspace-members.controller.ts
+git commit -m "feat(rbac): enforce team:view/team:manage on workspace-members routes"
+```
+
+---
+
+### Task 4: Full verification pass (both repos)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: BE full build + test**
+
+Run: `cd socialmedia-workspace && npm run build && npm test`
+Expected: build OK; full Jest suite green (or pre-existing unrelated failures only — note them, do not fix out of scope).
+
+- [ ] **Step 2: FE full test**
+
+Run: `cd socialmedia-frontend && npm test`
+Expected: vitest suite green.
+
+- [ ] **Step 3: FE build**
+
+Run: `cd socialmedia-frontend && npm run build`
+Expected: `tsc -b && vite build` OK — confirms the `team:view` addition typechecks against every `Capability` consumer.
+
+- [ ] **Step 4: Record result in the ledger** (no commit — verification only). If anything failed, surface it before the whole-branch review.

--- a/docs/superpowers/plans/2026-08-19-composer-ai-assist.md
+++ b/docs/superpowers/plans/2026-08-19-composer-ai-assist.md
@@ -1,0 +1,314 @@
+# Composer AI Assist — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship an inline AI-assist layer in the post composer (Phase 1): a right-pane Preview⇆AI toggle where a user gives one prompt + tone and gets either a single caption (fills the draft) or per-channel tailored captions (fill per-platform overrides), metered as free-quota → paid, powered by Gemini (primary) with Groq fallback.
+
+**Architecture:** The backend `src/ai/` module already exposes Groq-backed generate endpoints + `AiTokenService` metering. We insert an `AiTextService` (Gemini-primary, Groq-fallback) beneath the existing typed generators so the whole `/ai/*` surface upgrades transparently, add ONE new per-channel orchestration endpoint, and wire the orphaned, mock-backed `AiAssistantPanel` on the frontend into the composer's draft state.
+
+**Tech Stack:** NestJS + Drizzle + class-validator + Jest (BE, `@google/generative-ai` already installed) · React 19 + Vite + TanStack Query + shadcn + Vitest (FE).
+
+**Spec:** `socialmedia-workspace/docs/superpowers/specs/2026-08-19-composer-ai-assist-design.md`
+
+## Global Constraints
+
+- Two repos, both on branch `feat/composer-ai-assist` (off `origin/main`: BE `5804f1d`, FE `54700df`).
+- **Provider:** Gemini (`gemini-2.0-flash`, `GOOGLE_AI_API_KEY`) primary, Groq (`GROQ_API_KEY`) fallback for inline. Maestro/Anthropic untouched. If Gemini key absent → silent Groq fallback (no breakage).
+- **Metering:** reuse `AiTokenService.executeWithTokens` — FREE plan (`aiTokensPerMonth=0`) → 403; success deducts once; failure deducts nothing. Existing op keys (`caption`/`hashtags`/`improve`/`variations`) reused; ONE new key `generate_per_channel` (cost 8).
+- **Scope = composer only.** No inbox AI, no media AI, no Maestro change. Keep the new BE path generic (task-typed) so later phases reuse it.
+- Hashtags: append to caption text (no separate hashtags-field UI this phase).
+- shadcn-only UI; theme tokens only (no hex/arbitrary Tailwind colors); Form/RHF where forms apply; loading/disabled/empty/error states required.
+- Never `git add .`/`-A` (both `.env` files are secret-bearing — FE tracked, BE gitignored). Surgical `git add <path>` only. Commit per task; do not push (controller finishes the branch).
+- Verify BE `npm run build` + `npm test`; FE `npm test` + `npm run build`.
+
+---
+
+### Task 1: `AiTextService` — Gemini-primary, Groq-fallback single-shot completion
+
+**Files:**
+- Create: `socialmedia-workspace/src/ai/ai-text.service.ts`
+- Create: `socialmedia-workspace/src/ai/ai-text.service.spec.ts`
+- Modify: `socialmedia-workspace/src/chatbot/llm/gemini.provider.ts` (add a public single-shot `generateText`)
+- Modify: `socialmedia-workspace/src/ai/ai.module.ts` (provide/export `AiTextService`; import whatever module exposes `GeminiChatProvider`)
+
+**Interfaces:**
+- Produces: `AiTextService.complete(systemPrompt: string, userPrompt: string, opts?: { temperature?: number; maxTokens?: number }): Promise<string>` — tries Gemini `generateText`, on throw/unavailability falls back to Groq. `AiTextService.isReady(): boolean` = Gemini-ready OR Groq-ready. Consumed by Task 2 (Groq methods delegate) and Task 3 (per-channel orchestrator).
+- `GeminiChatProvider.generateText(systemPrompt, userPrompt, opts?): Promise<string>` — single `generateContent` call returning text; throws if `!isAvailable()`.
+
+- [ ] **Step 1: Write the failing test** (`ai-text.service.spec.ts`)
+
+Test with mocked providers: (a) when Gemini `generateText` resolves, `complete` returns Gemini's text and Groq is NOT called; (b) when Gemini throws, `complete` returns Groq's text (fallback); (c) when Gemini unavailable AND Groq unavailable, `complete` rejects. Construct `new AiTextService(geminiStub, groqStub)` with jest stubs.
+
+```ts
+it('uses Gemini when it succeeds', async () => {
+  const gemini = { isAvailable: () => true, generateText: jest.fn().mockResolvedValue('G') } as any;
+  const groq = { isReady: () => true, completeRaw: jest.fn() } as any;
+  const svc = new AiTextService(gemini, groq);
+  await expect(svc.complete('s', 'u')).resolves.toBe('G');
+  expect(groq.completeRaw).not.toHaveBeenCalled();
+});
+it('falls back to Groq when Gemini throws', async () => {
+  const gemini = { isAvailable: () => true, generateText: jest.fn().mockRejectedValue(new Error('rl')) } as any;
+  const groq = { isReady: () => true, completeRaw: jest.fn().mockResolvedValue('Q') } as any;
+  const svc = new AiTextService(gemini, groq);
+  await expect(svc.complete('s', 'u')).resolves.toBe('Q');
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails** — `cd socialmedia-workspace && npx jest ai-text` → FAIL (service/method absent).
+
+- [ ] **Step 3: Add `generateText` to `GeminiChatProvider`**
+
+In `gemini.provider.ts`, add a public method that does one non-chat completion:
+
+```ts
+async generateText(
+  systemPrompt: string,
+  userPrompt: string,
+  opts?: { temperature?: number; maxTokens?: number },
+): Promise<string> {
+  const genAI = this.ensureGenAI();
+  const model = genAI.getGenerativeModel({
+    model: this.defaultModel,
+    generationConfig: {
+      temperature: opts?.temperature ?? 0.7,
+      maxOutputTokens: opts?.maxTokens ?? 1024,
+    },
+    systemInstruction: systemPrompt,
+  });
+  const result = await model.generateContent(userPrompt);
+  return result.response.text();
+}
+```
+
+- [ ] **Step 4: Add a Groq raw-completion surface for fallback**
+
+`GroqService.generateCompletion` is private. Add a thin public passthrough on `GroqService` so `AiTextService` can call it as the fallback (keep prompt-building in Groq's typed methods; this is just the raw runner):
+
+```ts
+async completeRaw(
+  systemPrompt: string,
+  userPrompt: string,
+  opts?: { temperature?: number; maxTokens?: number; model?: string },
+): Promise<string> {
+  return this.generateCompletion(systemPrompt, userPrompt, opts);
+}
+```
+(Modify `groq.service.ts` for this small addition — list it in this task's files.)
+
+- [ ] **Step 5: Implement `AiTextService`**
+
+```ts
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { GeminiChatProvider } from '../chatbot/llm/gemini.provider';
+import { GroqService } from './groq.service';
+
+@Injectable()
+export class AiTextService {
+  private readonly logger = new Logger(AiTextService.name);
+  constructor(
+    private readonly gemini: GeminiChatProvider,
+    private readonly groq: GroqService,
+  ) {}
+
+  isReady(): boolean {
+    return this.gemini.isAvailable() || this.groq.isReady();
+  }
+
+  async complete(
+    systemPrompt: string,
+    userPrompt: string,
+    opts?: { temperature?: number; maxTokens?: number },
+  ): Promise<string> {
+    if (this.gemini.isAvailable()) {
+      try {
+        return await this.gemini.generateText(systemPrompt, userPrompt, opts);
+      } catch (err) {
+        this.logger.warn(`Gemini failed, falling back to Groq: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+    if (this.groq.isReady()) {
+      return this.groq.completeRaw(systemPrompt, userPrompt, opts);
+    }
+    throw new BadRequestException('AI is not configured');
+  }
+}
+```
+
+- [ ] **Step 6: Wire the module** — in `ai.module.ts`, ensure `GeminiChatProvider` is importable (import the chatbot LLM module or add `GeminiChatProvider` to providers if not already exported), add `AiTextService` to providers + exports.
+
+- [ ] **Step 7: Run tests + build** — `npx jest ai-text && npm run build` → PASS.
+
+- [ ] **Step 8: Commit** — surgical add of the 4 files + `ai.module.ts`; `git commit -m "feat(ai): AiTextService with Gemini-primary Groq-fallback completion"`.
+
+---
+
+### Task 2: Route existing Groq generators through `AiTextService` (transparent provider upgrade)
+
+**Files:**
+- Modify: `socialmedia-workspace/src/ai/groq.service.ts` (inject `AiTextService`; typed methods delegate completion to it)
+- Modify: `socialmedia-workspace/src/ai/groq.service.spec.ts` if present (else no test file change)
+
+**Interfaces:**
+- Consumes: `AiTextService.complete` (Task 1).
+- Produces: no signature change to `GroqService.generateCaption/generateHashtags/improvePost/generateVariations` — they now run via Gemini-primary path. All existing `/ai/*` endpoints unchanged.
+
+> **Circular-dependency note:** Task 1 has `AiTextService` depend on `GroqService` (for fallback), and this task makes `GroqService` depend on `AiTextService` — a cycle. Resolve by NOT injecting `AiTextService` into `GroqService`. Instead: `GroqService.completeRaw` stays the raw Groq runner (no AiTextService), and the **typed generator methods move their "run completion" call to go through `AiTextService`** only if that doesn't create a cycle. **Chosen, cycle-free approach:** keep `GroqService` as-is (it only ever runs Groq); do the provider-selection in the CONTROLLER/orchestration layer by calling `AiTextService.complete` with Groq's prompt builders. Since prompt-building lives inside `GroqService`'s private methods, extract the prompt strings: add public `buildCaptionPrompt(opts): {system,user}` (and hashtags/improve/variations) to `GroqService` that return the prompt pair WITHOUT running it. Then the controller path calls `AiTextService.complete(prompt.system, prompt.user)`.
+>
+> **Ruling for the implementer:** implement the extract-prompt-builders approach — add `buildCaptionPrompt`, `buildHashtagsPrompt`, `buildImprovePrompt`, `buildVariationsPrompt` (returning `{ system: string; user: string }`, reusing the existing SYSTEM_PROMPTS/USER_PROMPTS) as public methods on `GroqService`. Do NOT inject `AiTextService` into `GroqService`. Keep the old typed methods (`generateCaption` etc.) intact for any existing callers (e.g. EvergreenService) — they still run pure-Groq, unchanged. New AI-assist code (Task 3) uses the builders + `AiTextService`.
+
+- [ ] **Step 1: Add public prompt-builder methods to `GroqService`**
+
+For caption/hashtags/improve/variations, add `buildXPrompt(opts): { system: string; user: string }` that assemble the same system+user strings the private typed methods use (copy the prompt-assembly lines out of each typed method into the builder; the typed method can then call its builder + `generateCompletion` to stay DRY, but that refactor is optional — minimal path: builders duplicate the assembly, typed methods stay untouched). Prefer: typed method calls `const {system,user}=this.buildXPrompt(opts); return this.postProcess(await this.generateCompletion(system,user,...))` so there's ONE prompt source.
+
+- [ ] **Step 2: Build** — `npm run build` → PASS. (No behavior change yet; this task only exposes builders.)
+
+- [ ] **Step 3: Commit** — `git commit -m "refactor(ai): expose GroqService prompt builders for provider-agnostic use"`.
+
+---
+
+### Task 3: Per-channel orchestrator + endpoint + cost key
+
+**Files:**
+- Create: `socialmedia-workspace/src/ai/composer-ai.service.ts`
+- Create: `socialmedia-workspace/src/ai/composer-ai.service.spec.ts`
+- Modify: `socialmedia-workspace/src/ai/services/ai-token.service.ts` (+`generate_per_channel: 8` in `AI_OPERATION_COSTS`)
+- Modify: `socialmedia-workspace/src/ai/dto/ai.dto.ts` (+`GeneratePerChannelDto` + response type)
+- Modify: `socialmedia-workspace/src/ai/ai.controller.ts` (+`POST /ai/workspaces/:workspaceId/generate/per-channel`)
+- Modify: `socialmedia-workspace/src/ai/ai.module.ts` (provide `ComposerAiService`)
+
+**Interfaces:**
+- Consumes: `AiTextService.complete` (T1), `GroqService.buildCaptionPrompt`/`buildVariationsPrompt` (T2), `AiTokenService.executeWithTokens`.
+- Produces: `ComposerAiService.generatePerChannel(workspaceId, userId, { description, platforms, tone?, includeHashtags? }): Promise<{ variations: {platform,text,hashtags?}[]; usage }>`. Endpoint returns the same shape. Consumed by FE Task 5.
+
+- [ ] **Step 1: Add the cost key**
+
+In `ai-token.service.ts` `AI_OPERATION_COSTS`, add `generate_per_channel: 8,`.
+
+- [ ] **Step 2: Write the failing test** (`composer-ai.service.spec.ts`)
+
+Mock `AiTextService.complete` to echo the platform, mock `AiTokenService.executeWithTokens` to run the fn and return `{ result, usage: {...} }`. Assert: 3 platforms → 3 `{platform,text}` entries, tone threaded into prompts, `executeWithTokens` called ONCE with op `'generate_per_channel'`.
+
+- [ ] **Step 3: Run it, verify it fails** — `npx jest composer-ai` → FAIL.
+
+- [ ] **Step 4: Implement `ComposerAiService.generatePerChannel`**
+
+```ts
+async generatePerChannel(workspaceId, userId, input) {
+  const { description, platforms, tone, includeHashtags } = input;
+  const { result, usage } = await this.aiTokens.executeWithTokens(
+    workspaceId, userId, 'generate_per_channel', platforms.join(','),
+    `Per-channel: ${description.substring(0, 80)}`,
+    async () => {
+      const variations = await Promise.all(
+        platforms.map(async (platform) => {
+          const { system, user } = this.groq.buildCaptionPrompt({
+            description, platform, tone, includeHashtags: !!includeHashtags, includeCta: true,
+          });
+          const text = await this.aiText.complete(system, user);
+          return { platform, text };
+        }),
+      );
+      return { result: { variations }, outputLength: variations.map(v => v.text).join('').length };
+    },
+  );
+  return { ...result, usage };
+}
+```
+
+- [ ] **Step 5: DTO + endpoint**
+
+`GeneratePerChannelDto`: `@IsString() @IsNotEmpty() description`; `@IsArray() @ArrayMinSize(1) @IsIn(PLATFORMS, { each: true }) platforms`; optional `@IsIn(TONES) tone`; optional `@IsBoolean() includeHashtags`. Controller method mirrors siblings:
+
+```ts
+@Post('workspaces/:workspaceId/generate/per-channel')
+generatePerChannel(
+  @Param('workspaceId') workspaceId: string,
+  @Body() dto: GeneratePerChannelDto,
+  @CurrentUser() user: { userId: string },
+) {
+  return this.composerAi.generatePerChannel(workspaceId, user.userId, dto);
+}
+```
+
+- [ ] **Step 6: Run tests + build** — `npx jest composer-ai ai-token && npm run build` → PASS.
+
+- [ ] **Step 7: Commit** — surgical add; `git commit -m "feat(ai): per-channel caption generation endpoint (metered)"`.
+
+---
+
+### Task 4: `.env.example` + backend verification
+
+**Files:**
+- Modify: `socialmedia-workspace/.env.example`
+
+- [ ] **Step 1:** Add `GOOGLE_AI_API_KEY=` (with a comment: "Gemini for inline AI assist; falls back to GROQ_API_KEY if unset") near the other AI keys. Do NOT touch the real `.env`.
+- [ ] **Step 2: Full BE verify** — `npm run build && npm test`. Note any pre-existing unrelated failures (do not fix out of scope); the `ai`/`composer-ai`/`ai-text` suites must pass.
+- [ ] **Step 3: Commit** — `git add .env.example && git commit -m "docs(ai): document GOOGLE_AI_API_KEY"`.
+
+---
+
+### Task 5: Frontend — API layer + hooks
+
+**Files:**
+- Create: `socialmedia-frontend/src/features/composer/api/ai.api.ts`
+- Create: `socialmedia-frontend/src/features/composer/hooks/use-ai-generate.ts`
+- Create: `socialmedia-frontend/src/features/composer/hooks/use-ai-usage.ts`
+- Create: `socialmedia-frontend/src/features/composer/types/ai.ts` (typed request/response mirroring BE DTOs)
+
+**Interfaces:**
+- Consumes: BE endpoints `/ai/workspaces/:id/generate/caption`, `/hashtags`, `/improve`, `/generate/per-channel`, `/usage`.
+- Produces: `useAiGenerate(workspaceId)` (mutations: `caption`, `perChannel`) and `useAiUsage(workspaceId)` (query → remaining tokens). Consumed by Task 6 (panel).
+
+- [ ] **Step 1:** Add types in `types/ai.ts`: `AiTone`, `PerChannelVariation = { platform: SocialPlatform; text: string; hashtags?: string[] }`, request/response shapes matching the BE DTOs exactly (full-stack consistency).
+- [ ] **Step 2:** `ai.api.ts` — typed `apiClient` wrappers for each endpoint (follow existing `composer.api.ts` style).
+- [ ] **Step 3:** `use-ai-generate.ts` — TanStack `useMutation`s; `use-ai-usage.ts` — `useQuery` on `/usage` (query key via the feature's key factory pattern). Map a 403 error to a typed `quotaExhausted` flag consumers can read.
+- [ ] **Step 4:** FE typecheck — `cd socialmedia-frontend && npx tsc -b` (or `npm run build`) → PASS. (No component yet; this compiles the API/hooks.)
+- [ ] **Step 5: Commit** — surgical add; `git commit -m "feat(composer): AI assist API layer + hooks"`.
+
+---
+
+### Task 6: Frontend — wire `AiAssistantPanel` (mode toggle, per-channel cards, quota) + fill draft
+
+**Files:**
+- Modify: `socialmedia-frontend/src/features/composer/components/ai-assistant-panel.tsx`
+- Remove/replace: `socialmedia-frontend/src/features/composer/lib/ai-mock.ts` (delete once unused)
+- Test: `socialmedia-frontend/src/features/composer/components/ai-assistant-panel.test.tsx` (Vitest, `renderToStaticMarkup` per repo norm)
+
+**Interfaces:**
+- Consumes: `useAiGenerate`, `useAiUsage` (T5); `useLocalDraft().update` + the per-platform override model.
+- Produces: a panel that fills `draft.base.text` (One caption) or per-platform overrides (Per-channel).
+
+- [ ] **Step 1:** Replace `generateMockAiOutput` calls with `useAiGenerate`. Add the **mode toggle** (One caption | Per-channel) using shadcn `Tabs` or `ToggleGroup`.
+- [ ] **Step 2:** One-caption result → "Insert into post" calls a prop `onApplyCaption(text)` that the composer wires to `update((prev)=>({ base: { ...prev.base, text } }))`. If `includeHashtags`, append hashtags to the text before applying (per locked decision).
+- [ ] **Step 3:** Per-channel → derive selected platforms from `draft.channels` (distinct platforms), call `perChannel` mutation, render one card per returned variation with "Apply to <Platform>" → prop `onApplyToPlatform(platform, text)` (composer writes the per-platform override via the existing `handleEnableCustomize`-style path) + "Apply all".
+- [ ] **Step 4:** Quota — `useAiUsage` shows remaining near Generate; on `quotaExhausted` (403) render an upsell empty-state and disable Generate (tooltip). Loading spinner in Generate; error → toast.
+- [ ] **Step 5:** Write a Vitest test: panel renders One-caption + Per-channel modes; quota-exhausted state renders the upsell (mock the hooks). Use `renderToStaticMarkup`.
+- [ ] **Step 6:** Delete `ai-mock.ts` (confirm no remaining imports).
+- [ ] **Step 7:** FE build + test — `npm test && npm run build` → PASS.
+- [ ] **Step 8: Commit** — surgical add; `git commit -m "feat(composer): wire AI assist panel to real generation + per-channel"`.
+
+---
+
+### Task 7: Frontend — mount panel via right-pane Preview⇆AI toggle + wire apply handlers
+
+**Files:**
+- Modify: `socialmedia-frontend/src/features/composer/components/right-pane-tabs.tsx` (add Preview⇆AI toggle)
+- Modify: `socialmedia-frontend/src/features/composer/pages/composer-page.tsx` (pass `onApplyCaption`/`onApplyToPlatform` handlers wired to `useLocalDraft` + the existing customize path; provide selected platforms + workspaceId to the panel)
+
+**Interfaces:**
+- Consumes: `AiAssistantPanel` (T6), `useLocalDraft` handlers already present in `composer-page.tsx` (`handleEnableCustomize`, `handlePlatformTextChange`).
+
+- [ ] **Step 1:** Add a segment/toggle at the top of the right pane: **Preview** (existing `PreviewPane`/`ChannelTabBar` machinery, unchanged) | **✨ AI Assist** (renders `AiAssistantPanel`). Default = Preview. Use shadcn `ToggleGroup`/`Tabs`; theme tokens only.
+- [ ] **Step 2:** In `composer-page.tsx`, implement `onApplyCaption(text)` → `update((prev)=>({ base: { ...prev.base, text } }))`; `onApplyToPlatform(platform, text)` → reuse the existing enable-customize + set-override flow (snapshot base → set `perPlatform[platform].overrides.text`) so it matches manual customization exactly. Pass selected platforms (distinct from `draft.channels`) + `workspaceId` into the panel.
+- [ ] **Step 3:** Manual-ish check via build + existing tests; ensure switching to Preview after Apply shows the applied text.
+- [ ] **Step 4:** FE build + test — `npm test && npm run build` → PASS.
+- [ ] **Step 5: Commit** — surgical add; `git commit -m "feat(composer): mount AI assist via right-pane Preview/AI toggle"`.
+
+---
+
+### Task 8: Full-stack verification
+
+- [ ] **Step 1:** BE `npm run build && npm test` (ai suites green; note pre-existing unrelated failures only).
+- [ ] **Step 2:** FE `npm test && npm run build`.
+- [ ] **Step 3:** Record result in ledger. Manual E2E (real `GOOGLE_AI_API_KEY`, PRO workspace) is a post-merge deploy step: generate caption → fills field; per-channel → apply → override set → publish; exhaust quota → upsell; non-English prompt → quality multilingual copy. Note it as pending for the user.

--- a/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
+++ b/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
@@ -146,7 +146,7 @@ channel.
 
 Loading, disabled, and error states per CLAUDE.md Rule 4.
 
-### Task 7b — fix the COOP popup close
+### Task 7b — fix the COOP popup close — ALREADY DONE, no work needed
 
 `project_oauth_popup_close_bug`: on production the OAuth popup does not
 auto-close after connecting, because COOP severs the child's `window.close()`.
@@ -156,8 +156,11 @@ This is queued work we are pulling in deliberately, not scope creep: Task 7
 makes the bug the ending of the agent's headline flow. Shipping a connect button
 that leaves a stranded window is worse than not shipping it.
 
-If it turns out to need more than a parent-side close, stop and raise it —
-do not let it silently expand this branch.
+**Verified on main and closed:** `use-channel-connect.ts` already closes the
+popup opener-side on the `postMessage` handler, with the COOP reason in its own
+comment (commit 7fe4b7d, 2026-06-21). Nothing to do here — the queued note in
+memory was stale. Because the connect card reuses that same hook, it inherits
+the fix rather than needing its own.
 
 ### Task 8 — frontend verification
 

--- a/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
+++ b/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
@@ -56,18 +56,32 @@ as an argument.
 
 Register in `build-mcp-server.ts` alongside the existing tool groups.
 
-### Task 3 — `connect_channel` card
+### Task 3 — analytics read tools
 
-Returns an interactive card naming the platform to connect, which the frontend
-renders as a button routing to `/settings/channels` with that platform
-preselected.
+`src/maestro/tools/analytics.tools.ts` (new)
 
-Not an outward action — it performs nothing, so **no confirm gate**. The user
-clicking is the action.
+Everything the Insights UI shows: KPIs and trend, the metric series over a
+period, per-platform breakdown, per-channel performance.
+
+Read through the services `kpi-strip`, `metrics-chart`, `platform-breakdown`,
+and `channel-table` already call. Do not recompute — if the agent and the
+Insights page can disagree, this task is wrong.
+
+Prefer one tool with a period/metric argument over four near-identical tools
+(tool-count discipline, see Notes).
+
+### Task 4 — `connect_channel` card
+
+Returns an interactive card naming the platform to connect. The frontend renders
+it as a button that runs **the real OAuth flow** — same behaviour as the
+Channels page.
+
+Not an outward action in the confirm-gate sense — the tool performs nothing, so
+**no confirm gate**. The user clicking is the action.
 
 If the platform is already connected, say so instead of offering the button.
 
-### Task 4 — backend verification
+### Task 5 — backend verification
 
 ```
 npx jest src/maestro test/maestro-core   # 93 existing + new
@@ -81,6 +95,7 @@ New tests:
 - Reads are workspace-scoped — another workspace's channels never appear.
 - `connect_channel` on an already-connected platform offers no button.
 - A tool result with no entities still renders (empty references, not absent).
+- Analytics tools return the same figures as the Insights services they wrap.
 
 **Then STOP.** Present the backend and propose the frontend plan before writing
 frontend code.
@@ -89,7 +104,7 @@ frontend code.
 
 ## Frontend (after user approval)
 
-### Task 5 — render references as links
+### Task 6 — render references as links
 
 `rich-text.tsx` today handles paragraphs, bullets, and `**bold**` — there is no
 link support. Add reference resolution:
@@ -105,15 +120,39 @@ tell the user rather than hand-rolling a badge.
 Keep `RevealedText` streaming intact: a link must fade in with the words around
 it, not pop in fully-formed.
 
-### Task 6 — the connect card
+### Task 7 — the connect card
 
 Render `connect_channel`'s result as a button, following `MediaGrid`'s
-precedent for a rich tool result. Route to `/settings/channels` with the
-platform preselected.
+precedent for a rich tool result. The button runs the real OAuth flow.
+
+**Reuse `useInitiateOAuth` + `openOAuthPopup`.** Do not write a second connect
+path — a divergent one would drift from the Channels page and break in ways only
+the agent shows.
+
+The popup must be opened **synchronously in the click handler** (the hook's own
+docblock says so: it does not redirect on its own, and popup blockers fire
+otherwise). So the card owns the click; `openOAuthPopup` first, then point it at
+the authorization URL from the mutation's `onSuccess`.
+
+On success, refresh the channel list so the agent's next answer reflects the new
+channel.
 
 Loading, disabled, and error states per CLAUDE.md Rule 4.
 
-### Task 7 — frontend verification
+### Task 7b — fix the COOP popup close
+
+`project_oauth_popup_close_bug`: on production the OAuth popup does not
+auto-close after connecting, because COOP severs the child's `window.close()`.
+Fix parent-side in the opener.
+
+This is queued work we are pulling in deliberately, not scope creep: Task 7
+makes the bug the ending of the agent's headline flow. Shipping a connect button
+that leaves a stranded window is worse than not shipping it.
+
+If it turns out to need more than a parent-side close, stop and raise it —
+do not let it silently expand this branch.
+
+### Task 8 — frontend verification
 
 ```
 npm run build
@@ -133,14 +172,25 @@ Using Chrome DevTools MCP, on a real workspace:
    structured, and that the rendered href matches the entity id.
 4. Ask something with **no** results (a workspace with no campaigns) → confirm a
    real empty state, not a broken reference or a dead link.
-5. Ask "I don't know how to connect a channel" → confirm the question card
-   appears with platform options, then the button, then that clicking it routes
-   correctly with the platform preselected.
-6. Reload mid-conversation → confirm links still work on the hydrated message
+5. Ask about analytics → confirm the figures **match the Insights page** for the
+   same period. Open both and compare; a plausible-looking wrong number is the
+   failure mode here, and only a side-by-side catches it.
+6. Ask "I don't know how to connect a channel" → confirm the question card
+   appears with platform options, then the button. Click it and confirm the
+   OAuth popup actually opens against the right provider — not merely that the
+   button rendered.
+7. Complete a real connection through that popup → confirm the popup closes on
+   its own (Task 7b), the channel appears, and asking again reflects it.
+8. Reload mid-conversation → confirm links still work on the hydrated message
    (references must survive persistence, not only live streaming).
 
 Screenshot each step. A link that looks right but points at the wrong id is
-exactly the failure this step exists to catch — check both.
+exactly the failure this step exists to catch — check the rendered href against
+the entity id, not just the pixels.
+
+Where the browser cannot complete a step (a real OAuth consent screen may need
+the user's own credentials), say so plainly and hand that step to the user
+rather than reporting it as passed.
 
 ---
 
@@ -154,7 +204,12 @@ exactly the failure this step exists to catch — check both.
   test the reloaded path explicitly (step 6), not just the streaming one.
 - **Tool-count discipline.** Layer 1 across all modules should land near a dozen
   tools, not thirty. If a module seems to need five read tools, it probably
-  needs one with a filter argument.
+  needs one with a filter argument. This matters more as we approach full
+  parity: the target is everything the user can do, but reached through well-
+  chosen tools, not one tool per button in the UI.
+- **One connect path, not two.** The agent reuses the UI's OAuth hook and popup.
+  If the agent ever grows its own variant, they will drift and only the agent's
+  will be broken.
 - **Workspace scoping is a security boundary**, not a convenience. Every read
   derives its workspace from `ctx`, never from tool arguments.
 - If a task needs production code reshaped beyond this scope, stop and raise it

--- a/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
+++ b/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
@@ -1,0 +1,161 @@
+# Maestro platform tools — Layer 1 implementation plan
+
+**Spec:** `docs/superpowers/specs/2026-08-27-maestro-platform-tools-design.md`
+**Branch:** `feat/maestro-platform-tools` (same name BOTH repos, off `main`)
+
+Backend first, then frontend — workspace CLAUDE.md rule. Frontend starts only
+after the backend half is reviewed with the user.
+
+---
+
+## Task 0 — branches
+
+```
+cd socialmedia-workspace && git checkout main && git pull
+git checkout -b feat/maestro-platform-tools
+# frontend at Task 5
+```
+
+---
+
+## Backend
+
+### Task 1 — the reference contract
+
+`src/maestro/tools/references.ts` (new)
+
+A tool result carries the entities it names, so the frontend can turn them into
+links. Decide once, here, and reuse for every later tool:
+
+- what a reference is (kind, id, label, optional status)
+- how the model points at one from its prose
+- what happens to a marker that resolves to nothing → **plain text, never a
+  broken link**
+
+Ship a helper that wraps a tool result with its references, plus a type the
+frontend imports, so the shape cannot drift between repos.
+
+**Do not** put URLs in the reference. The backend does not own frontend routing;
+the model owning it would be worse still.
+
+**Green check:** unit tests for the helper — well-formed refs, empty refs, and a
+marker with no matching entity.
+
+### Task 2 — channel read tools
+
+`src/maestro/tools/channel.tools.ts` (new)
+
+- `list_channels` — connected channels, health/expiry state, per platform
+- `get_channel_stats` — followers, reach, performance for one channel
+
+Both return references so each channel name becomes a link.
+
+Reuse the existing channels service — do not query Drizzle directly from a tool.
+Scope every read to `ctx.workspaceId`; a tool must never accept a workspace id
+as an argument.
+
+Register in `build-mcp-server.ts` alongside the existing tool groups.
+
+### Task 3 — `connect_channel` card
+
+Returns an interactive card naming the platform to connect, which the frontend
+renders as a button routing to `/settings/channels` with that platform
+preselected.
+
+Not an outward action — it performs nothing, so **no confirm gate**. The user
+clicking is the action.
+
+If the platform is already connected, say so instead of offering the button.
+
+### Task 4 — backend verification
+
+```
+npx jest src/maestro test/maestro-core   # 93 existing + new
+npm run test          # 4 pre-existing failures (billing, evergreen, db-pool) — expect exactly those
+npm run build
+npx eslint <changed files>
+```
+
+New tests:
+- Each tool returns references whose ids match the entities named.
+- Reads are workspace-scoped — another workspace's channels never appear.
+- `connect_channel` on an already-connected platform offers no button.
+- A tool result with no entities still renders (empty references, not absent).
+
+**Then STOP.** Present the backend and propose the frontend plan before writing
+frontend code.
+
+---
+
+## Frontend (after user approval)
+
+### Task 5 — render references as links
+
+`rich-text.tsx` today handles paragraphs, bullets, and `**bold**` — there is no
+link support. Add reference resolution:
+
+- marker → `<a>` routed via the workspace route table the app already owns
+- status rendered inline beside the label as a shadcn `Badge`
+- **unresolved marker → plain text**, never a dead link
+
+Follow the shadcn-only rule: check the MCP before reaching for any component.
+The shadcn MCP failed to connect this session — if it is still down, STOP and
+tell the user rather than hand-rolling a badge.
+
+Keep `RevealedText` streaming intact: a link must fade in with the words around
+it, not pop in fully-formed.
+
+### Task 6 — the connect card
+
+Render `connect_channel`'s result as a button, following `MediaGrid`'s
+precedent for a rich tool result. Route to `/settings/channels` with the
+platform preselected.
+
+Loading, disabled, and error states per CLAUDE.md Rule 4.
+
+### Task 7 — frontend verification
+
+```
+npm run build
+npm run lint
+```
+
+**Then verify it in a real browser — visually and technically, both.** The user
+asked for this explicitly; a green build is not evidence that a link renders
+correctly.
+
+Using Chrome DevTools MCP, on a real workspace:
+
+1. Ask "which channels do I have connected?" → screenshot the answer. Channel
+   names must be visibly links, with status pills beside them.
+2. Click one → confirm it lands on the right screen for that channel.
+3. Inspect the SSE payload behind the answer — confirm references arrived
+   structured, and that the rendered href matches the entity id.
+4. Ask something with **no** results (a workspace with no campaigns) → confirm a
+   real empty state, not a broken reference or a dead link.
+5. Ask "I don't know how to connect a channel" → confirm the question card
+   appears with platform options, then the button, then that clicking it routes
+   correctly with the platform preselected.
+6. Reload mid-conversation → confirm links still work on the hydrated message
+   (references must survive persistence, not only live streaming).
+
+Screenshot each step. A link that looks right but points at the wrong id is
+exactly the failure this step exists to catch — check both.
+
+---
+
+## Notes and risks
+
+- **The model must not invent URLs.** It knows ids because a tool gave them; it
+  does not know our routing. If a link's href can be traced back to model output
+  rather than the route table, that is a bug.
+- **Hydration parity.** A reference that renders live but breaks after reload is
+  the same class of bug as the `serverId` defect in the question-turn work —
+  test the reloaded path explicitly (step 6), not just the streaming one.
+- **Tool-count discipline.** Layer 1 across all modules should land near a dozen
+  tools, not thirty. If a module seems to need five read tools, it probably
+  needs one with a filter argument.
+- **Workspace scoping is a security boundary**, not a convenience. Every read
+  derives its workspace from `ctx`, never from tool arguments.
+- If a task needs production code reshaped beyond this scope, stop and raise it
+  rather than widening silently.

--- a/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
+++ b/docs/superpowers/plans/2026-08-27-maestro-platform-tools.md
@@ -109,9 +109,16 @@ frontend code.
 `rich-text.tsx` today handles paragraphs, bullets, and `**bold**` — there is no
 link support. Add reference resolution:
 
-- marker → `<a>` routed via the workspace route table the app already owns
-- status rendered inline beside the label as a shadcn `Badge`
+- marker → a clickable chip routed via the workspace route table the app owns
+- **not a bare underlined link — a badge/pill carrying the platform icon**, the
+  way ClickUp renders a task reference. Clicking it opens that entity's detail
+  page. Compare against ClickUp side by side while building.
+- status shown inline beside the label
 - **unresolved marker → plain text**, never a dead link
+
+The prose around the chips must read professionally — this is the agent's
+public voice, not debug output. Verify the whole answer visually, not just that
+the link resolves.
 
 Follow the shadcn-only rule: check the MCP before reaching for any component.
 The shadcn MCP failed to connect this session — if it is still down, STOP and
@@ -207,10 +214,24 @@ rather than reporting it as passed.
   needs one with a filter argument. This matters more as we approach full
   parity: the target is everything the user can do, but reached through well-
   chosen tools, not one tool per button in the UI.
+- **`tool_result` carries an empty tool name.** Pre-existing, found while
+  verifying live: the SDK's tool_result block has only `tool_use_id`, so
+  `claude-agent-sdk.runtime.ts` hardcodes `name: ''` and the event reaches the
+  frontend blank (`tool_executing` has the name; `tool_result` does not).
+  Harmless until the frontend needs to know which tool produced a result — which
+  Task 7 does, to render the connect card. Fix by correlating `tool_use_id`
+  against the earlier `tool_use`, in Task 7 or its own change; do not let it
+  expand the backend tasks.
 - **One connect path, not two.** The agent reuses the UI's OAuth hook and popup.
   If the agent ever grows its own variant, they will drift and only the agent's
   will be broken.
 - **Workspace scoping is a security boundary**, not a convenience. Every read
   derives its workspace from `ctx`, never from tool arguments.
+- **Integrations are not channels.** Cloud storage and calendars share the
+  channels table but are not publishing channels, and must never appear when the
+  user asks about channels or in channel counts. Derive this from the PLATFORM
+  via `CHANNEL_CATEGORY` — the stored `category` column defaults to 'social' and
+  is only correct where the backfill migration has run. Caught live: the first
+  build listed Google Drive as a connected channel.
 - If a task needs production code reshaped beyond this scope, stop and raise it
   rather than widening silently.

--- a/docs/superpowers/specs/2026-08-16-campaign-messaging-channels-design.md
+++ b/docs/superpowers/specs/2026-08-16-campaign-messaging-channels-design.md
@@ -1,0 +1,144 @@
+# Campaign Messaging Channels (Slack + Discord) — Design Spec
+
+**Date:** 2026-08-16
+**Branches:** `feat/campaign-messaging-channels` (both `socialmedia-workspace` and `socialmedia-frontend-campaigns`, each off `main`)
+**Type:** Architectural (new backend publish capability + interface change carried through post model + new frontend composer path)
+
+---
+
+## 1. Problem
+
+Campaigns (bulk + drip) can target social platforms (Twitter/FB/IG/LinkedIn/…), but **not** the chat/messaging platforms Slack, Discord, Telegram, WhatsApp. Two independent defects:
+
+1. **They can't publish.** `PublisherFactory` has no publisher for slack/discord/telegram/whatsapp — `getPublisher('slack')` throws `No publisher found for platform: slack`. A campaign slot targeting one fails at fire time.
+2. **Wrong composer.** These platforms have `types: []` in `PLATFORM_POST_TYPES`, so selecting one falls back to `'text'` and shows the full **post** composer (mode strip + post-type tabs + rich EditorCard + platform-options). Messaging platforms should get a simple **chat-style** composer: one message + at most one media.
+
+The user's ask: messaging channels should use a chat-style input (not the post composer), and one slot = **one message + one optional media**, in **both** drip and bulk campaigns.
+
+## 2. Scope
+
+**In scope (this effort): Slack + Discord only.**
+
+**Deferred (documented, NOT built here):**
+- **WhatsApp** — Cloud API only permits sends inside a 24-hour customer-service window; unsolicited scheduled posts require pre-approved **message templates**, and no template-send code exists in the backend. Cold campaign sends would silently fail. Needs its own effort + Meta template approval.
+- **Telegram** — the Bot API cannot enumerate a bot's chats (platform limitation); the only known chat ids are those captured from inbound webhook messages into `inbox_items`. A destination picker would only list "chats that already messaged the bot," which is confusing for a broadcast feature. Needs its own design.
+
+## 3. Key facts the design rests on (verified in code)
+
+- **Send code already exists** (from the inbox feature) — no API clients to write:
+  - Slack: `SlackService.postMessage(botToken, { channel, text })` (`src/channels/services/slack.service.ts:90`) and `uploadFile(botToken, { channelId, filename, contentType, buffer, initialComment })` (`:352`).
+  - Discord: `DiscordService.createMessage(channelId, { content?, files? })` (`src/channels/services/discord.service.ts:27`); `files: { name, data: Buffer, contentType? }[]`.
+- **Destination list endpoints already exist** (both `JwtAuthGuard`, in `src/channels/channels.controller.ts`):
+  - Slack: `GET workspaces/:workspaceId/slack/:channelId/conversations` → `{ channels: { id, name, isMember, isPrivate, ... }[], nextCursor }`.
+  - Discord: `GET workspaces/:workspaceId/discord/:channelId/channels` → `{ channels: { id, name, type }[] }`.
+- **Publisher contract** (`src/posts/publishers/base.publisher.ts`): abstract `platform`, `publish(options: PublishOptions): Promise<PublishResult>`, `validate(options): void`, `supportsMediaTypes(mediaItems): boolean`.
+  - `PublishOptions`: `{ content, mediaItems, metadata, accessToken, platformAccountId, channelMetadata, channelId }`.
+  - `PublishResult`: `{ platformPostId, platformPostUrl?, metadata? }`.
+  - `MediaItem`: `{ url, type, thumbnailUrl?, altText?, ... }` — media is always URL-based; publishers download it.
+- **Publish path:** campaign materializer inserts a `posts` row + enqueues `publish-post` → `PostPublishProcessor` → `PostService.publishPost` → per target `publisherFactory.getPublisher(target.platform).publish({...})` (`src/posts/services/post.service.ts:807-818`). A second inline path (`publish-orchestrator.service.ts:148`) uses the same contract.
+- **Destination gap:** `PostTarget` (`src/drizzle/schema/posts.schema.ts:52-61`) has only `channelId + platform` — no field for "which Slack channel / Discord channel." This is the one new data-shape change needed.
+- **Discord auth model:** `DiscordService` uses a single shared `process.env.DISCORD_BOT_TOKEN` (not a per-channel token). The Discord publisher ignores `PublishOptions.accessToken`. Slack uses the per-channel bot token (decrypted via `channelService.getAccessToken`).
+- **Slack public-post:** OAuth scope `chat:write.public` is already granted, so the bot can post to **public** channels without joining. (Decision: post to public channels without join; private/member-only handled by the picker flagging `isMember`.)
+
+## 4. Design — three layers, backend-first
+
+### Layer 1 — Backend
+
+**1a. Carry the destination through the post model.**
+Add an optional field to `PostTarget`:
+```ts
+destination?: {
+  id: string;      // Slack channel id (C0123…) or Discord channel id
+  name?: string;   // human label for display/audit (e.g. "#announcements")
+};
+```
+Null/absent for every existing platform → zero behavioural change for them. **Verified:** `targets` is `jsonb('targets').$type<PostTarget[]>()` (`posts.schema.ts:84`) and `PostTarget` is a plain TS interface (`:52`), so adding an optional nested field is a **pure type change — NO DB migration required.**
+
+**1b. `SlackPublisher`** (`src/posts/publishers/slack.publisher.ts`):
+- `platform = 'slack'`.
+- `validate(options)`: require a destination id in `options.metadata.destination` (materializer copies it there — see 1e); require `content` OR exactly one media item; reject >1 media.
+- `supportsMediaTypes`: true iff `mediaItems.length <= 1`.
+- `publish`:
+  - No media → `slackService.postMessage(accessToken, { channel: destination.id, text: content })`.
+  - One media → `fetch(mediaItems[0].url)` → Buffer → `slackService.uploadFile(accessToken, { channelId: destination.id, filename, contentType, buffer, initialComment: content })`.
+  - Return `{ platformPostId: ts, platformPostUrl?: undefined }`.
+
+**1c. `DiscordPublisher`** (`src/posts/publishers/discord.publisher.ts`):
+- `platform = 'discord'`.
+- `validate`: require destination id; content OR one media; reject >1 media.
+- `publish`: download media (if any) → Buffer; `discordService.createMessage(destination.id, { content, files })`. Ignores `accessToken` (shared env bot token). Return `{ platformPostId: message.id }`.
+
+**1d. Register both in `PublisherFactory`** (constructor-inject, add to the map). Ensure both are provided by whatever module wires the factory (`PostsModule` / publishers provider list), and that `ChannelsModule`'s `SlackService`/`DiscordService` are importable there (they already are used elsewhere in posts — confirm).
+
+**1e. Campaign materializer carries the destination.**
+`campaign-publishing.service.ts`:
+- `MaterializeInput` gains `destination?: { id: string; name?: string }`.
+- `buildTargets(channelId, platform, destination?)` includes `destination` in the `PostTarget`.
+- The publish path (`post.service.ts`) already merges `target` fields into `metadata` before calling the publisher; ensure `destination` reaches `options.metadata.destination` (add to the metadata merge if not automatic).
+- The caller that builds `MaterializeInput` from a campaign slot reads the destination from the slot's stored `ChannelDayContent` (see Layer 2 data shape) and threads it through.
+
+### Layer 2 — Frontend
+
+**2a. Post-type config.** In `PLATFORM_POST_TYPES`, give `slack` and `discord` `types: ['message']`, `default: 'message'`, keep their `charLimit` (slack 40000, discord 2000). Add a new `PostType` `'message'` with `composer: 'message'` (new `ComposerKind`). Leave telegram/whatsapp `types: []` (still deferred).
+
+**2b. Slot-content shape.** `ChannelDayContent` gains an optional `destination?: { id: string; name?: string }` (only messaging slots populate it). `isChannelDayFilled` for a `'message'` slot: filled iff `destination` is set AND (`caption` non-empty OR one media). Media cap enforced in the composer, not the type.
+
+**2c. `MessageComposer`** (`src/features/campaigns/components/create/steps/composers/message-composer.tsx`):
+- One `Textarea` (shadcn) for the message, char counter against platform limit.
+- One optional media attach, **max 1**, reusing the existing media picker/`EditorCard` media path but capped at 1 (or the existing `MediaComposer` with `mediaMax: 1`). No thread, poll, carousel.
+- A **destination picker** (shadcn `Select` or `Combobox`) — see 2d.
+- **No** mode strip, **no** post-type tabs, **no** platform-options panel, **no** AI/Template.
+
+**2d. Destination picker + data hooks.**
+- New API wrappers + React Query hooks:
+  - Slack: `GET workspaces/:workspaceId/slack/:channelId/conversations` (paginate via `nextCursor`; show name, flag non-member public channels are fine, hide/disable private where `isMember === false`).
+  - Discord: `GET workspaces/:workspaceId/discord/:channelId/channels`.
+- Selecting a destination writes `{ id, name }` into `ChannelDayContent.destination`.
+- Loading/empty/error states per CLAUDE.md Rule 4 (skeleton while fetching, "No channels found" empty, inline error + retry).
+
+**2e. Routing in `ChannelDayComposer`.** When `platform` is a messaging platform (or `postType === 'message'`), render `MessageComposer` instead of the mode strip + `ManualBody` + `PlatformOptions` block. Bulk and drip both flow through `ChannelDayComposer`, so both get it. Non-messaging platforms unchanged (byte-for-byte).
+
+**2f. `ChannelsColumn` add-flow.** Messaging channels already appear in the "+ Add channel" menu. For a `'message'` slot the card meta shows the destination name (e.g. "→ #announcements") instead of a post-type chip; media count still shown (0 or 1).
+
+**2g. Launch validation.** A messaging slot with **no destination** blocks launch (destination is required). Surface it in the existing pre-flight/launch check (`preflight-summary.tsx` or the launch mutation guard): list offending slots ("Pick a destination for <channel> on <date>").
+
+### Layer 3 — Consistency
+
+Because `ChannelDayComposer` routes by platform, **drip and bulk both** get the chat composer with no extra work. Bulk behaviour for non-messaging platforms stays byte-for-byte unchanged (verified by the existing bulk-safety tests + a final review).
+
+## 5. Data flow (Slack example)
+
+```
+Composer: user adds Slack channel → MessageComposer →
+  picks destination (#announcements, id C0123) + types message + optional 1 media
+  → ChannelDayContent { postType:'message', caption, media[0..1], destination:{id:'C0123',name:'#announcements'} }
+Launch: materializer → posts row + PostTarget { channelId, platform:'slack', destination:{id,name} }
+  → enqueue publish-post { postId } at fire time
+Fire: PostPublishProcessor → PostService.publishPost → per target
+  → getPublisher('slack').publish({ content, mediaItems, metadata:{destination}, accessToken, ... })
+  → SlackService.postMessage / uploadFile → Slack
+```
+
+## 6. Error handling
+
+- **No destination:** blocked at launch (validation), not at fire time.
+- **>1 media:** prevented in composer (cap); publisher `validate` rejects as defence-in-depth.
+- **Empty message AND no media:** slot not "filled"; blocked at launch.
+- **Slack private channel, bot not member:** picker disables/hides it; public channels post without join (`chat:write.public`).
+- **Discord channel deleted / bot removed:** publish throws → BullMQ retry → slot marked failed with the error (existing runtime-status path).
+
+## 7. Testing
+
+- **Backend:** unit tests for `SlackPublisher` and `DiscordPublisher` (`validate` rejects missing destination / >1 media; `publish` calls the right service method with the destination id; media path downloads + passes buffer). Mock `SlackService`/`DiscordService`. Factory test: `getPublisher('slack')`/`('discord')` returns the publisher (no throw). Materializer test: destination copied into `PostTarget`.
+- **Frontend:** `MessageComposer` renders message box + destination picker, caps media at 1, no mode strip / post-type tabs. `isChannelDayFilled` for `'message'`. Destination-picker hooks (loading/empty/error). Launch validation flags a destination-less messaging slot. Bulk non-messaging path unchanged (existing tests stay green).
+- **Build:** `npm run build` green both repos.
+
+## 8. Global constraints
+
+- **shadcn-only** UI; theme tokens only (no hex, no arbitrary Tailwind colors).
+- **Never** `git add .`/`-A` — surgical `git add <path>` only (tracked `.env` on FE, gitignored `.env` on BE, both hold secrets).
+- Commit/push only when the user explicitly asks.
+- Assistant runs **no** `db:*`/`psql`/migration commands — the user applies any migration.
+- Bulk campaign behaviour for non-messaging platforms stays **byte-for-byte** unchanged.
+- Backend-first (Layer 1 before Layer 2).
+- Telegram + WhatsApp remain deferred — do not add them to `PLATFORM_POST_TYPES.types` or the factory.

--- a/docs/superpowers/specs/2026-08-16-campaign-slot-time-edit-design.md
+++ b/docs/superpowers/specs/2026-08-16-campaign-slot-time-edit-design.md
@@ -1,0 +1,106 @@
+# Campaign Slot Time Edit + Past-Due Warnings — Design Spec
+
+**Date:** 2026-08-16
+**Branches:** `feat/campaign-slot-time-edit` (both `socialmedia-workspace` and `socialmedia-frontend-campaigns`, each off `main` — which now includes messaging + launched-slot-edit)
+**Type:** Architectural (new backend time-move capability + FE time picker + a new time-aware past-due model surfaced across preflight, slot badges, and the days column)
+
+---
+
+## 1. Problem
+
+Two related gaps:
+
+1. **A slot's time can't be changed after it's added.** Time is chosen once at add-time (bulk = `schedule.defaultTime`; drip = pick from `schedule.times`) and is baked into the slot key (`${channelId}@${time}`). `updateEvent`'s `time` is a MATCHER only. The only way to "move" a slot today is remove+add, which BLANKS the authored content.
+
+2. **Past-due slots are invisible until it's too late.** The backend computes past-due correctly (timezone-aware, in `computeSlotSchedule`) and silently marks a past-due slot `skipped` at launch — but the FRONTEND never compares a slot's date+time+timezone to "now". `isSchedulable` is date-only; preflight has no past-due check; slot badges and the days "N/M ready" count ignore time. User's case: a 5:00 PM slot, now 5:26 PM → the slot shows a normal "Pending" badge, passes preflight, launches, and is silently skipped.
+
+## 2. Scope (approved with user)
+
+- **Editable slot time (pre-launch):** in the composer, the slot's time becomes editable via a time picker. Changing it MOVES the slot (preserves content). Backend: extend `updateEvent` with an optional `newTime` (content-preserving move); 409 on a unique-key collision.
+- **Past-due surfaced in 3 places:** (a) a red "Past due" badge on the slot card (replacing the neutral Pending look), (b) a launch **preflight blocker** that names the offending slots, (c) a past-due indicator in the Days column.
+- **Launch rule: BLOCK until fixed.** If any *ready* (would-otherwise-publish) slot is past-due, the Launch button is disabled; the user must change its time (now possible) or remove it. (Confirmed with user, understanding this also blocks a campaign that has future slots alongside a past-due one — acceptable because both escape hatches exist.)
+- Time comparison is **timezone-correct** (slot date + time + `schedule.timezone` → absolute instant vs now).
+- Out of scope (deferred, documented): surfacing blackout/weekend/wrong-weekday skips (already handled by hiding the day — no content loss); post-launch time editing of an already-scheduled slot (this effort's time edit is pre-launch/draft; a launched campaign's composer time field stays read-only, consistent with the launched-slot-edit effort); a launch "these slots were skipped" response summary (nice-to-have, not needed once past-due is blocked pre-launch).
+
+## 3. Key facts (verified in code)
+
+**Backend (`socialmedia-workspace`):**
+- `campaign_slot_content` unique index `(campaignId, date, channelId, time)` — time is part of the key (`campaigns.schema.ts:217-221`). `time` is `varchar(5)` NOT NULL.
+- `updateEvent` (`campaigns.service.ts:1334-1430`) merges content only; `dto.time` matches, never mutates. No `.set({ time })` anywhere.
+- `computeSlotSchedule` (`campaign-schedule.util.ts:71-100`) is timezone-correct (native `Intl.DateTimeFormat` offset, DST-aware). Past-due rule: `scheduledAt >= now → due, else pastDue` (`:92-96`). `schedule.timezone` is the zone.
+- `assertLaunchedSlotEditable` + `cancelAndClearSlotPost` exist (from launched-slot-edit) — a launched-campaign time move would reuse them, but that's OUT of scope here (pre-launch only).
+- `ConflictException` 409 precedent exists (`:1273, :988, :1378, :1469`).
+
+**Frontend (`socialmedia-frontend-campaigns`):**
+- `TimePickerSelect` (`src/features/inbox/components/composer/time-picker-select.tsx`) — reusable shadcn hour/minute/AM-PM control. `TimesListField` + `parseHHmm`/`toHHmm` (`create/times-list-field.tsx`) as a model.
+- Slot key `${channelId}@${time}`, helpers in `utils/slot-key.ts`.
+- `isSchedulable` (`utils/campaign-dates.ts:32-44`) — DATE ONLY, no time/now.
+- `computePreflight` (`utils/preflight.ts:60-127`) — blockers: name, channels, content, notifications, destination. NO past-due.
+- Slot badges: authoring `slot-status-config.tsx` (`ready|draft|published|failed`) + runtime `slot-runtime-config.tsx` (`pending|…|skipped`). No past-due state.
+- Days rollup `campaign-days.ts` (`readyCount` = filled only).
+- `schedule.timezone` (IANA) on `campaign.ts:51/68/83`. FE has a timezone catalog (`constants/timezones.ts`) but never builds a zoned instant — this is NEW.
+- Composer time flows through `event-composer.tsx` (prop, passed to `updateEvent` as matcher).
+
+## 4. Design — two layers, backend-first
+
+### Layer 1 — Backend: content-preserving time move
+
+**1a. `UpdateEventDto` gains optional `newTime`** (`dto/campaigns.dto.ts`): `@IsOptional @Matches(/^\d{2}:\d{2}$/) newTime?: string`. When present, the slot identified by `(date, channelId, time)` is MOVED to `newTime`.
+
+**1b. `updateEvent` handles `newTime`** (`campaigns.service.ts`): after finding the slot + merging content, if `dto.newTime` is set and differs from the slot's current time:
+- Pre-check collision: does a slot already exist at `(campaignId, date, channelId, newTime)`? If yes → `ConflictException` "A post already exists for this channel at HH:mm on this day."
+- `db.update(campaignSlotContent).set({ time: dto.newTime, content: mergedContent, updatedAt })` for the matched row.
+- **Guard:** only allow the time move when the campaign is NOT launched (`status !== 'active'`) OR the slot is still `pending`/`scheduled` — reuse `assertLaunchedSlotEditable`. For a launched+scheduled slot, a time move would also need re-materialize; since that's out of scope this effort, REJECT a `newTime` on a launched campaign with a clear 409 ("Change the time before launching."). (Pre-launch is the whole target.)
+- Draft campaign (the primary path): `slotStatus` is `pending`, `scheduledAt` null — a pure time-column update; launch recomputes everything from the new time. No re-enqueue needed.
+
+**1c. Tests:** move to a free time → row's `time` updated, content preserved; move onto an occupied time → 409; move on a launched campaign → 409; `newTime` absent → existing content-only behaviour unchanged.
+
+### Layer 2 — Frontend: time picker + past-due model
+
+**2a. Time picker in the composer** (`event-composer.tsx`). Near the channel identity / time display, show the slot's time as an editable `TimePickerSelect` (reuse the inbox component). On change, call `updateEvent.mutate({ date, channelId, time: <oldTime>, patch: {...draft}, newTime: <picked> })`. On 409 (collision) → toast the server message. On success, the slot key changes → re-select the moved slot (`slotKey(channelId, newTime)`). Only editable when the slot is editable (not launched-and-published — reuse `isSlotEditable` from launched-slot-edit). Keep it available for bulk too (bulk slots currently hide the time badge — for editing, show the picker so a bulk slot's per-day time can be adjusted; if this complicates bulk's single-defaultTime model, gate the picker to drip/evergreen and note it — DECISION: show for all; a bulk per-day time override already exists in the schedule model as `perDayTimes`, but to keep scope tight, the time move here just changes the slot's `time` column, which launch honors regardless of schedule type).
+
+**2b. `newTime` in the API + hook** (`campaigns.api.ts`, `use-campaign-event-mutations.ts`): thread an optional `newTime` through `updateEvent`.
+
+**2c. Past-due detection util** (`utils/campaign-dates.ts` or a new `utils/slot-timing.ts`): `isSlotPastDue(date, time, timezone, now)` → builds the absolute instant from `date`+`time`+`timezone` (zoned conversion mirroring the backend's `wallClockToUtc`: compute the zone offset via `Intl.DateTimeFormat` with `timeZone`, apply it) and returns `instant < now`. Unit-tested with fixed `now` + a couple of zones. This is the one genuinely new FE primitive.
+
+**2d. Red "Past due" badge on the slot card** (`channels-column.tsx`): for a NON-launched campaign, if `isSlotPastDue(...)` and the slot isn't already published/skipped, show a `text-destructive` "Past due" badge (with a tooltip "This time has passed — change it or remove this post before launching") instead of the neutral status. Do not touch launched runtime badges.
+
+**2e. Preflight blocker** (`preflight.ts` + `computePreflight`): add a `pastDue` blocker. Compute the set of *ready* (filled / would-publish) slots that are past-due; if non-empty, emit a blocker naming the first ("Past due: <channel> on <date> at <time> — change its time or remove it") + "(+N more)". Wire into `builder-header.tsx` launch gating (already blocks on `blockers.length > 0`) and `preflight-summary.tsx`. `computePreflight` needs `now` + the campaign schedule's timezone passed in (it already takes `channelNameById`; extend similarly).
+
+**2f. Days column indicator** (`campaign-days.ts` + `days-column.tsx`): a day whose ready slots include a past-due one gets a past-due marker (e.g. a small destructive dot / "past due" text alongside "N/M ready"). Keep the existing ready/partial/empty/skipped states.
+
+## 5. Data flow (change a slot's time)
+
+```
+User opens a draft campaign → selects a slot → composer shows time as TimePickerSelect (5:00 PM)
+  → picks 6:00 PM → updateEvent.mutate({ date, channelId, time:'17:00', newTime:'18:00', patch })
+Backend updateEvent: find slot @ 17:00 → newTime set + differs → collision check @ 18:00
+  → (free) UPDATE set time='18:00', content=merged → return CampaignDto
+  → (occupied) 409 "already a post at 6:00 PM"
+Frontend: slot key now channelId@18:00 → re-select moved slot; badge/preflight recompute (no longer past-due)
+```
+
+## 6. Error handling
+
+- Time collision (target time occupied) → 409, toast the message; picker reverts to the old time.
+- `newTime` on a launched campaign → 409 "Change the time before launching."; the picker is disabled there anyway (defence-in-depth).
+- Past-due ready slot present → Launch disabled + preflight blocker names it; user changes time or removes it.
+- Timezone edge: a slot exactly at `now` counts as NOT past-due (matches backend's `>= now → due`).
+- Draft campaign, all future slots → no change, no blockers.
+
+## 7. Testing
+
+- **Backend:** `updateEvent` newTime move (free → time updated + content preserved), collision → 409, launched → 409, no-newTime → unchanged. Reuse existing spec mocking style.
+- **Frontend:** `isSlotPastDue` (fixed now, multiple zones, exactly-now = not past-due, future = not, past = yes). `computePreflight` pastDue blocker (ready past-due slot → blocker with name/time; future-only → none; unfilled past-due slot → NOT a blocker since it wouldn't publish anyway). Slot card renders "Past due" badge for a past-due draft slot. TimePickerSelect wired → updateEvent called with newTime. Launch disabled when a pastDue blocker exists. Existing preflight/badge tests stay green.
+- **Build:** `npm run build` green both repos.
+
+## 8. Global constraints
+
+- **NO DB migration** (time column + index already exist; only logic).
+- **shadcn-only** UI, theme tokens only (past-due badge uses `text-destructive`/`bg-destructive/…` tokens, no hex).
+- **Never** `git add .`/`-A` — surgical (FE `.env` git-tracked; BE `.env` gitignored, both secrets).
+- Commit/push only when the user explicitly asks.
+- Assistant runs **no** `db:*`/`psql`/migration commands.
+- **Draft-campaign non-time-edit behaviour unchanged**; bulk/social slot rendering unchanged except the added time picker + past-due badge.
+- Past-due comparison must be timezone-correct (mirror backend `wallClockToUtc`), never server-local-naive.
+- Off `main` (has messaging + launched-slot-edit merged); independent effort, its own branch/PR.

--- a/docs/superpowers/specs/2026-08-19-composer-ai-assist-design.md
+++ b/docs/superpowers/specs/2026-08-19-composer-ai-assist-design.md
@@ -1,0 +1,139 @@
+# Composer AI Assist — Design
+
+**Date:** 2026-08-19
+**Branch:** `feat/composer-ai-assist` (both repos)
+**Type:** Architectural (new inline-AI path + provider upgrade + FE wiring)
+**Plan of record:** approved plan at `~/.claude/plans/glimmering-squishing-token.md`
+
+## Problem & goal
+
+Schedura (`schedura.ai`) promises AI throughout. It already ships **Maestro** (paid, agentic, conversational). We want an **inline assist** layer — fast, single-shot, in-context — that fills the composer's real fields, WITHOUT duplicating Maestro's chat model. Phase 1 (this effort) = **composer only**: generate a caption + hashtags, and produce **per-channel tailored variations**, metered as a free-quota → paid feature.
+
+Most of the backend already exists (`src/ai/` module: Groq-backed generators + `AiTokenService` metering + live `/ai/*` endpoints) and the composer already has a built-but-orphaned `AiAssistantPanel` (mock-backed). This is mostly **wiring + a provider upgrade + one new orchestration endpoint**, not a from-scratch build.
+
+## Locked decisions
+
+- **UX = generate-fills-fields** (not a chatbot). Results write into `useLocalDraft` and per-platform overrides; fields stay editable.
+- **Provider = Gemini Flash primary, Groq fallback** for inline. Maestro stays Anthropic. Gemini provider is already built (`GeminiChatProvider`, `@google/generative-ai`, `gemini-2.0-flash`); needs `GOOGLE_AI_API_KEY` + a single-shot helper.
+- **Per-channel variations = AI auto per-platform + user tone override.**
+- **Pricing = free monthly quota → paid**, via the existing `AiTokenService.executeWithTokens` metering (FREE plan `aiTokensPerMonth=0` → `ForbiddenException`; PRO 10k/mo). New per-op cost keys added.
+- **Scope this branch = composer only.** Inbox/media are later branches; backend kept generic so they reuse it.
+
+## Backend design
+
+### 1. Provider abstraction (Gemini primary, Groq fallback)
+
+Add a **single-shot text helper on the Gemini side** and a thin selector so inline generation prefers Gemini and falls back to Groq on error/unavailability. Two options considered:
+
+- **(A) Route through `LLMRouterService`** with `preferredProvider:'gemini'`. Rejected for inline: that router is chat/tool-calling oriented (`LLMMessage[]`), heavier than needed, and `GroqService`'s typed generators already encode the right system prompts.
+- **(B, chosen) Add `generateCompletion` to a Gemini single-shot path + a fallback wrapper.** Concretely:
+  - Add a public `generateText(systemPrompt, userPrompt, options?)` to `GeminiChatProvider` (or a small `GeminiTextService`) that calls `model.generateContent` once and returns the string — mirroring `GroqService.generateCompletion`'s contract (which is private today; expose an internal-callable equivalent or keep Groq's public typed methods as the fallback surface).
+  - Introduce an **`AiTextService`** in `src/ai/` that owns the "run one system+user prompt, get text" primitive with **Gemini→Groq fallback**: try Gemini `generateText`; on throw or unavailability, call Groq's `generateCompletion`-equivalent. Log which provider served the call.
+  - **Refactor `GroqService`'s public typed methods** (`generateCaption`, `generateHashtags`, `improvePost`, `generateVariations`) to obtain their completion via `AiTextService` instead of calling `this.generateCompletion` directly — so every existing `/ai/*` endpoint transparently gains Gemini-primary + Groq-fallback with **no controller/DTO change**. `GroqService` keeps its prompt-building; only the "who runs the completion" line changes. (If cleaner, move prompt-building into `AiTextService` callers; but minimal-diff route is: `AiTextService.complete(system,user,opts)` and Groq methods delegate to it.)
+  - `AiTextService` exposes `isReady()` = Gemini-ready OR Groq-ready.
+
+This keeps the whole existing `/ai/*` surface working, upgrades quality/reliability globally, and gives the new per-channel endpoint the same path.
+
+### 2. Per-channel variation orchestration (new)
+
+`GroqService.generateVariations(content, platform, count)` makes N variants of one caption for one platform. It has no concept of the workspace's connected channels. Add an orchestrator:
+
+- **New method** (in a new `ComposerAiService` in `src/ai/`, or on `AiTextService`): `generatePerChannel({ description, platforms: Platform[], tone?, includeHashtags? })` → returns `{ platform: Platform; text: string; hashtags?: string[] }[]`.
+- Implementation: for each requested platform, call the caption path with that platform + tone (AI auto-applies platform norms via the existing platform-aware system prompts; `tone` overrides when supplied). Run platforms concurrently (`Promise.all`), bounded to the requested list (composer selection is small — a handful of platforms).
+- **Metering:** the whole per-channel call is ONE `executeWithTokens` unit priced by a new op key (below), NOT one deduction per platform — simpler for the user, and matches "one generate action." `outputLength` = joined length of all variations.
+
+### 3. New endpoint
+
+Add to `src/ai/ai.controller.ts` (same `@Controller('ai')`, `@UseGuards(JwtAuthGuard)`, `:workspaceId` param — note: this controller is NOT workspace-role-guarded today; keep consistent with siblings, metering is the gate):
+
+```
+POST /ai/workspaces/:workspaceId/generate/per-channel
+body: { description: string; platforms: Platform[]; tone?: Tone; includeHashtags?: boolean }
+resp: { variations: { platform: Platform; text: string; hashtags?: string[] }[]; usage: TokenDeductResult }
+```
+
+New DTO `GeneratePerChannelDto` in `src/ai/dto/ai.dto.ts` (class-validator: `@IsString() description`, `@IsArray() @IsIn(PLATFORMS,{each:true}) platforms`, optional `tone`/`includeHashtags`). Response DTO mirrors the shape.
+
+### 4. Operation cost keys
+
+Add to `AI_OPERATION_COSTS` (`src/ai/services/ai-token.service.ts`): `generate_per_channel` (cost ~8, it fans out). The existing `caption`/`hashtags`/`improve`/`variations` keys already exist and are reused unchanged for the single-field generate. (No `inline_*` rename — reuse existing keys to avoid double-defining; only the genuinely-new per-channel op is added.)
+
+### 5. Env
+
+Add `GOOGLE_AI_API_KEY` to backend `.env.example` (documented). Real key set on Railway at deploy. If the key is absent, `AiTextService` silently falls back to Groq — no breakage.
+
+### Backend explicitly out of scope
+- No inbox AI (`suggestReply`) this branch.
+- No change to Maestro / `TokenTrackingService`.
+- No new usage-*count* metering (we meter tokens via the existing path, not a new `UsageService` ResourceType).
+
+## Frontend design
+
+### UX flow (locked)
+
+The user clicks a right-pane toggle to switch the pane between **Preview** and **✨ AI Assist** (see mount below). The AI panel is a **single-shot form, NOT a chat** (AI never asks follow-up questions — that's Maestro's job):
+1. Prompt box: "What's this post about?"
+2. Tone chips (professional/playful/bold/casual…) — the AI-auto default per platform, user override.
+3. Mode toggle: **One caption** | **Per-channel**.
+4. Generate (spinner, disabled while pending / when quota exhausted; quota shown near it).
+5. **One caption** → result card with **Insert into post** (writes `draft.base.text`) + Regenerate.
+6. **Per-channel** → one card per currently-selected platform (from `draft.channels` distinct platforms), each tailored (Twitter short, LinkedIn formal, IG emoji-heavy…), each with **Apply to <Platform>** (writes that platform's override) + **Apply all**.
+
+### 1. Wire the orphaned `AiAssistantPanel`
+
+`AiAssistantPanel` (`src/features/composer/components/ai-assistant-panel.tsx`) is fully built (prompt Textarea, tone picker, Generate, Copy, Insert) but mock-backed and unmounted. Changes:
+- Replace `generateMockAiOutput` (`lib/ai-mock.ts`) with a real API call.
+- Add the **mode toggle** (One caption | Per-channel) and the per-channel result cards to the panel.
+- Add an API module `src/features/composer/api/ai.api.ts` (typed `apiClient` wrappers): `generateCaption`, `generateHashtags`, `improve`, `generatePerChannel`, `getAiUsage` — hitting the `/ai/workspaces/:id/...` endpoints.
+- Add hooks `src/features/composer/hooks/use-ai-generate.ts` (+ `use-ai-usage.ts`) — TanStack `useMutation`/`useQuery`.
+
+### Mount — right-pane Preview ⇆ AI toggle
+
+Add a **toggle/segment at the top of the right pane** (`right-pane-tabs.tsx` / its container) with two modes: **Preview** (current channel-preview cards, unchanged) and **✨ AI Assist** (the panel). One pane, two modes — generate on AI, switch to Preview to see it land. This is layered ON TOP of the existing channel `ChannelTabBar`/preview machinery, not a replacement — the channel tabs still drive which platform preview shows in Preview mode.
+
+### 2. Write results into the draft (fills fields)
+
+- Single caption → `update((prev)=>({ base: { ...prev.base, text: <generated> } }))` via `useLocalDraft`.
+- Hashtags → the composer doesn't wire `base.hashtags` to UI today; simplest Phase-1 behavior: **append hashtags to the caption text** (matches how users add hashtags now — inline in the body). (Wiring a separate hashtags field is out of scope.)
+- The panel's existing "Insert into post" (`onInsert`) is the natural hook — repoint it to `update`.
+
+### 3. Per-channel variations surface
+
+- Extend the panel's output: a **"Per-channel" mode** that calls `generatePerChannel` with the composer's currently-selected platforms (derived from `draft.channels` distinct platforms) + chosen tone.
+- Render **one card per platform** (reuse platform badges/labels), each with the tailored caption and an **"Apply to <Platform>"** action that writes into the per-platform override: `update((prev)=>({ perPlatform: { ...prev.perPlatform, [platform]: enableCustomizeWith(text) } }))` — following the existing `handleEnableCustomize`/`platform-tab.tsx` override model (snapshot base → set `overrides.text`).
+- "Apply all" convenience writes every card into its platform override.
+
+### 4. Quota surfacing
+
+- `useAiUsage` reads `GET /ai/workspaces/:id/usage` → remaining tokens/generations.
+- Show remaining count near the Generate button; when the plan gates (FREE = 0) or tokens exhausted, the endpoint returns 403 → render an **empty/upsell state** ("You've used your free AI generations — upgrade for more") reusing existing billing-upgrade UI patterns. Generate button disabled + tooltip when exhausted.
+- Loading/disabled/error states per the composer's polish rules (spinner in button, toast on error).
+
+### FE out of scope
+- Inbox ✨ button (Phase 2). Media (Phase 3). Separate hashtags-field UI. Streaming.
+
+## Error & edge handling
+- Gemini error/rate-limit → Groq fallback (backend, transparent to FE).
+- Both providers down → endpoint 400 "AI is not configured"; FE toasts a friendly error.
+- 403 (plan/quota) → FE upsell state, NOT a generic error toast.
+- Empty prompt → client-side validation (panel already disables Generate on empty).
+- Multilingual: verify a non-English prompt returns quality copy (international requirement) — Gemini's strength; part of manual E2E.
+
+## Testing
+**Backend (Jest):**
+- `AiTextService`: Gemini primary used when ready; Groq fallback on Gemini throw; both-unready → throws. (Mock both providers.)
+- Per-channel orchestrator: N platforms → N `{platform,text}` entries; tone passed through; one `executeWithTokens` unit.
+- Metering: FREE plan (0 tokens) → 403; success deducts once; failure deducts nothing (reuse existing `AiTokenService` test patterns).
+- New DTO validation (bad platform rejected).
+
+**Frontend (Vitest):**
+- API/hook wiring shape; per-channel result maps to cards; apply-to-channel writes the right `perPlatform` override shape; quota-exhausted state renders on 403.
+
+## Files
+**Backend:** `src/ai/ai-text.service.ts` (new), `src/ai/composer-ai.service.ts` (new, or fold into ai-text), `src/chatbot/llm/gemini.provider.ts` (add single-shot `generateText`), `src/ai/groq.service.ts` (delegate completion to AiTextService), `src/ai/services/ai-token.service.ts` (+`generate_per_channel` cost), `src/ai/ai.controller.ts` (+per-channel route), `src/ai/dto/ai.dto.ts` (+DTOs), `src/ai/ai.module.ts` (wire new services), `.env.example` (+`GOOGLE_AI_API_KEY`). Tests co-located `*.spec.ts`.
+**Frontend:** `src/features/composer/api/ai.api.ts` (new), `src/features/composer/hooks/use-ai-generate.ts` + `use-ai-usage.ts` (new), `src/features/composer/components/ai-assistant-panel.tsx` (rewire + per-channel + quota), mount point in `right-pane-tabs.tsx`, remove/replace `src/features/composer/lib/ai-mock.ts`. Tests co-located.
+
+## Verification
+- BE `npm run build` + `npm test`; FE `npm test` + `npm run build`.
+- Manual E2E with a real `GOOGLE_AI_API_KEY` in a PRO test workspace: generate caption → fills field; per-channel → cards → apply → per-platform override set → publish; exhaust quota → upsell; non-English prompt → quality multilingual copy.
+- Standing rules: backend-first; surgical `git add`; both `.env` files untracked-safe; ship to `main`.

--- a/docs/superpowers/specs/2026-08-27-maestro-platform-tools-design.md
+++ b/docs/superpowers/specs/2026-08-27-maestro-platform-tools-design.md
@@ -1,0 +1,132 @@
+# Maestro — platform tools, and answers you can click
+
+**Date:** 2026-08-27
+**Status:** Layer 1 approved, layers 2–4 agreed in principle
+**Scope:** backend (`socialmedia-workspace`) + frontend (`socialmedia-frontend`)
+
+---
+
+## Where we are
+
+Maestro has 28 tools. **26 of them are messaging** — Slack, Discord, Telegram,
+WhatsApp. The product itself has three: `list_posts`, `get_post`, `publish_post`.
+
+So Maestro today is a messaging agent that happens to live inside Schedura. It
+cannot answer "how many channels do I have", "what's going out this week", or
+"which post did best" — the three things a user is most likely to ask it.
+
+---
+
+## Not module by module
+
+The obvious plan is to finish Channels, then Campaigns, then Inbox. We are
+deliberately not doing that, for two reasons.
+
+**Users think in tasks, not modules.** "What's going out this week?" touches
+posts, campaigns, and the calendar at once. Finishing Campaigns' twelve tools
+while Channels has none leaves the agent unable to answer ordinary questions —
+it would look no better than it does now, for a lot of work.
+
+**More tools means worse tool choice.** Going from 28 to ~80 tools degrades
+selection accuracy, and we run Haiku 4.5 by default. Breadth-first keeps the
+tool count honest: each layer adds a thin slice everywhere rather than a deep
+well in one place.
+
+So: **capability by capability**, each layer spanning the whole product.
+
+| Layer | What | Risk | Gate |
+|---|---|---|---|
+| 1 | Read — show me | none | none |
+| 2 | Interactive cards — do it in the UI | none (user acts) | none |
+| 3 | Create / edit drafts | reversible | none |
+| 4 | Publish, launch, delete | irreversible | confirm |
+
+Layer 4 rides on the confirm gate fixed in
+`2026-08-27-maestro-question-turn-design.md`.
+
+---
+
+## Layer 1 — read, with references
+
+This document covers Layer 1. Later layers get their own specs.
+
+### The actual requirement: answers you can click
+
+Not just "return the data". Every entity Maestro names must be a **link back
+into the app**, rendered inline the way ClickUp's assistant does it: the task
+name is clickable, and its status rides beside it as a pill.
+
+Today `rich-text.tsx` renders paragraphs, bullets, and `**bold**` — and nothing
+else. There is no link support at all. A tool returning a channel list can only
+produce dead text.
+
+This is the substance of Layer 1, not a polish pass on top of it. A read tool
+whose answer cannot be clicked has not really answered.
+
+### How references travel
+
+Tools return **structured references**, never a pre-baked URL string.
+
+A tool result carries the entities it mentions — kind, id, label, and status —
+and the model refers to them by a marker in its prose. The frontend resolves
+each marker into a link, building the href from the workspace route table it
+already owns.
+
+This matters because the model must not be inventing URLs. It knows entity ids
+because the tool gave them; it does not know our routing, and should not.
+Anything it cannot resolve renders as plain text — a wrong link is worse than
+no link.
+
+### Tools
+
+Channels first — it is where the user's own example starts ("I don't know how
+to connect a channel"), and everything else depends on channels existing.
+
+1. `list_channels` — what is connected, what is expiring, what needs reconnecting
+2. `get_channel_stats` — followers, reach, per-channel performance
+3. `connect_channel` — an interactive card (below)
+
+Then the same shape across posts, campaigns, inbox, media, and calendar.
+
+### `connect_channel` — the card pattern
+
+The user's example: *"I don't know how to connect a channel"* → agent asks which
+platform → user picks → agent returns **a button** → user clicks → connected.
+
+This is a new pattern, not just a new tool: **the agent returns an interactive
+card, and the actual work happens in the browser.** `MediaGrid` already proves
+the panel can render a rich tool result; this extends it to one that acts.
+
+The card routes to `/settings/channels` with the platform preselected. It does
+**not** open the OAuth popup directly from the panel: the COOP popup-close bug
+is still open on production (`project_oauth_popup_close_bug`), and routing the
+user to the page they would have used anyway avoids inheriting it.
+
+The pattern is reused later for "open this post", "show this campaign",
+"reconnect this channel".
+
+---
+
+## Out of scope
+
+- **Layers 2–4.** `connect_channel` is included because it is Layer 1's proof of
+  the card pattern at small scope, not because Layer 2 starts here.
+- **Analytics comparisons.** Reading numbers is Layer 1. Charts, period-over-
+  period, and cross-channel comparison are a separate effort.
+- **Write of any kind.** No tool in this layer changes state.
+
+---
+
+## Definition of done
+
+- Asking about channels, posts, campaigns, inbox, media, or the calendar returns
+  real data from the user's workspace.
+- Every entity named in an answer is clickable and lands on the right screen,
+  with status shown inline where the entity has one.
+- An unresolvable reference degrades to plain text — never a broken link.
+- Reference rendering is verified **visually in a real browser**, not only by
+  unit test: screenshots of the rendered answer plus the network payload behind
+  it.
+- No tool in this layer can change workspace state.
+- `npm run test` and `npm run build` green on the backend; `npm run build` green
+  on the frontend.

--- a/docs/superpowers/specs/2026-08-27-maestro-platform-tools-design.md
+++ b/docs/superpowers/specs/2026-08-27-maestro-platform-tools-design.md
@@ -15,6 +15,23 @@ So Maestro today is a messaging agent that happens to live inside Schedura. It
 cannot answer "how many channels do I have", "what's going out this week", or
 "which post did best" — the three things a user is most likely to ask it.
 
+## The target
+
+**Anything the user can do or see in the app, the agent can do or see too.**
+
+That is the standard set for this work, and it is what makes the layering below
+a sequence rather than a subset: every layer is on the way to full parity, none
+of them is the stopping point.
+
+Two things follow from it, and they hold for every later layer:
+
+- **The agent uses the same paths the UI uses.** Not a parallel implementation
+  that drifts. If connecting a channel runs OAuth in the UI, it runs OAuth from
+  the agent — the same hook, the same popup, the same callback.
+- **Parity of surface, not of permission.** The agent inherits the user's own
+  capabilities and workspace scope. It can never see or do more than the person
+  asking, and every read derives its workspace from the request context.
+
 ---
 
 ## Not module by module
@@ -88,6 +105,19 @@ to connect a channel"), and everything else depends on channels existing.
 
 Then the same shape across posts, campaigns, inbox, media, and calendar.
 
+**Analytics: everything the Insights UI shows** — per the user's decision. That
+surface is `kpi-strip`, `metrics-chart`, `platform-breakdown`, and
+`channel-table`, so the agent reads the same numbers behind them: KPIs and their
+trend, the metric series over a period, the per-platform split, and per-channel
+performance.
+
+Read the values through the services the UI already calls. Nothing new is
+computed for the agent, and no number should be derivable only by asking it —
+if the agent and the Insights page disagree, that is a bug in this work.
+
+The agent answers in prose and links; it does not draw charts. Rendering a chart
+in the panel is a later question, and not what "show me my analytics" needs.
+
 ### `connect_channel` — the card pattern
 
 The user's example: *"I don't know how to connect a channel"* → agent asks which
@@ -97,10 +127,23 @@ This is a new pattern, not just a new tool: **the agent returns an interactive
 card, and the actual work happens in the browser.** `MediaGrid` already proves
 the panel can render a rich tool result; this extends it to one that acts.
 
-The card routes to `/settings/channels` with the platform preselected. It does
-**not** open the OAuth popup directly from the panel: the COOP popup-close bug
-is still open on production (`project_oauth_popup_close_bug`), and routing the
-user to the page they would have used anyway avoids inheriting it.
+**The button runs the real OAuth flow** — the same behaviour as connecting from
+the Channels page, per the user's decision. It reuses `useInitiateOAuth` and
+`openOAuthPopup` rather than reimplementing anything: the agent must not become
+a second, subtly different connect path.
+
+One constraint shapes the card: `useInitiateOAuth` does not redirect on its own,
+and the popup **must be opened synchronously inside the click handler** or popup
+blockers kill it. So the card owns the click and the popup; the agent's job ends
+at rendering it. An agent-initiated popup is not possible here, and that is
+fine — the user clicking is the action.
+
+**This inherits the open COOP popup bug.** `project_oauth_popup_close_bug`:
+on production the popup does not auto-close after connecting, because COOP
+severs `window.close()`. It is real today on the Channels page and it will be
+equally real inside Maestro. Since this work makes it more visible, the fix
+(parent-side close) belongs here rather than staying queued — otherwise the
+agent's headline feature ends in a window the user has to close by hand.
 
 The pattern is reused later for "open this post", "show this campaign",
 "reconnect this channel".
@@ -111,8 +154,7 @@ The pattern is reused later for "open this post", "show this campaign",
 
 - **Layers 2–4.** `connect_channel` is included because it is Layer 1's proof of
   the card pattern at small scope, not because Layer 2 starts here.
-- **Analytics comparisons.** Reading numbers is Layer 1. Charts, period-over-
-  period, and cross-channel comparison are a separate effort.
+- **Analytics beyond what the UI shows.** Nothing new is computed for the agent.
 - **Write of any kind.** No tool in this layer changes state.
 
 ---

--- a/src/maestro/maestro.module.ts
+++ b/src/maestro/maestro.module.ts
@@ -13,6 +13,11 @@ import { PostsModule } from '../posts/posts.module';
 // (sent via the same path as a manual reply, fromMe=true).
 import { InboxModule } from '../inbox/inbox.module';
 import { ChannelsModule } from '../channels/channels.module';
+// CampaignsModule exports CampaignsService — for the campaign read tools. Like
+// ChannelsModule it owns DB and queue dependencies, so it comes in as a module
+// import rather than a directly-provided service. It does not import Maestro,
+// so no forwardRef is needed.
+import { CampaignsModule } from '../campaigns/campaigns.module';
 import { MaestroController } from './maestro.controller';
 import { MaestroService } from './services/maestro.service';
 import { MaestroKeyService } from './services/maestro-key.service';
@@ -60,6 +65,7 @@ import { MaestroBridgeProcessor } from './bridge/processors/maestro-bridge.proce
     // directly — the module import is the right call here. ChannelsModule does
     // not import Maestro, so no forwardRef is needed.
     ChannelsModule,
+    CampaignsModule,
     BullModule.registerQueue({ name: QUEUES.MAESTRO_BRIDGE }),
   ],
   controllers: [MaestroController],

--- a/src/maestro/maestro.module.ts
+++ b/src/maestro/maestro.module.ts
@@ -12,6 +12,7 @@ import { PostsModule } from '../posts/posts.module';
 // InboxModule exports InboxService — used so Maestro's DMs persist to the inbox
 // (sent via the same path as a manual reply, fromMe=true).
 import { InboxModule } from '../inbox/inbox.module';
+import { ChannelsModule } from '../channels/channels.module';
 import { MaestroController } from './maestro.controller';
 import { MaestroService } from './services/maestro.service';
 import { MaestroKeyService } from './services/maestro-key.service';
@@ -54,6 +55,11 @@ import { MaestroBridgeProcessor } from './bridge/processors/maestro-bridge.proce
     AiModule,
     PostsModule,
     InboxModule,
+    // For the channel read tools. Unlike the stateless REST clients above,
+    // ChannelService owns DB + queue dependencies, so it cannot be provided
+    // directly — the module import is the right call here. ChannelsModule does
+    // not import Maestro, so no forwardRef is needed.
+    ChannelsModule,
     BullModule.registerQueue({ name: QUEUES.MAESTRO_BRIDGE }),
   ],
   controllers: [MaestroController],

--- a/src/maestro/prompt/system-prompt.ts
+++ b/src/maestro/prompt/system-prompt.ts
@@ -74,10 +74,25 @@ Right: [[ref:10]] needs reconnecting; [[ref:1]] and [[ref:2]] are fine.
   - get_post — full details of one post (content, target platforms, media, status). Read-only.
   - publish_post — publish a draft NOW to its target channels. OUTWARD-FACING.
 
+- Channels (the social accounts connected to this workspace):
+  - list_channels — which channels are connected, and whether each is healthy, expiring, or needs reconnecting. Read-only.
+  - get_channel_stats — the totals: how many channels, how many healthy, the split per platform. Read-only.
+  - connect_channel — show the user a button that starts connecting an account. They click it; nothing is connected until they do.
+
+- Campaigns (scheduled multi-post campaigns — bulk, drip, and evergreen):
+  - list_campaigns — the workspace's campaigns, optionally filtered by status or searched by name. Read-only.
+  - get_campaign — one campaign in full: schedule, channels, and how many of its posts have published, failed, or been skipped. Read-only.
+
 ## Posts
 - When the user says "publish my post / this draft", first find it: if they didn't give an id, call list_posts (status 'draft') and identify the right one (by content match) — or use ask_user if several drafts are plausible.
 - A post publishes to the channels the draft is already set up for. If the user names platforms (e.g. "Instagram and Facebook") that aren't the draft's targets, tell them that's a draft edit, not something publish_post changes.
 - After publishing, report the per-platform result plainly: which succeeded (with a link if present) and which failed and why. Don't claim success if a target failed.
+
+## Campaigns
+- A campaign is a schedule, not a single post. Bulk runs between two dates, drip repeats on chosen weekdays at chosen times, and evergreen rotates a pool of posts with no end date — so never promise an evergreen campaign an end date.
+- "How is my campaign doing" is answered from its progress counts: how many of its planned posts have published, failed, or been skipped. Give the real numbers rather than a vague "it's going well".
+- If the user names a campaign, call list_campaigns with that search term rather than guessing an id.
+- You can read campaigns but not change them. If the user wants to launch, pause, edit, or delete one, say plainly that they'll need to do it on the campaign's own page — and cite the campaign so they can click straight through.
 
 ## Discord
 - These tools act on the user's real Discord server. If a tool returns ok:false, tell the user the message plainly (e.g. no server connected, channel not found, missing permission) — don't retry blindly.
@@ -172,4 +187,4 @@ The user wants to confirm before anything leaves the app. This is handled FOR YO
 - NEVER write a confirmation in prose. Do NOT type "Confirm?", do NOT list "Yes / No" choices in your text, and NEVER say things like "you should see buttons above". If you find yourself about to ask the user to confirm in words, that is a bug — call the tool instead and let it confirm.
 - After the user approves, the action is ALREADY PERFORMED for you — the approval runs the tool directly. Do NOT call the tool again, do NOT produce another confirmation card, and never say you are "waiting for approval" for something already approved. If they pick "No, cancel", do not call it — acknowledge the cancellation in one short line.
 - If you ever find yourself about to ask for the same approval twice, stop: the first one already went through.
-- Read-only tools (list_posts, get_post, list_discord_channels, read_discord_messages, list_discord_dm_contacts, search_media, web_search) never need confirmation.`;
+- Read-only tools (list_posts, get_post, list_channels, get_channel_stats, list_campaigns, get_campaign, list_discord_channels, read_discord_messages, list_discord_dm_contacts, search_media, web_search) never need confirmation. Neither does connect_channel: it performs nothing — the user clicking the button is the action.`;

--- a/src/maestro/prompt/system-prompt.ts
+++ b/src/maestro/prompt/system-prompt.ts
@@ -19,7 +19,20 @@ export const STATIC_SYSTEM_PROMPT = `You are Maestro, the AI assistant built int
 ## Voice
 - Concise, warm, direct. Short answers for simple things; a little more only for genuine how-to.
 - Ground every factual claim in a tool result. NEVER invent the user's data, image URLs, or app details. If you have no tool for something, say so plainly in one line instead of guessing.
-- Light Markdown (bold for key values), minimal emojis.
+- Light Markdown, minimal emojis.
+
+## Naming the user's things — ALWAYS as a citation, never as plain text
+Some tools return entities (channels, posts, campaigns, conversations, media) with an id. Whenever you NAME one of those in a reply, write its citation marker [[ref:<id>]] instead of typing the name. The UI turns the marker into a clickable chip carrying the item's icon, name, and status; plain text is a dead end for the user.
+
+This applies EVERY time, not only in the turn where the tool ran:
+- On a later turn, a past reply's citations are restated to you in the transcript as "[Entities cited above — ...]". Reuse those ids; do not fall back to prose.
+- It applies when you refer to something by its platform or type too. Write [[ref:10]], not "your Threads account"; [[ref:1]] and [[ref:2]], not "Discord and Slack".
+- NEVER bold the name of an entity that has a marker. Bold is for values with no chip — a count, a date, a bare state.
+- A name you are quoting rather than pointing at goes in double quotes and bold: **"Launch week"**.
+- If an entity genuinely has no id in any result, say the name plainly. Never invent an id.
+
+Wrong: Your **Threads** account needs reconnecting; **Discord** and **Slack** are fine.
+Right: [[ref:10]] needs reconnecting; [[ref:1]] and [[ref:2]] are fine.
 
 ## Tools — and when to reach for each
 - get_user_profile — the user's name, email, role, join date. Use for any question about their account.

--- a/src/maestro/services/maestro.service.spec.ts
+++ b/src/maestro/services/maestro.service.spec.ts
@@ -153,6 +153,7 @@ function makeHarness(
     inbox,
     stub, // r2
     { getDecryptedKey } as never,
+    stub, // channels
   );
 
   jest

--- a/src/maestro/services/maestro.service.spec.ts
+++ b/src/maestro/services/maestro.service.spec.ts
@@ -154,6 +154,7 @@ function makeHarness(
     stub, // r2
     { getDecryptedKey } as never,
     stub, // channels
+    stub, // campaigns
   );
 
   jest

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -30,6 +30,11 @@ import { createTelegramTools } from '../tools/telegram.tools';
 import { createWhatsAppTools } from '../tools/whatsapp.tools';
 import { createPostTools } from '../tools/post.tools';
 import { createChannelTools } from '../tools/channel.tools';
+import {
+  mergeReferences,
+  isReferencePayload,
+  type EntityReference,
+} from '../tools/references';
 import { ChannelService } from '../../channels/services/channel.service';
 import {
   resolveAgentAuth,
@@ -822,6 +827,10 @@ export class MaestroService {
     let maestroWeb:
       | { title: string; url: string; content: string }[]
       | null = null;
+    // References accumulate across tool calls (unlike media/questions, where a
+    // later result replaces an earlier one): asking about two things in one
+    // turn must leave every named entity clickable.
+    let maestroRefs: EntityReference[] = [];
 
     try {
       for await (const ev of this.runtime.run(input)) {
@@ -896,6 +905,8 @@ export class MaestroService {
                   ? { pendingAction: data.pendingAction }
                   : {}),
               };
+            } else if (isReferencePayload(data)) {
+              maestroRefs = mergeReferences(maestroRefs, data.refs);
             } else if (data?.kind === 'web') {
               if (Array.isArray(data.images) && data.images.length > 0) {
                 maestroMedia = {
@@ -945,12 +956,16 @@ export class MaestroService {
               .filter(Boolean)
               .slice(0, 4);
 
+      const hasRefs = maestroRefs.length > 0;
       const metadata =
-        maestroMedia || maestroQuestion || maestroWeb
+        maestroMedia || maestroQuestion || maestroWeb || hasRefs
           ? {
               ...(maestroMedia ? { maestroMedia } : {}),
               ...(maestroQuestion ? { maestroQuestion } : {}),
               ...(maestroWeb ? { maestroWeb } : {}),
+              // Without this a reference renders live but dies on reload —
+              // the marker would survive in the text with nothing to resolve it.
+              ...(hasRefs ? { maestroRefs } : {}),
             }
           : undefined;
 

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -30,6 +30,7 @@ import { createTelegramTools } from '../tools/telegram.tools';
 import { createWhatsAppTools } from '../tools/whatsapp.tools';
 import { createPostTools } from '../tools/post.tools';
 import { createChannelTools } from '../tools/channel.tools';
+import { createCampaignTools } from '../tools/campaign.tools';
 import {
   mergeReferences,
   isReferencePayload,
@@ -37,6 +38,7 @@ import {
   type EntityReference,
 } from '../tools/references';
 import { ChannelService } from '../../channels/services/channel.service';
+import { CampaignsService } from '../../campaigns/campaigns.service';
 import {
   resolveAgentAuth,
   MaestroAuthUnavailableError,
@@ -179,6 +181,7 @@ export class MaestroService {
     private readonly r2: CloudflareR2Service,
     private readonly keys: MaestroKeyService,
     private readonly channels: ChannelService,
+    private readonly campaigns: CampaignsService,
   ) {}
 
   /**
@@ -432,6 +435,7 @@ export class MaestroService {
       ...createWhatsAppTools(this.inbox, { confirmBeforeSend }),
       ...createPostTools(this.posts, { confirmBeforeSend }),
       ...createChannelTools(this.channels),
+      ...createCampaignTools(this.campaigns),
       ...createInteractionTools(),
     ];
   }

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -29,6 +29,8 @@ import { createSlackTools } from '../tools/slack.tools';
 import { createTelegramTools } from '../tools/telegram.tools';
 import { createWhatsAppTools } from '../tools/whatsapp.tools';
 import { createPostTools } from '../tools/post.tools';
+import { createChannelTools } from '../tools/channel.tools';
+import { ChannelService } from '../../channels/services/channel.service';
 import {
   resolveAgentAuth,
   MaestroAuthUnavailableError,
@@ -170,6 +172,7 @@ export class MaestroService {
     private readonly inbox: InboxService,
     private readonly r2: CloudflareR2Service,
     private readonly keys: MaestroKeyService,
+    private readonly channels: ChannelService,
   ) {}
 
   /**
@@ -418,6 +421,7 @@ export class MaestroService {
       ...createTelegramTools(this.inbox, { confirmBeforeSend }),
       ...createWhatsAppTools(this.inbox, { confirmBeforeSend }),
       ...createPostTools(this.posts, { confirmBeforeSend }),
+      ...createChannelTools(this.channels),
       ...createInteractionTools(),
     ];
   }

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -33,6 +33,7 @@ import { createChannelTools } from '../tools/channel.tools';
 import {
   mergeReferences,
   isReferencePayload,
+  referenceMarker,
   type EntityReference,
 } from '../tools/references';
 import { ChannelService } from '../../channels/services/channel.service';
@@ -759,6 +760,29 @@ export class MaestroService {
         if (m.role === 'user' && Array.isArray(atts) && atts.length > 0) {
           const list = atts.map((a) => `${a.name} — ${a.url}`).join('; ');
           const note = `[Attached files (URLs for tool use only, do not paste in replies): ${list}]`;
+          content = content ? `${content}\n${note}` : note;
+        }
+
+        // Replay what each [[ref:id]] in a past reply pointed at.
+        //
+        // Without this the markers come back as opaque text: the model can see
+        // that it once wrote [[ref:10]] but not that it meant the Threads
+        // channel, so on a follow-up it names the entity in prose and the user
+        // loses the link. Restating the mapping lets it keep citing entities it
+        // has already mentioned, without calling the tool again.
+        const refs = (
+          m.metadata as { maestroRefs?: EntityReference[] } | null
+        )?.maestroRefs;
+        if (m.role === 'assistant' && Array.isArray(refs) && refs.length > 0) {
+          const known = refs
+            .map(
+              (r) =>
+                `${referenceMarker(r.id)} = ${r.label}` +
+                (r.platform ? ` (${r.platform})` : '') +
+                (r.status ? `, ${r.status}` : ''),
+            )
+            .join('; ');
+          const note = `[Entities cited above — when you mention any of these again, cite it by its marker rather than writing the name as plain text: ${known}]`;
           content = content ? `${content}\n${note}` : note;
         }
         return { role: m.role as 'user' | 'assistant', content };

--- a/src/maestro/services/maestro.service.ts
+++ b/src/maestro/services/maestro.service.ts
@@ -81,8 +81,8 @@ const EMPTY_USAGE = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 function isFailedToolResult(result: unknown): boolean {
   return Boolean(
     result &&
-      typeof result === 'object' &&
-      (result as { ok?: unknown }).ok === false,
+    typeof result === 'object' &&
+    (result as { ok?: unknown }).ok === false,
   );
 }
 
@@ -287,7 +287,11 @@ export class MaestroService {
     };
   }
 
-  async createConversation(userId: string, workspaceId: string, title?: string) {
+  async createConversation(
+    userId: string,
+    workspaceId: string,
+    title?: string,
+  ) {
     return this.conversations.create(userId, workspaceId, title);
   }
 
@@ -504,10 +508,7 @@ export class MaestroService {
       return null;
     }
 
-    const result = await tool.handler(
-      parsed.data as Record<string, unknown>,
-      ctx,
-    );
+    const result = await tool.handler(parsed.data, ctx);
     await this.conversations.setMessageMetadata(approval.messageId, {
       ...(meta ?? {}),
       maestroResolved: { approved: true, at: new Date().toISOString() },
@@ -549,7 +550,13 @@ export class MaestroService {
         event: 'message_complete',
         data: { content: text, messageId: saved.id },
       };
-      yield { event: 'done', data: { usage: EMPTY_USAGE, budget: await this.getUsage(ctx.workspaceId) } };
+      yield {
+        event: 'done',
+        data: {
+          usage: EMPTY_USAGE,
+          budget: await this.getUsage(ctx.workspaceId),
+        },
+      };
       return;
     }
 
@@ -595,7 +602,10 @@ export class MaestroService {
 
     yield {
       event: 'done',
-      data: { usage: EMPTY_USAGE, budget: await this.getUsage(ctx.workspaceId) },
+      data: {
+        usage: EMPTY_USAGE,
+        budget: await this.getUsage(ctx.workspaceId),
+      },
     };
   }
 
@@ -739,9 +749,8 @@ export class MaestroService {
         if (m.content) return true;
         // Keep an image/file-only user turn (empty text) so its attachment URLs
         // still reach later turns.
-        const atts = (
-          m.metadata as { maestroAttachments?: unknown[] } | null
-        )?.maestroAttachments;
+        const atts = (m.metadata as { maestroAttachments?: unknown[] } | null)
+          ?.maestroAttachments;
         return m.role === 'user' && Array.isArray(atts) && atts.length > 0;
       })
       .slice(0, -1)
@@ -770,9 +779,8 @@ export class MaestroService {
         // channel, so on a follow-up it names the entity in prose and the user
         // loses the link. Restating the mapping lets it keep citing entities it
         // has already mentioned, without calling the tool again.
-        const refs = (
-          m.metadata as { maestroRefs?: EntityReference[] } | null
-        )?.maestroRefs;
+        const refs = (m.metadata as { maestroRefs?: EntityReference[] } | null)
+          ?.maestroRefs;
         if (m.role === 'assistant' && Array.isArray(refs) && refs.length > 0) {
           const known = refs
             .map(
@@ -848,9 +856,8 @@ export class MaestroService {
       /** Present only on confirm-gate cards — what the card is waiting to do. */
       pendingAction?: PendingAction;
     } | null = null;
-    let maestroWeb:
-      | { title: string; url: string; content: string }[]
-      | null = null;
+    let maestroWeb: { title: string; url: string; content: string }[] | null =
+      null;
     // References accumulate across tool calls (unlike media/questions, where a
     // later result replaces an earlier one): asking about two things in one
     // turn must leave every named entity clickable.
@@ -964,7 +971,10 @@ export class MaestroService {
 
       // Flush any held-back display text when no marker was ever seen.
       if (markerIdx === -1 && raw.length > emittedLen) {
-        yield { event: 'message_stream', data: { token: raw.slice(emittedLen) } };
+        yield {
+          event: 'message_stream',
+          data: { token: raw.slice(emittedLen) },
+        };
       }
 
       const displayText = (
@@ -976,7 +986,12 @@ export class MaestroService {
           : raw
               .slice(markerIdx + FOLLOWUPS_MARKER.length)
               .split('|')
-              .map((s) => s.trim().replace(/^[-•\d.)\s]+/, '').trim())
+              .map((s) =>
+                s
+                  .trim()
+                  .replace(/^[-•\d.)\s]+/, '')
+                  .trim(),
+              )
               .filter(Boolean)
               .slice(0, 4);
 

--- a/src/maestro/tools/campaign.tools.spec.ts
+++ b/src/maestro/tools/campaign.tools.spec.ts
@@ -1,0 +1,336 @@
+import type {
+  CampaignsService,
+  CampaignDto,
+} from '../../campaigns/campaigns.service';
+import type { AgentToolDefinition, ToolContext } from '../maestro.types';
+import { createCampaignTools } from './campaign.tools';
+import { isReferencePayload, type ReferencePayload } from './references';
+
+const CTX: ToolContext = { userId: 'u1', workspaceId: 'ws-1' };
+
+/** A campaign as `list`/`getOne` return it — only the fields the tools read. */
+function campaignRow(over: Partial<CampaignDto> = {}): CampaignDto {
+  return {
+    id: 'c-1',
+    workspaceId: 'ws-1',
+    name: 'Launch week',
+    description: null,
+    type: 'bulk',
+    status: 'active',
+    channelIds: ['1', '2'],
+    platforms: ['instagram', 'facebook'],
+    schedule: {
+      type: 'bulk',
+      startDate: '2026-09-01',
+      endDate: '2026-09-07',
+      defaultTime: '09:00',
+      timezone: 'UTC',
+      blackoutDates: [],
+      skipWeekends: false,
+    },
+    contentSource: 'manual',
+    aiConfig: null,
+    libraryTemplateIds: [],
+    slotContent: {},
+    metrics: {
+      postsPlanned: 10,
+      postsPublished: 4,
+      postsFailed: 1,
+      postsSkipped: 0,
+    },
+    createdAt: '2026-08-20T00:00:00.000Z',
+    updatedAt: '2026-08-20T00:00:00.000Z',
+    launchedAt: '2026-09-01T00:00:00.000Z',
+    nextRunAt: '2026-09-03T09:00:00.000Z',
+    ...over,
+  };
+}
+
+interface Recorded {
+  workspaceId: string;
+  filters?: unknown;
+  id?: string;
+}
+
+function fakeService(rows: CampaignDto[], calls: Recorded[] = []) {
+  return {
+    list: (workspaceId: string, filters?: Record<string, string>) => {
+      calls.push({ workspaceId, filters });
+      let out = rows.filter((r) => r.workspaceId === workspaceId);
+      if (filters?.status) out = out.filter((r) => r.status === filters.status);
+      if (filters?.search) {
+        const q = filters.search.toLowerCase();
+        out = out.filter((r) => r.name.toLowerCase().includes(q));
+      }
+      return Promise.resolve(out);
+    },
+    getOne: (workspaceId: string, id: string) => {
+      calls.push({ workspaceId, id });
+      const found = rows.find(
+        (r) => r.id === id && r.workspaceId === workspaceId,
+      );
+      if (!found) return Promise.reject(new Error('Campaign not found'));
+      return Promise.resolve(found);
+    },
+  } as unknown as CampaignsService;
+}
+
+function tool(tools: AgentToolDefinition[], name: string): AgentToolDefinition {
+  const found = tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not registered`);
+  return found;
+}
+
+describe('campaign tools', () => {
+  describe('list_campaigns', () => {
+    it('returns each campaign with a reference so its name can be linked', async () => {
+      const tools = createCampaignTools(fakeService([campaignRow()]));
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs).toEqual([
+        { kind: 'campaign', id: 'c-1', label: 'Launch week', status: 'active' },
+      ]);
+    });
+
+    it("gives the reference the campaign's real status, so the chip is the right colour", async () => {
+      const tools = createCampaignTools(
+        fakeService([campaignRow({ status: 'paused' })]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs[0].status).toBe('paused');
+    });
+
+    it("reads only the caller's workspace, never one passed as an argument", async () => {
+      const calls: Recorded[] = [];
+      const tools = createCampaignTools(
+        fakeService(
+          [
+            campaignRow({ id: 'mine', workspaceId: 'ws-1' }),
+            campaignRow({ id: 'theirs', workspaceId: 'ws-2', name: 'Theirs' }),
+          ],
+          calls,
+        ),
+      );
+
+      const result = (await tool(tools, 'list_campaigns').handler(
+        { workspaceId: 'ws-2' },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(calls[0].workspaceId).toBe('ws-1');
+      expect(result.refs.map((r) => r.id)).toEqual(['mine']);
+    });
+
+    it('reports the true total even when the page is trimmed', async () => {
+      const rows = Array.from({ length: 12 }, (_, i) =>
+        campaignRow({ id: `c-${i}`, name: `Campaign ${i}` }),
+      );
+      const tools = createCampaignTools(fakeService(rows));
+
+      const result = (await tool(tools, 'list_campaigns').handler(
+        { limit: 3 },
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as { total: number; showing: number };
+
+      // Saying "you have 3 campaigns" when there are 12 would be wrong.
+      expect(data.total).toBe(12);
+      expect(data.showing).toBe(3);
+      expect(result.refs).toHaveLength(3);
+    });
+
+    it('passes a status filter through to the service', async () => {
+      const calls: Recorded[] = [];
+      const tools = createCampaignTools(
+        fakeService(
+          [
+            campaignRow({ id: 'a', status: 'active' }),
+            campaignRow({ id: 'p', status: 'paused' }),
+          ],
+          calls,
+        ),
+      );
+
+      const result = (await tool(tools, 'list_campaigns').handler(
+        { status: 'paused' },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(calls[0].filters).toEqual({ status: 'paused' });
+      expect(result.refs.map((r) => r.id)).toEqual(['p']);
+    });
+
+    it('returns an empty reference list rather than nothing when there are no campaigns', async () => {
+      const tools = createCampaignTools(fakeService([]));
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs).toEqual([]);
+      expect((result.data as { total: number }).total).toBe(0);
+    });
+
+    it('describes an evergreen campaign as ongoing, never with an end date', async () => {
+      const tools = createCampaignTools(
+        fakeService([
+          campaignRow({
+            type: 'evergreen',
+            schedule: {
+              type: 'evergreen',
+              startDate: '2026-09-01',
+              weekdays: [1, 3, 5],
+              times: ['09:00'],
+              timezone: 'UTC',
+              blackoutDates: [],
+              loop: true,
+            },
+          }),
+        ]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { campaigns } = result.data as {
+        campaigns: { schedule: string | null }[];
+      };
+
+      expect(campaigns[0].schedule).toBe('from 2026-09-01, ongoing');
+    });
+
+    it('does not invent an end date for a drip campaign that has none', async () => {
+      const tools = createCampaignTools(
+        fakeService([
+          campaignRow({
+            type: 'drip',
+            schedule: {
+              type: 'drip',
+              startDate: '2026-09-01',
+              endDate: null,
+              weekdays: [1, 3],
+              times: ['09:00', '17:00'],
+              timezone: 'UTC',
+              blackoutDates: [],
+            },
+          }),
+        ]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { campaigns } = result.data as {
+        campaigns: { schedule: string | null }[];
+      };
+
+      expect(campaigns[0].schedule).toBe('from 2026-09-01, no end date');
+    });
+
+    it('carries the progress counts the user asks about', async () => {
+      const tools = createCampaignTools(fakeService([campaignRow()]));
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { campaigns } = result.data as {
+        campaigns: { progress: Record<string, number> }[];
+      };
+
+      expect(campaigns[0].progress).toEqual({
+        planned: 10,
+        published: 4,
+        failed: 1,
+        skipped: 0,
+      });
+    });
+  });
+
+  describe('get_campaign', () => {
+    it('returns the campaign with a reference so it can be linked', async () => {
+      const tools = createCampaignTools(fakeService([campaignRow()]));
+      const result = (await tool(tools, 'get_campaign').handler(
+        { campaignId: 'c-1' },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs[0].id).toBe('c-1');
+      expect(result.refs[0].label).toBe('Launch week');
+    });
+
+    it('cannot read a campaign belonging to another workspace', async () => {
+      const tools = createCampaignTools(
+        fakeService([campaignRow({ id: 'theirs', workspaceId: 'ws-2' })]),
+      );
+
+      const result = (await tool(tools, 'get_campaign').handler(
+        { campaignId: 'theirs' },
+        CTX,
+      )) as { error?: string };
+
+      // Indistinguishable from a campaign that never existed — deliberately,
+      // so the answer cannot confirm another tenant's ids.
+      expect(result.error).toBe('No campaign with that id in this workspace.');
+    });
+
+    it('ignores a workspace id the model supplies as an argument', async () => {
+      // The tenant boundary has to hold even when the model invents an
+      // argument for it. Without this the previous test passes against a
+      // handler that reads `args.workspaceId` — verified by injecting exactly
+      // that defect, which this test catches and that one does not.
+      const calls: Recorded[] = [];
+      const tools = createCampaignTools(
+        fakeService(
+          [campaignRow({ id: 'theirs', workspaceId: 'ws-2' })],
+          calls,
+        ),
+      );
+
+      const result = (await tool(tools, 'get_campaign').handler(
+        { campaignId: 'theirs', workspaceId: 'ws-2' },
+        CTX,
+      )) as { error?: string };
+
+      expect(calls[0].workspaceId).toBe('ws-1');
+      expect(result.error).toBe('No campaign with that id in this workspace.');
+    });
+
+    it('reports a missing campaign instead of throwing', async () => {
+      const tools = createCampaignTools(fakeService([]));
+      const result = (await tool(tools, 'get_campaign').handler(
+        { campaignId: 'nope' },
+        CTX,
+      )) as { error?: string };
+
+      expect(result.error).toBeTruthy();
+    });
+
+    it('rejects an empty id without calling the service', async () => {
+      const calls: Recorded[] = [];
+      const tools = createCampaignTools(fakeService([campaignRow()], calls));
+
+      const result = (await tool(tools, 'get_campaign').handler(
+        { campaignId: '  ' },
+        CTX,
+      )) as { error?: string };
+
+      expect(result.error).toBe('A campaign id is required.');
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  it('registers exactly the two read tools', () => {
+    const names = createCampaignTools(fakeService([])).map((t) => t.name);
+    expect(names).toEqual(['list_campaigns', 'get_campaign']);
+  });
+});

--- a/src/maestro/tools/campaign.tools.spec.ts
+++ b/src/maestro/tools/campaign.tools.spec.ts
@@ -92,7 +92,13 @@ describe('campaign tools', () => {
 
       expect(isReferencePayload(result)).toBe(true);
       expect(result.refs).toEqual([
-        { kind: 'campaign', id: 'c-1', label: 'Launch week', status: 'active' },
+        {
+          kind: 'campaign',
+          id: 'c-1',
+          label: 'Launch week',
+          status: 'active',
+          variant: 'bulk',
+        },
       ]);
     });
 
@@ -201,11 +207,11 @@ describe('campaign tools', () => {
         {},
         CTX,
       )) as ReferencePayload;
-      const { campaigns } = result.data as {
-        campaigns: { schedule: string | null }[];
+      const { onTrack } = result.data as {
+        onTrack: { schedule: string | null }[];
       };
 
-      expect(campaigns[0].schedule).toBe('from 2026-09-01, ongoing');
+      expect(onTrack[0].schedule).toBe('from 2026-09-01, ongoing');
     });
 
     it('does not invent an end date for a drip campaign that has none', async () => {
@@ -229,11 +235,131 @@ describe('campaign tools', () => {
         {},
         CTX,
       )) as ReferencePayload;
-      const { campaigns } = result.data as {
-        campaigns: { schedule: string | null }[];
+      const { onTrack } = result.data as {
+        onTrack: { schedule: string | null }[];
       };
 
-      expect(campaigns[0].schedule).toBe('from 2026-09-01, no end date');
+      expect(onTrack[0].schedule).toBe('from 2026-09-01, no end date');
+    });
+
+    it('calls a bulk campaign "Simple", the name the product uses', async () => {
+      // The UI has never shown the word "bulk" — that is the database's word.
+      // An agent that says it is naming a thing the user cannot find.
+      const tools = createCampaignTools(fakeService([campaignRow()]));
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { onTrack } = result.data as { onTrack: { type: string }[] };
+
+      expect(onTrack[0].type).toBe('Simple');
+    });
+
+    it('passes an unknown type through rather than dropping it', async () => {
+      const tools = createCampaignTools(
+        fakeService([campaignRow({ type: 'experimental' })]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { onTrack } = result.data as { onTrack: { type: string }[] };
+
+      expect(onTrack[0].type).toBe('experimental');
+    });
+
+    it('splits campaigns into the ones waiting on the user and the rest', async () => {
+      const tools = createCampaignTools(
+        fakeService([
+          campaignRow({ id: 'a', status: 'active' }),
+          campaignRow({ id: 'd', status: 'draft' }),
+          campaignRow({ id: 'p', status: 'paused' }),
+          campaignRow({ id: 'f', status: 'failed' }),
+          campaignRow({ id: 'c', status: 'completed' }),
+        ]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as {
+        needsAttentionCount: number;
+        onTrackCount: number;
+        needsAttention: { id: string }[];
+        onTrack: { id: string }[];
+      };
+
+      expect(data.needsAttention.map((c) => c.id)).toEqual(['d', 'p', 'f']);
+      expect(data.onTrack.map((c) => c.id)).toEqual(['a', 'c']);
+      expect(data.needsAttentionCount).toBe(3);
+      expect(data.onTrackCount).toBe(2);
+    });
+
+    it('still references every campaign, whichever group it landed in', async () => {
+      const tools = createCampaignTools(
+        fakeService([
+          campaignRow({ id: 'a', status: 'active' }),
+          campaignRow({ id: 'd', status: 'draft' }),
+        ]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs.map((r) => r.id).sort()).toEqual(['a', 'd']);
+    });
+
+    it('gives each campaign the next step to take, so the prose is not left to invent one', async () => {
+      const tools = createCampaignTools(
+        fakeService([
+          campaignRow({ id: 'd', status: 'draft' }),
+          campaignRow({ id: 'p', status: 'paused' }),
+        ]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { needsAttention } = result.data as {
+        needsAttention: { id: string; suggestedAction?: string }[];
+      };
+
+      expect(needsAttention[0].suggestedAction).toBe(
+        'finish setup and launch it',
+      );
+      expect(needsAttention[1].suggestedAction).toBe(
+        'resume it to start posting again',
+      );
+    });
+
+    it('offers no action for a campaign that needs none', async () => {
+      const tools = createCampaignTools(
+        fakeService([campaignRow({ status: 'active' })]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const { onTrack } = result.data as {
+        onTrack: { suggestedAction?: string }[];
+      };
+
+      expect(onTrack[0].suggestedAction).toBeUndefined();
+    });
+
+    it('tells the chip which campaign type it is, so it wears the right icon', async () => {
+      const tools = createCampaignTools(
+        fakeService([campaignRow({ type: 'evergreen' })]),
+      );
+      const result = (await tool(tools, 'list_campaigns').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      // The raw id, not the label — the frontend maps it to the Campaigns
+      // page's own icon.
+      expect(result.refs[0].variant).toBe('evergreen');
     });
 
     it('carries the progress counts the user asks about', async () => {
@@ -242,11 +368,11 @@ describe('campaign tools', () => {
         {},
         CTX,
       )) as ReferencePayload;
-      const { campaigns } = result.data as {
-        campaigns: { progress: Record<string, number> }[];
+      const { onTrack } = result.data as {
+        onTrack: { progress: Record<string, number> }[];
       };
 
-      expect(campaigns[0].progress).toEqual({
+      expect(onTrack[0].progress).toEqual({
         planned: 10,
         published: 4,
         failed: 1,

--- a/src/maestro/tools/campaign.tools.ts
+++ b/src/maestro/tools/campaign.tools.ts
@@ -1,0 +1,214 @@
+import { z } from 'zod';
+import type {
+  CampaignsService,
+  CampaignDto,
+} from '../../campaigns/campaigns.service';
+import type { AgentToolDefinition } from '../maestro.types';
+import {
+  REFERENCE_USAGE_HINT,
+  withReferences,
+  type EntityReference,
+} from './references';
+
+/**
+ * Campaign statuses the UI knows how to colour. Kept in step with the
+ * frontend's CAMPAIGN_STATUS_CONFIG: a status outside this set still renders,
+ * but as a neutral pill rather than its own colour.
+ */
+const CAMPAIGN_STATUSES = [
+  'draft',
+  'scheduled',
+  'active',
+  'paused',
+  'completed',
+  'failed',
+] as const;
+
+/** How many campaigns one answer can name before the reply stops being useful. */
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 25;
+
+/**
+ * A campaign's schedule window as a short phrase.
+ *
+ * Switched on the SCHEDULE's own discriminant rather than the campaign's `type`
+ * column, because the union is what actually carries `endDate` — so the
+ * compiler checks this rather than a cast hiding it. Evergreen has no end (it
+ * rotates a pool forever) and a drip schedule may have none either, so neither
+ * gets an end date invented for it.
+ */
+function scheduleSummary(c: CampaignDto): string | null {
+  const schedule = c.schedule;
+  if (!schedule) return null;
+
+  if (schedule.type === 'evergreen') {
+    return schedule.startDate
+      ? `from ${schedule.startDate}, ongoing`
+      : 'ongoing';
+  }
+
+  const { startDate, endDate } = schedule;
+  if (startDate && endDate) return `${startDate} → ${endDate}`;
+  if (startDate) return `from ${startDate}, no end date`;
+  return null;
+}
+
+/**
+ * The campaign's progress in the terms the user thinks in.
+ *
+ * `metrics` counts slots, which is what the campaign detail page shows. We pass
+ * the raw counts through rather than pre-computing a percentage: a model given
+ * "12 of 30" writes a better sentence than one given "40%".
+ */
+function progressOf(c: CampaignDto) {
+  const m = c.metrics;
+  return {
+    planned: m.postsPlanned,
+    published: m.postsPublished,
+    failed: m.postsFailed,
+    skipped: m.postsSkipped,
+  };
+}
+
+/** One campaign, flattened to what an answer actually needs. */
+function summarize(c: CampaignDto) {
+  return {
+    id: c.id,
+    name: c.name,
+    status: c.status,
+    type: c.type,
+    platforms: c.platforms,
+    channelCount: c.channelIds.length,
+    schedule: scheduleSummary(c),
+    progress: progressOf(c),
+    nextRunAt: c.nextRunAt,
+    launchedAt: c.launchedAt,
+  };
+}
+
+function referenceFor(c: CampaignDto): EntityReference {
+  return {
+    kind: 'campaign',
+    id: c.id,
+    label: c.name,
+    status: c.status,
+  };
+}
+
+/**
+ * Read-only tools over the workspace's campaigns.
+ *
+ * Two tools, not five: a list with filters answers "what campaigns do I have",
+ * "which are running", and "anything failing"; a detail tool answers everything
+ * about one. Splitting those into a tool per question would multiply the
+ * model's choices without adding an answer it could not already give.
+ *
+ * Every read derives its workspace from `ctx` — never from tool arguments, so
+ * the tenant boundary is enforced by shape rather than by instruction.
+ */
+export function createCampaignTools(
+  campaigns: CampaignsService,
+): AgentToolDefinition[] {
+  return [
+    {
+      name: 'list_campaigns',
+      description:
+        'List this workspace\'s campaigns, optionally filtered by status or searched by name. Use this for "what campaigns do I have", "what\'s running right now", "any campaigns paused", or before suggesting the user schedule something. Covers all three types: bulk, drip, and evergreen.' +
+        REFERENCE_USAGE_HINT,
+      inputSchema: {
+        status: z
+          .enum(CAMPAIGN_STATUSES)
+          .optional()
+          .describe(
+            'Optional status filter. Omit to list campaigns in every state.',
+          ),
+        search: z
+          .string()
+          .optional()
+          .describe(
+            'Optional text to match against campaign name or description.',
+          ),
+        limit: z
+          .number()
+          .optional()
+          .describe(
+            `Max campaigns to return (1-${MAX_LIMIT}, default ${DEFAULT_LIMIT}).`,
+          ),
+      },
+      handler: async (args, ctx) => {
+        const status =
+          typeof args.status === 'string' &&
+          (CAMPAIGN_STATUSES as readonly string[]).includes(args.status)
+            ? args.status
+            : undefined;
+        const search =
+          typeof args.search === 'string' && args.search.trim()
+            ? args.search.trim()
+            : undefined;
+        const limit = Math.min(
+          Math.max(Number(args.limit) || DEFAULT_LIMIT, 1),
+          MAX_LIMIT,
+        );
+
+        const all = await campaigns.list(ctx.workspaceId, {
+          ...(status ? { status } : {}),
+          ...(search ? { search } : {}),
+        });
+
+        // The service returns every match, newest first. Trim here rather than
+        // in the query so `total` reports what actually exists — an answer that
+        // says "you have 10 campaigns" when there are 40 is wrong.
+        const page = all.slice(0, limit);
+
+        return withReferences(
+          {
+            total: all.length,
+            showing: page.length,
+            ...(status ? { filteredByStatus: status } : {}),
+            campaigns: page.map(summarize),
+          },
+          page.map(referenceFor),
+        );
+      },
+    },
+
+    {
+      name: 'get_campaign',
+      description:
+        'Get one campaign in full: its status, type, schedule, the channels it posts to, and how many of its posts have gone out, failed, or been skipped. Use this when the user asks about a specific campaign by name or after list_campaigns narrowed it down.' +
+        REFERENCE_USAGE_HINT,
+      inputSchema: {
+        campaignId: z.string().describe('The id of the campaign to fetch.'),
+      },
+      handler: async (args, ctx) => {
+        const id =
+          typeof args.campaignId === 'string' ? args.campaignId.trim() : '';
+        if (!id) {
+          return { error: 'A campaign id is required.' };
+        }
+
+        let campaign: CampaignDto;
+        try {
+          // getOne is workspace-scoped and throws NotFound for a campaign in
+          // another tenant — which is the same answer as one that never
+          // existed, and deliberately indistinguishable to the model.
+          campaign = await campaigns.getOne(ctx.workspaceId, id);
+        } catch {
+          return { error: 'No campaign with that id in this workspace.' };
+        }
+
+        return withReferences(
+          {
+            campaign: {
+              ...summarize(campaign),
+              description: campaign.description,
+              contentSource: campaign.contentSource,
+              createdAt: campaign.createdAt,
+            },
+          },
+          [referenceFor(campaign)],
+        );
+      },
+    },
+  ];
+}

--- a/src/maestro/tools/campaign.tools.ts
+++ b/src/maestro/tools/campaign.tools.ts
@@ -24,6 +24,27 @@ const CAMPAIGN_STATUSES = [
   'failed',
 ] as const;
 
+/**
+ * What each campaign type is CALLED in the product.
+ *
+ * `bulk` is the database's word; the user has never seen it — every screen
+ * calls that type "Simple" (see the frontend's CAMPAIGN_TYPES). An agent that
+ * says "bulk" is naming a thing that does not exist in the interface, which
+ * reads as a fabricated attribute rather than a synonym.
+ *
+ * A type absent from this map passes through unchanged: a new type is better
+ * named by its raw id than dropped from the answer.
+ */
+const CAMPAIGN_TYPE_LABEL: Record<string, string> = {
+  bulk: 'Simple',
+  drip: 'Drip',
+  evergreen: 'Evergreen',
+};
+
+function typeLabel(type: string): string {
+  return CAMPAIGN_TYPE_LABEL[type] ?? type;
+}
+
 /** How many campaigns one answer can name before the reply stops being useful. */
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 25;
@@ -70,19 +91,57 @@ function progressOf(c: CampaignDto) {
   };
 }
 
+/**
+ * Whether this campaign is waiting on the user.
+ *
+ * A draft was never launched and a paused campaign was stopped by hand — both
+ * sit still until someone acts. `failed` needs looking at for the opposite
+ * reason. Everything else is either running or finished, so it needs nothing.
+ *
+ * Computed here rather than left to the model: "which ones need attention" is
+ * the question users actually ask, and an answer that re-derives it from six
+ * status strings gets it wrong eventually.
+ */
+function needsAttention(c: CampaignDto): boolean {
+  return c.status === 'draft' || c.status === 'paused' || c.status === 'failed';
+}
+
+/**
+ * The one thing the user would do about this campaign next.
+ *
+ * The status pill already shows the state, so the answer's prose has to earn
+ * its place by saying what the state MEANS. Supplying the verb here keeps that
+ * consistent instead of leaving the model to invent a phrasing per campaign.
+ */
+function suggestedAction(c: CampaignDto): string | null {
+  switch (c.status) {
+    case 'draft':
+      return 'finish setup and launch it';
+    case 'paused':
+      return 'resume it to start posting again';
+    case 'failed':
+      return 'check what went wrong';
+    default:
+      return null;
+  }
+}
+
 /** One campaign, flattened to what an answer actually needs. */
 function summarize(c: CampaignDto) {
   return {
     id: c.id,
     name: c.name,
     status: c.status,
-    type: c.type,
+    // The product's word, not the database's — see CAMPAIGN_TYPE_LABEL.
+    type: typeLabel(c.type),
     platforms: c.platforms,
     channelCount: c.channelIds.length,
     schedule: scheduleSummary(c),
     progress: progressOf(c),
     nextRunAt: c.nextRunAt,
     launchedAt: c.launchedAt,
+    needsAttention: needsAttention(c),
+    ...(suggestedAction(c) ? { suggestedAction: suggestedAction(c) } : {}),
   };
 }
 
@@ -92,6 +151,9 @@ function referenceFor(c: CampaignDto): EntityReference {
     id: c.id,
     label: c.name,
     status: c.status,
+    // The raw type, not its label — the frontend maps this to the same icon the
+    // Campaigns page draws on the card, so a chip looks like what it links to.
+    variant: c.type,
   };
 }
 
@@ -113,7 +175,10 @@ export function createCampaignTools(
     {
       name: 'list_campaigns',
       description:
-        'List this workspace\'s campaigns, optionally filtered by status or searched by name. Use this for "what campaigns do I have", "what\'s running right now", "any campaigns paused", or before suggesting the user schedule something. Covers all three types: bulk, drip, and evergreen.' +
+        'List this workspace\'s campaigns, optionally filtered by status or searched by name. Use this for "what campaigns do I have", "what\'s running right now", "any campaigns paused", or before suggesting the user schedule something. Covers all three types: Simple, Drip, and Evergreen.\n\n' +
+        'The result arrives already split into `needsAttention` (drafts, paused, and failed — the ones waiting on the user) and `onTrack`. Lead your answer with that split: say how many need attention, name those first, and only then mention the ones running fine. Do not walk through every campaign in list order before reaching the point.\n\n' +
+        'Each campaign carries a `suggestedAction` — the next thing the user would do. Use it instead of writing your own, and never explain what the status means ("it\'s in draft, so it hasn\'t started"): the chip shows the state, so your words are for what to do about it.\n\n' +
+        "Do NOT write the campaign's type in your sentence — the chip already carries its type icon. `type` is there so you can filter or answer a direct question about it, not to be repeated beside every name." +
         REFERENCE_USAGE_HINT,
       inputSchema: {
         status: z
@@ -160,12 +225,22 @@ export function createCampaignTools(
         // says "you have 10 campaigns" when there are 40 is wrong.
         const page = all.slice(0, limit);
 
+        // Split rather than hand back one flat list. "Which need attention" is
+        // the question behind most campaign questions, and a result already
+        // sorted into the two groups leads the model to answer with the
+        // conclusion first instead of narrating every campaign in turn.
+        const waiting = page.filter(needsAttention);
+        const running = page.filter((c) => !needsAttention(c));
+
         return withReferences(
           {
             total: all.length,
             showing: page.length,
             ...(status ? { filteredByStatus: status } : {}),
-            campaigns: page.map(summarize),
+            needsAttentionCount: waiting.length,
+            onTrackCount: running.length,
+            needsAttention: waiting.map(summarize),
+            onTrack: running.map(summarize),
           },
           page.map(referenceFor),
         );

--- a/src/maestro/tools/channel.tools.spec.ts
+++ b/src/maestro/tools/channel.tools.spec.ts
@@ -64,8 +64,16 @@ describe('channel tools', () => {
       )) as ReferencePayload;
 
       expect(isReferencePayload(result)).toBe(true);
+      // `platform` rides along so the chip can show the brand logo without the
+      // frontend digging it out of each tool's differently-shaped data.
       expect(result.refs).toEqual([
-        { kind: 'channel', id: '1', label: 'Schedura', status: 'connected' },
+        {
+          kind: 'channel',
+          id: '1',
+          label: 'Schedura',
+          status: 'connected',
+          platform: 'instagram',
+        },
       ]);
     });
 

--- a/src/maestro/tools/channel.tools.spec.ts
+++ b/src/maestro/tools/channel.tools.spec.ts
@@ -1,0 +1,290 @@
+import type { ChannelService } from '../../channels/services/channel.service';
+import type { AgentToolDefinition, ToolContext } from '../maestro.types';
+import { createChannelTools } from './channel.tools';
+import { isReferencePayload, type ReferencePayload } from './references';
+
+const CTX: ToolContext = { userId: 'u1', workspaceId: 'ws-1' };
+
+/** A channel as `getWorkspaceChannels` returns it — only the fields we read. */
+function channelRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    platform: 'instagram',
+    accountName: 'Schedura',
+    username: 'schedura',
+    isActive: true,
+    connectionStatus: 'connected',
+    isTokenExpired: false,
+    refreshTokenExpiresInDays: null,
+    lastPostedAt: null,
+    ...over,
+  };
+}
+
+interface Recorded {
+  workspaceId: string;
+  query: unknown;
+}
+
+function fakeService(rows: unknown[], calls: Recorded[] = []) {
+  return {
+    getWorkspaceChannels: (workspaceId: string, query?: unknown) => {
+      calls.push({ workspaceId, query });
+      const platform = (query as { platform?: string } | undefined)?.platform;
+      const filtered = platform
+        ? rows.filter((r) => (r as { platform: string }).platform === platform)
+        : rows;
+      return Promise.resolve(filtered);
+    },
+    getChannelStats: () =>
+      Promise.resolve({
+        totalChannels: 4,
+        activeChannels: 3,
+        expiredChannels: 1,
+        errorChannels: 0,
+        byPlatform: { instagram: 2, facebook: 2 },
+      }),
+  } as unknown as ChannelService;
+}
+
+function tool(tools: AgentToolDefinition[], name: string): AgentToolDefinition {
+  const found = tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not registered`);
+  return found;
+}
+
+describe('channel tools', () => {
+  describe('list_channels', () => {
+    it('returns each channel with a reference so the name can be linked', async () => {
+      const tools = createChannelTools(fakeService([channelRow()]));
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs).toEqual([
+        { kind: 'channel', id: '1', label: 'Schedura', status: 'connected' },
+      ]);
+    });
+
+    // A reference whose id does not match the entity produces a link to the
+    // wrong place — worse than no link. Pin the correspondence explicitly.
+    it('gives every listed channel a reference with its own id', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 7, accountName: 'A' }),
+          channelRow({ id: 9, accountName: 'B' }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as { channels: { id: string; name: string }[] };
+
+      expect(result.refs.map((r) => [r.id, r.label])).toEqual([
+        ['7', 'A'],
+        ['9', 'B'],
+      ]);
+      expect(data.channels.map((c) => c.id)).toEqual(['7', '9']);
+    });
+
+    // The workspace is a tenant boundary: it must come from the request
+    // context, never from something the model can put in an argument.
+    it('scopes the read to the caller workspace, ignoring any argument', async () => {
+      const calls: Recorded[] = [];
+      const tools = createChannelTools(fakeService([channelRow()], calls));
+
+      await tool(tools, 'list_channels').handler(
+        { workspaceId: 'ws-someone-else' },
+        CTX,
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].workspaceId).toBe('ws-1');
+    });
+
+    it('passes a platform filter through when asked for one', async () => {
+      const calls: Recorded[] = [];
+      const tools = createChannelTools(
+        fakeService(
+          [channelRow(), channelRow({ id: 2, platform: 'facebook' })],
+          calls,
+        ),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        { platform: 'Facebook' },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(calls[0].query).toEqual({ platform: 'facebook' });
+      expect(result.refs).toHaveLength(1);
+    });
+
+    it('reports an empty workspace as empty, not as an error', async () => {
+      const tools = createChannelTools(fakeService([]));
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as { total: number };
+
+      expect(data.total).toBe(0);
+      expect(result.refs).toEqual([]);
+    });
+
+    it.each([
+      [
+        'an expired connection',
+        { connectionStatus: 'expired' },
+        'needs reconnect',
+      ],
+      ['an expired token', { isTokenExpired: true }, 'needs reconnect'],
+      ['a revoked channel', { connectionStatus: 'revoked' }, 'access revoked'],
+      ['an erroring channel', { connectionStatus: 'error' }, 'error'],
+      ['a deactivated channel', { isActive: false }, 'inactive'],
+      [
+        'a token expiring soon',
+        { refreshTokenExpiresInDays: 3 },
+        'expires in 3d',
+      ],
+      ['a healthy channel', {}, 'connected'],
+    ])('describes %s as "%s"', async (_name, over, expected) => {
+      const tools = createChannelTools(fakeService([channelRow(over)]));
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs[0].status).toBe(expected);
+    });
+
+    it('surfaces the channels needing attention so the agent can lead with them', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1, accountName: 'Healthy' }),
+          channelRow({
+            id: 2,
+            accountName: 'Broken',
+            connectionStatus: 'expired',
+          }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as { needsAttention: string[] };
+
+      expect(data.needsAttention).toEqual(['Broken']);
+    });
+
+    it('falls back to the username, then the platform, for an unnamed channel', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1, accountName: null }),
+          channelRow({ id: 2, accountName: null, username: null }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs.map((r) => r.label)).toEqual([
+        'schedura',
+        'instagram',
+      ]);
+    });
+  });
+
+  describe('get_channel_stats', () => {
+    it('summarises connection health for the workspace', async () => {
+      const tools = createChannelTools(fakeService([]));
+
+      const result = (await tool(tools, 'get_channel_stats').handler(
+        {},
+        CTX,
+      )) as Record<string, unknown>;
+
+      expect(result).toEqual({
+        total: 4,
+        healthy: 3,
+        expired: 1,
+        erroring: 0,
+        byPlatform: { instagram: 2, facebook: 2 },
+      });
+    });
+  });
+
+  describe('connect_channel', () => {
+    it('offers a connect card for a platform with no channel yet', async () => {
+      const tools = createChannelTools(fakeService([]));
+
+      const result = (await tool(tools, 'connect_channel').handler(
+        { platform: 'tiktok' },
+        CTX,
+      )) as Record<string, unknown>;
+
+      expect(result).toEqual({
+        kind: 'connect',
+        platform: 'tiktok',
+        alreadyConnected: false,
+        reconnect: false,
+      });
+    });
+
+    // Offering a button for something already working sends the user through a
+    // redundant OAuth round trip and reads as if the agent cannot see state.
+    it('says it is already connected instead of offering a button', async () => {
+      const tools = createChannelTools(fakeService([channelRow()]));
+
+      const result = (await tool(tools, 'connect_channel').handler(
+        { platform: 'instagram' },
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as {
+        alreadyConnected: boolean;
+        accounts: string[];
+      };
+
+      expect(data.alreadyConnected).toBe(true);
+      expect(data.accounts).toEqual(['Schedura']);
+      expect(result.refs[0].id).toBe('1');
+    });
+
+    it('offers to reconnect when the existing channel is broken', async () => {
+      const tools = createChannelTools(
+        fakeService([channelRow({ connectionStatus: 'expired' })]),
+      );
+
+      const result = (await tool(tools, 'connect_channel').handler(
+        { platform: 'instagram' },
+        CTX,
+      )) as Record<string, unknown>;
+
+      expect(result.alreadyConnected).toBe(false);
+      expect(result.reconnect).toBe(true);
+    });
+
+    it('refuses a platform this workspace cannot connect', async () => {
+      const tools = createChannelTools(fakeService([]));
+
+      const result = (await tool(tools, 'connect_channel').handler(
+        { platform: 'myspace' },
+        CTX,
+      )) as Record<string, unknown>;
+
+      expect(result.error).toContain('myspace');
+      expect(result.kind).toBeUndefined();
+    });
+  });
+});

--- a/src/maestro/tools/channel.tools.spec.ts
+++ b/src/maestro/tools/channel.tools.spec.ts
@@ -125,6 +125,69 @@ describe('channel tools', () => {
       expect(result.refs).toHaveLength(1);
     });
 
+    // Cloud storage and calendars live in the same table but are not channels
+    // you publish to. Asking "which channels do I have" must not answer with
+    // Google Drive — caught live before this test existed.
+    it('leaves cloud storage and calendar integrations out', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1, platform: 'instagram', accountName: 'Real' }),
+          channelRow({ id: 2, platform: 'google_drive', accountName: 'Drive' }),
+          channelRow({ id: 3, platform: 'dropbox', accountName: 'Dropbox' }),
+          channelRow({
+            id: 4,
+            platform: 'google_calendar',
+            accountName: 'Cal',
+          }),
+          channelRow({ id: 5, platform: 'onedrive', accountName: 'OneDrive' }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+      const data = result.data as { total: number };
+
+      expect(data.total).toBe(1);
+      expect(result.refs.map((r) => r.label)).toEqual(['Real']);
+    });
+
+    // Messaging channels ARE publishing surfaces — the agent can post to Slack
+    // and Discord, so excluding them would hide real capability.
+    it('keeps messaging channels, which are publishing surfaces', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1, platform: 'slack', accountName: 'Slack WS' }),
+          channelRow({ id: 2, platform: 'discord', accountName: 'Server' }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs.map((r) => r.label)).toEqual(['Slack WS', 'Server']);
+    });
+
+    // Hiding a real channel is worse than showing one extra, and a new platform
+    // is far more likely to be a social network than a cloud drive.
+    it('keeps a platform it does not recognise', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1, platform: 'newnetwork', accountName: 'New' }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'list_channels').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(result.refs.map((r) => r.label)).toEqual(['New']);
+    });
+
     it('reports an empty workspace as empty, not as an error', async () => {
       const tools = createChannelTools(fakeService([]));
 
@@ -208,7 +271,14 @@ describe('channel tools', () => {
 
   describe('get_channel_stats', () => {
     it('summarises connection health for the workspace', async () => {
-      const tools = createChannelTools(fakeService([]));
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1 }),
+          channelRow({ id: 2, platform: 'facebook' }),
+          channelRow({ id: 3, connectionStatus: 'expired' }),
+          channelRow({ id: 4, platform: 'twitter', connectionStatus: 'error' }),
+        ]),
+      );
 
       const result = (await tool(tools, 'get_channel_stats').handler(
         {},
@@ -217,11 +287,31 @@ describe('channel tools', () => {
 
       expect(result).toEqual({
         total: 4,
-        healthy: 3,
-        expired: 1,
-        erroring: 0,
-        byPlatform: { instagram: 2, facebook: 2 },
+        healthy: 2,
+        needsReconnect: 1,
+        erroring: 1,
+        byPlatform: { instagram: 2, facebook: 1, twitter: 1 },
       });
+    });
+
+    // Counting cloud storage would answer "how are my channels doing" with
+    // Google Drive included in the total.
+    it('does not count integrations toward the channel totals', async () => {
+      const tools = createChannelTools(
+        fakeService([
+          channelRow({ id: 1 }),
+          channelRow({ id: 2, platform: 'google_drive' }),
+          channelRow({ id: 3, platform: 'dropbox' }),
+        ]),
+      );
+
+      const result = (await tool(tools, 'get_channel_stats').handler(
+        {},
+        CTX,
+      )) as Record<string, unknown>;
+
+      expect(result.total).toBe(1);
+      expect(result.byPlatform).toEqual({ instagram: 1 });
     });
   });
 

--- a/src/maestro/tools/channel.tools.ts
+++ b/src/maestro/tools/channel.tools.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+import type { ChannelService } from '../../channels/services/channel.service';
+import type { AgentToolDefinition } from '../maestro.types';
+import {
+  REFERENCE_USAGE_HINT,
+  withReferences,
+  type EntityReference,
+} from './references';
+
+/** Platforms a user can connect. Mirrors the OAuth initiate surface. */
+const CONNECTABLE_PLATFORMS = [
+  'facebook',
+  'instagram',
+  'twitter',
+  'linkedin',
+  'youtube',
+  'tiktok',
+  'pinterest',
+  'threads',
+  'bluesky',
+  'mastodon',
+  'reddit',
+] as const;
+
+/**
+ * What the user actually needs to know about a channel's health, derived from
+ * connection status and token expiry. The raw DTO carries a dozen token fields;
+ * an agent answer needs one short phrase.
+ */
+function channelHealth(ch: {
+  connectionStatus: string;
+  isActive: boolean;
+  isTokenExpired?: boolean;
+  refreshTokenExpiresInDays?: number | null;
+}): string {
+  if (ch.connectionStatus === 'expired' || ch.isTokenExpired) {
+    return 'needs reconnect';
+  }
+  if (ch.connectionStatus === 'revoked') return 'access revoked';
+  if (ch.connectionStatus === 'error') return 'error';
+  if (!ch.isActive) return 'inactive';
+
+  const days = ch.refreshTokenExpiresInDays;
+  if (typeof days === 'number' && days <= 7) {
+    return days <= 0 ? 'needs reconnect' : `expires in ${days}d`;
+  }
+  return 'connected';
+}
+
+/** The label a channel is known by, falling back through what we actually have. */
+function channelLabel(ch: {
+  accountName?: string | null;
+  username?: string | null;
+  platform: string;
+}): string {
+  return ch.accountName || ch.username || ch.platform;
+}
+
+/**
+ * Read-only tools over the workspace's connected channels, plus the interactive
+ * card that starts a connection.
+ *
+ * Every read derives its workspace from `ctx` — never from tool arguments. A
+ * workspace id accepted as an argument would let the model read across tenants
+ * if it ever hallucinated one, so the boundary is enforced by shape, not by
+ * instruction.
+ */
+export function createChannelTools(
+  channels: ChannelService,
+): AgentToolDefinition[] {
+  return [
+    {
+      name: 'list_channels',
+      description:
+        'List the social media channels connected to this workspace, with each one\'s health (connected, needs reconnect, expiring soon, error). Use this for "what channels do I have", "is anything disconnected", or before suggesting where to post.' +
+        REFERENCE_USAGE_HINT,
+      inputSchema: {
+        platform: z
+          .string()
+          .optional()
+          .describe(
+            'Optional platform filter, e.g. "instagram". Omit to list every channel.',
+          ),
+      },
+      handler: async (args, ctx) => {
+        const platform =
+          typeof args.platform === 'string' && args.platform.trim()
+            ? args.platform.trim().toLowerCase()
+            : undefined;
+
+        const list = await channels.getWorkspaceChannels(ctx.workspaceId, {
+          ...(platform ? { platform } : {}),
+        } as never);
+
+        const items = list.map((ch) => ({
+          id: String(ch.id),
+          platform: ch.platform,
+          name: channelLabel(ch),
+          username: ch.username ?? null,
+          health: channelHealth(ch),
+          lastPostedAt: ch.lastPostedAt ?? null,
+        }));
+
+        const refs: EntityReference[] = items.map((it) => ({
+          kind: 'channel',
+          id: it.id,
+          label: it.name,
+          status: it.health,
+        }));
+
+        return withReferences(
+          {
+            total: items.length,
+            channels: items,
+            needsAttention: items
+              .filter((it) => it.health !== 'connected')
+              .map((it) => it.name),
+          },
+          refs,
+        );
+      },
+    },
+
+    {
+      name: 'get_channel_stats',
+      description:
+        'Get a summary of this workspace\'s channel connections: how many in total, how many healthy, how many expired or erroring, and the split per platform. Use this for "how are my channels doing" or "is everything connected".',
+      inputSchema: {},
+      handler: async (_args, ctx) => {
+        const stats = await channels.getChannelStats(ctx.workspaceId);
+        return {
+          total: stats.totalChannels,
+          healthy: stats.activeChannels,
+          expired: stats.expiredChannels,
+          erroring: stats.errorChannels,
+          byPlatform: stats.byPlatform,
+        };
+      },
+    },
+
+    {
+      name: 'connect_channel',
+      description:
+        'Offer the user a button that starts connecting a social media account. Use this when the user wants to connect, add, or reconnect a channel — do NOT explain the steps in prose, and do NOT send them a URL. If you do not know which platform they mean, ask first with ask_user, then call this. Returns a card the user clicks; the connection happens in their browser, so nothing is connected until they do.',
+      inputSchema: {
+        platform: z
+          .enum(CONNECTABLE_PLATFORMS)
+          .describe('The platform to connect, e.g. "instagram".'),
+      },
+      handler: async (args, ctx) => {
+        // Zod validates this, but a tool handler is also reachable from the
+        // approval path with stored args — coerce defensively rather than
+        // stringifying whatever arrived.
+        const platform =
+          typeof args.platform === 'string'
+            ? args.platform.trim().toLowerCase()
+            : '';
+
+        if (!(CONNECTABLE_PLATFORMS as readonly string[]).includes(platform)) {
+          return {
+            error: `"${platform}" is not a platform this workspace can connect.`,
+            supported: CONNECTABLE_PLATFORMS,
+          };
+        }
+
+        // Already connected and healthy? Say so rather than offering a button
+        // that would start a redundant OAuth round trip.
+        const existing = await channels.getWorkspaceChannels(ctx.workspaceId, {
+          platform,
+        } as never);
+        const healthy = existing.filter(
+          (ch) => channelHealth(ch) === 'connected',
+        );
+
+        if (healthy.length > 0) {
+          return withReferences(
+            {
+              kind: 'connect',
+              platform,
+              alreadyConnected: true,
+              accounts: healthy.map((ch) => channelLabel(ch)),
+            },
+            healthy.map((ch) => ({
+              kind: 'channel' as const,
+              id: String(ch.id),
+              label: channelLabel(ch),
+              status: 'connected',
+            })),
+          );
+        }
+
+        return {
+          kind: 'connect',
+          platform,
+          alreadyConnected: false,
+          // Present when the user is re-authorising a broken channel rather
+          // than adding a new one — the UI words the button differently.
+          reconnect: existing.length > 0,
+        };
+      },
+    },
+  ];
+}

--- a/src/maestro/tools/channel.tools.ts
+++ b/src/maestro/tools/channel.tools.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import type { ChannelService } from '../../channels/services/channel.service';
+import {
+  CHANNEL_CATEGORY,
+  type SupportedPlatform,
+} from '../../drizzle/schema/channels.schema';
 import type { AgentToolDefinition } from '../maestro.types';
 import {
   REFERENCE_USAGE_HINT,
@@ -47,6 +51,22 @@ function channelHealth(ch: {
   return 'connected';
 }
 
+/**
+ * True for a publishing channel (social or messaging), false for a cloud
+ * storage or calendar integration.
+ *
+ * Derived from the PLATFORM, not from the row's stored `category` column: that
+ * column defaults to 'social' and was only backfilled where the migration ran,
+ * so a row can mislabel itself. Asking "which channels do I have" must not
+ * answer with Google Drive.
+ */
+function isPublishingChannel(platform: string): boolean {
+  const category = CHANNEL_CATEGORY[platform as SupportedPlatform];
+  // An unknown platform is more likely a new social network than a new cloud
+  // drive, and hiding a real channel is worse than showing one extra.
+  return category === undefined || category !== 'integration';
+}
+
 /** The label a channel is known by, falling back through what we actually have. */
 function channelLabel(ch: {
   accountName?: string | null;
@@ -92,14 +112,16 @@ export function createChannelTools(
           ...(platform ? { platform } : {}),
         } as never);
 
-        const items = list.map((ch) => ({
-          id: String(ch.id),
-          platform: ch.platform,
-          name: channelLabel(ch),
-          username: ch.username ?? null,
-          health: channelHealth(ch),
-          lastPostedAt: ch.lastPostedAt ?? null,
-        }));
+        const items = list
+          .filter((ch) => isPublishingChannel(ch.platform))
+          .map((ch) => ({
+            id: String(ch.id),
+            platform: ch.platform,
+            name: channelLabel(ch),
+            username: ch.username ?? null,
+            health: channelHealth(ch),
+            lastPostedAt: ch.lastPostedAt ?? null,
+          }));
 
         const refs: EntityReference[] = items.map((it) => ({
           kind: 'channel',
@@ -127,13 +149,28 @@ export function createChannelTools(
         'Get a summary of this workspace\'s channel connections: how many in total, how many healthy, how many expired or erroring, and the split per platform. Use this for "how are my channels doing" or "is everything connected".',
       inputSchema: {},
       handler: async (_args, ctx) => {
-        const stats = await channels.getChannelStats(ctx.workspaceId);
+        // Derived from the channel list rather than getChannelStats(), whose
+        // totals include cloud-storage and calendar integrations. Those are not
+        // publishing channels, and counting them would answer "how are my
+        // channels doing" with Google Drive in the total.
+        const list = (
+          await channels.getWorkspaceChannels(ctx.workspaceId)
+        ).filter((ch) => isPublishingChannel(ch.platform));
+
+        const byPlatform: Record<string, number> = {};
+        for (const ch of list) {
+          byPlatform[ch.platform] = (byPlatform[ch.platform] || 0) + 1;
+        }
+
+        const health = list.map((ch) => channelHealth(ch));
         return {
-          total: stats.totalChannels,
-          healthy: stats.activeChannels,
-          expired: stats.expiredChannels,
-          erroring: stats.errorChannels,
-          byPlatform: stats.byPlatform,
+          total: list.length,
+          healthy: health.filter((h) => h === 'connected').length,
+          needsReconnect: health.filter((h) => h === 'needs reconnect').length,
+          erroring: health.filter(
+            (h) => h === 'error' || h === 'access revoked',
+          ).length,
+          byPlatform,
         };
       },
     },
@@ -164,11 +201,15 @@ export function createChannelTools(
         }
 
         // Already connected and healthy? Say so rather than offering a button
-        // that would start a redundant OAuth round trip.
+        // that would start a redundant OAuth round trip. Integrations are
+        // excluded so a stray cloud-storage row cannot mask a real channel.
         const existing = await channels.getWorkspaceChannels(ctx.workspaceId, {
           platform,
         } as never);
-        const healthy = existing.filter(
+        const publishing = existing.filter((ch) =>
+          isPublishingChannel(ch.platform),
+        );
+        const healthy = publishing.filter(
           (ch) => channelHealth(ch) === 'connected',
         );
 
@@ -195,7 +236,7 @@ export function createChannelTools(
           alreadyConnected: false,
           // Present when the user is re-authorising a broken channel rather
           // than adding a new one — the UI words the button differently.
-          reconnect: existing.length > 0,
+          reconnect: publishing.length > 0,
         };
       },
     },

--- a/src/maestro/tools/channel.tools.ts
+++ b/src/maestro/tools/channel.tools.ts
@@ -128,6 +128,7 @@ export function createChannelTools(
           id: it.id,
           label: it.name,
           status: it.health,
+          platform: it.platform,
         }));
 
         return withReferences(
@@ -226,6 +227,7 @@ export function createChannelTools(
               id: String(ch.id),
               label: channelLabel(ch),
               status: 'connected',
+              platform: ch.platform,
             })),
           );
         }

--- a/src/maestro/tools/post.tools.spec.ts
+++ b/src/maestro/tools/post.tools.spec.ts
@@ -1,0 +1,209 @@
+import type { PostService } from '../../posts/services/post.service';
+import type { AgentToolDefinition, ToolContext } from '../maestro.types';
+import { createPostTools } from './post.tools';
+import { isReferencePayload, type ReferencePayload } from './references';
+
+const CTX: ToolContext = { userId: 'u1', workspaceId: 'ws-1' };
+
+/** A post row as the service returns it — only the fields the tools read. */
+function postRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p-1',
+    workspaceId: 'ws-1',
+    status: 'draft',
+    content: 'Autumn collection drops Friday',
+    mediaItems: [],
+    targets: [{ channelId: '1', platform: 'instagram', status: 'draft' }],
+    platformContent: {},
+    scheduledAt: null,
+    publishedAt: null,
+    ...over,
+  };
+}
+
+interface Recorded {
+  workspaceId: string;
+  options?: unknown;
+  postId?: string;
+}
+
+function fakeService(rows: Record<string, unknown>[], calls: Recorded[] = []) {
+  return {
+    getWorkspacePosts: (workspaceId: string, options?: unknown) => {
+      calls.push({ workspaceId, options });
+      const status = (options as { status?: string } | undefined)?.status;
+      const mine = rows.filter((r) => r.workspaceId === workspaceId);
+      const filtered = status ? mine.filter((r) => r.status === status) : mine;
+      return Promise.resolve({ posts: filtered, total: filtered.length });
+    },
+    getPost: (postId: string, workspaceId: string) => {
+      calls.push({ workspaceId, postId });
+      const found = rows.find(
+        (r) => r.id === postId && r.workspaceId === workspaceId,
+      );
+      if (!found) return Promise.reject(new Error('Post not found'));
+      return Promise.resolve(found);
+    },
+    publishPost: (postId: string) => {
+      const found = rows.find((r) => r.id === postId);
+      return Promise.resolve({
+        ...found,
+        status: 'published',
+        targets: [
+          {
+            channelId: '1',
+            platform: 'instagram',
+            status: 'published',
+            platformPostUrl: 'https://example.test/p/1',
+          },
+        ],
+      });
+    },
+  } as unknown as PostService;
+}
+
+function tool(tools: AgentToolDefinition[], name: string): AgentToolDefinition {
+  const found = tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not registered`);
+  return found;
+}
+
+function build(rows: Record<string, unknown>[], calls: Recorded[] = []) {
+  return createPostTools(fakeService(rows, calls), {
+    confirmBeforeSend: false,
+  });
+}
+
+describe('post tools', () => {
+  describe('list_posts', () => {
+    it('returns each post with a reference so it can be linked', async () => {
+      const result = (await tool(build([postRow()]), 'list_posts').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs).toEqual([
+        {
+          kind: 'draft',
+          id: 'p-1',
+          label: 'Autumn collection drops Friday',
+          status: 'draft',
+          platform: 'instagram',
+        },
+      ]);
+    });
+
+    it('labels a published post as a post, not a draft', async () => {
+      const result = (await tool(
+        build([postRow({ status: 'published' })]),
+        'list_posts',
+      ).handler({ status: 'published' }, CTX)) as ReferencePayload;
+
+      expect(result.refs[0].kind).toBe('post');
+      expect(result.refs[0].status).toBe('published');
+    });
+
+    it('shortens a long caption so the chip fits inside a sentence', async () => {
+      const long = 'A'.repeat(120);
+      const result = (await tool(
+        build([postRow({ content: long })]),
+        'list_posts',
+      ).handler({}, CTX)) as ReferencePayload;
+
+      const label = result.refs[0].label;
+      expect(label.length).toBeLessThanOrEqual(41);
+      expect(label.endsWith('…')).toBe(true);
+    });
+
+    it('names a title-only post by its platform title, like the Planner does', async () => {
+      // YouTube and Pinterest keep their title in platformContent, not
+      // `content` — a chip reading "Untitled post" would not match the UI.
+      const result = (await tool(
+        build([
+          postRow({
+            content: null,
+            targets: [{ channelId: '9', platform: 'youtube', status: 'draft' }],
+            platformContent: {
+              youtube: { platformSpecific: { title: 'Behind the scenes' } },
+            },
+          }),
+        ]),
+        'list_posts',
+      ).handler({}, CTX)) as ReferencePayload;
+
+      expect(result.refs[0].label).toBe('Behind the scenes');
+    });
+
+    it('falls back to a readable label when a post has no text at all', async () => {
+      const result = (await tool(
+        build([postRow({ content: null, platformContent: {} })]),
+        'list_posts',
+      ).handler({}, CTX)) as ReferencePayload;
+
+      expect(result.refs[0].label).toBe('Untitled post');
+    });
+
+    it("reads only the caller's workspace, never one passed as an argument", async () => {
+      const calls: Recorded[] = [];
+      const result = (await tool(
+        build(
+          [
+            postRow({ id: 'mine', workspaceId: 'ws-1' }),
+            postRow({ id: 'theirs', workspaceId: 'ws-2' }),
+          ],
+          calls,
+        ),
+        'list_posts',
+      ).handler({ workspaceId: 'ws-2' }, CTX)) as ReferencePayload;
+
+      expect(calls[0].workspaceId).toBe('ws-1');
+      expect(result.refs.map((r) => r.id)).toEqual(['mine']);
+    });
+
+    it('returns an empty reference list rather than nothing when there are no posts', async () => {
+      const result = (await tool(build([]), 'list_posts').handler(
+        {},
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs).toEqual([]);
+    });
+  });
+
+  describe('get_post', () => {
+    it('returns the post with a reference so it can be linked', async () => {
+      const result = (await tool(build([postRow()]), 'get_post').handler(
+        { postId: 'p-1' },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      expect(result.refs[0].id).toBe('p-1');
+    });
+
+    it('cannot read a post belonging to another workspace', async () => {
+      const result = (await tool(
+        build([postRow({ id: 'theirs', workspaceId: 'ws-2' })]),
+        'get_post',
+      ).handler({ postId: 'theirs' }, CTX)) as { ok?: boolean };
+
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('publish_post', () => {
+    it('cites the post with the status the publish actually reached', async () => {
+      const result = (await tool(build([postRow()]), 'publish_post').handler(
+        { postId: 'p-1', confirmed: true },
+        CTX,
+      )) as ReferencePayload;
+
+      expect(isReferencePayload(result)).toBe(true);
+      // Not 'draft' — the chip must show where the post ended up.
+      expect(result.refs[0].status).toBe('published');
+      expect(result.refs[0].kind).toBe('post');
+    });
+  });
+});

--- a/src/maestro/tools/post.tools.ts
+++ b/src/maestro/tools/post.tools.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import type { PostService } from '../../posts/services/post.service';
 import type { AgentToolDefinition } from '../maestro.types';
 import { confirmCard, isConfirmed } from './confirm';
+import {
+  REFERENCE_USAGE_HINT,
+  withReferences,
+  type EntityReference,
+} from './references';
 
 /** Per-channel publish target stored on a post (jsonb). */
 interface PostTargetLite {
@@ -38,6 +43,100 @@ function mediaCount(post: PostRow): number {
   return Array.isArray(post.mediaItems) ? post.mediaItems.length : 0;
 }
 
+/**
+ * Read a post id out of tool arguments.
+ *
+ * Zod validates these, but a handler is also reachable from the approval path
+ * with stored arguments, so it coerces defensively rather than stringifying
+ * whatever arrived — `String({})` is the string "[object Object]", which would
+ * become a lookup for a post whose id is literally that.
+ */
+function postIdArg(args: Record<string, unknown>): string {
+  return typeof args.postId === 'string' ? args.postId.trim() : '';
+}
+
+/**
+ * The text a post is known by.
+ *
+ * A post has no name, so its chip has to carry something the user recognises —
+ * and it must be the SAME something the Planner shows, or the agent will name a
+ * post the user cannot find. This mirrors the frontend's
+ * `getPostDisplayCaption`: body content first, then the platform-specific title
+ * that title-only platforms (YouTube, Pinterest, Reddit) keep in
+ * platformContent instead of `content`, then a per-platform body override.
+ */
+function displayCaption(post: PostRow): string | null {
+  const body = (post.content ?? '').trim();
+  if (body) return body;
+
+  const platformContent = (post.platformContent ?? {}) as Record<
+    string,
+    | {
+        text?: string;
+        metadata?: { title?: string; description?: string };
+        platformSpecific?: { title?: string; description?: string };
+        overrides?: { text?: string };
+      }
+    | undefined
+  >;
+
+  for (const target of targetsOf(post)) {
+    const pc = platformContent[target.platform];
+    if (!pc) continue;
+
+    // The composer writes per-platform settings under `platformSpecific`;
+    // older posts wrote them under `metadata`. Both are live in the data.
+    const fields = pc.platformSpecific ?? pc.metadata ?? {};
+
+    if (
+      target.platform === 'pinterest' ||
+      target.platform === 'youtube' ||
+      target.platform === 'reddit'
+    ) {
+      const title = fields.title?.trim();
+      if (title) return title;
+      const description = fields.description?.trim();
+      if (description) return description;
+    }
+
+    const override =
+      pc.overrides?.text?.trim() ??
+      (typeof pc.text === 'string' ? pc.text.trim() : '');
+    if (override) return override;
+  }
+
+  return null;
+}
+
+/**
+ * A short label for a post's chip.
+ *
+ * Much shorter than the excerpt the model reads: a chip sits inside a sentence,
+ * so a full caption would push the surrounding prose off the line. The model
+ * still gets the longer excerpt in the tool result to reason about.
+ */
+function chipLabel(post: PostRow): string {
+  const caption = displayCaption(post);
+  if (!caption) return 'Untitled post';
+  const oneLine = caption.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 40 ? `${oneLine.slice(0, 40).trimEnd()}…` : oneLine;
+}
+
+function referenceFor(post: PostRow): EntityReference {
+  return {
+    // A draft routes to the same editor as any other post, but the frontend
+    // colours the two differently, so the kind has to reflect the real state.
+    kind: post.status === 'draft' ? 'draft' : 'post',
+    id: post.id,
+    label: chipLabel(post),
+    status: post.status,
+    // A post can target several platforms; the chip shows one logo, so it gets
+    // the first. Multi-platform posts read as that platform's post in the UI
+    // too, so this matches what the user already sees.
+    ...(platformsOf(post)[0] ? { platform: platformsOf(post)[0] } : {}),
+  };
+}
+
 export function createPostTools(
   posts: PostService,
   opts: { confirmBeforeSend: boolean },
@@ -47,13 +146,23 @@ export function createPostTools(
     {
       name: 'list_posts',
       description:
-        "List the workspace's posts by status — use status 'draft' to find drafts the user can publish, 'scheduled' for upcoming, 'published' for recent. Read-only.",
+        "List the workspace's posts by status — use status 'draft' to find drafts the user can publish, 'scheduled' for upcoming, 'published' for recent. Read-only." +
+        REFERENCE_USAGE_HINT,
       inputSchema: {
         status: z
-          .enum(['draft', 'scheduled', 'published', 'failed', 'partially_published'])
+          .enum([
+            'draft',
+            'scheduled',
+            'published',
+            'failed',
+            'partially_published',
+          ])
           .optional()
           .describe("Which posts to list. Defaults to 'draft'."),
-        limit: z.number().optional().describe('Max posts to return (1-20, default 10).'),
+        limit: z
+          .number()
+          .optional()
+          .describe('Max posts to return (1-20, default 10).'),
       },
       handler: async (args, ctx) => {
         const status =
@@ -70,55 +179,66 @@ export function createPostTools(
           ctx.workspaceId,
           { status, limit },
         );
-        return {
-          kind: 'post' as const,
-          ok: true,
-          action: 'list',
-          status,
-          total,
-          posts: rows.map((p) => ({
-            id: p.id,
-            status: p.status,
-            content: excerpt(p.content),
-            platforms: platformsOf(p),
-            mediaCount: mediaCount(p),
-            scheduledAt: p.scheduledAt,
-          })),
-        };
+        return withReferences(
+          {
+            kind: 'post' as const,
+            ok: true,
+            action: 'list',
+            status,
+            total,
+            posts: rows.map((p) => ({
+              id: p.id,
+              status: p.status,
+              content: excerpt(displayCaption(p)),
+              platforms: platformsOf(p),
+              mediaCount: mediaCount(p),
+              scheduledAt: p.scheduledAt,
+            })),
+          },
+          rows.map(referenceFor),
+        );
       },
     },
 
     {
       name: 'get_post',
       description:
-        'Get the full details of one post by id (content, target platforms, media, status). Read-only.',
+        'Get the full details of one post by id (content, target platforms, media, status). Read-only.' +
+        REFERENCE_USAGE_HINT,
       inputSchema: {
         postId: z.string().describe('The id of the post to fetch.'),
       },
       handler: async (args, ctx) => {
         try {
-          const p = await posts.getPost(String(args.postId || ''), ctx.workspaceId);
+          const p = await posts.getPost(postIdArg(args), ctx.workspaceId);
+          return withReferences(
+            {
+              kind: 'post' as const,
+              ok: true,
+              action: 'detail',
+              post: {
+                id: p.id,
+                status: p.status,
+                content: p.content ?? '',
+                platforms: platformsOf(p),
+                mediaCount: mediaCount(p),
+                scheduledAt: p.scheduledAt,
+                publishedAt: p.publishedAt,
+                targets: targetsOf(p).map((t) => ({
+                  platform: t.platform,
+                  status: t.status,
+                  url: t.platformPostUrl,
+                })),
+              },
+            },
+            [referenceFor(p)],
+          );
+        } catch {
           return {
             kind: 'post' as const,
-            ok: true,
-            action: 'detail',
-            post: {
-              id: p.id,
-              status: p.status,
-              content: p.content ?? '',
-              platforms: platformsOf(p),
-              mediaCount: mediaCount(p),
-              scheduledAt: p.scheduledAt,
-              publishedAt: p.publishedAt,
-              targets: targetsOf(p).map((t) => ({
-                platform: t.platform,
-                status: t.status,
-                url: t.platformPostUrl,
-              })),
-            },
+            ok: false,
+            message: 'Post not found.',
           };
-        } catch {
-          return { kind: 'post' as const, ok: false, message: 'Post not found.' };
         }
       },
     },
@@ -139,9 +259,13 @@ export function createPostTools(
       handler: async (args, ctx) => {
         let post: PostRow;
         try {
-          post = await posts.getPost(String(args.postId || ''), ctx.workspaceId);
+          post = await posts.getPost(postIdArg(args), ctx.workspaceId);
         } catch {
-          return { kind: 'post' as const, ok: false, message: 'Post not found.' };
+          return {
+            kind: 'post' as const,
+            ok: false,
+            message: 'Post not found.',
+          };
         }
 
         if (post.status === 'published') {
@@ -158,50 +282,62 @@ export function createPostTools(
             message: 'This post is already being published.',
           };
         }
-        const hasContent = Boolean((post.content ?? '').trim()) || mediaCount(post) > 0;
+        const hasContent =
+          Boolean((post.content ?? '').trim()) || mediaCount(post) > 0;
         if (!hasContent) {
           return {
             kind: 'post' as const,
             ok: false,
-            message: 'The draft is empty — add some text or media before publishing.',
+            message:
+              'The draft is empty — add some text or media before publishing.',
           };
         }
         if (targetsOf(post).length === 0) {
           return {
             kind: 'post' as const,
             ok: false,
-            message: 'This draft has no target channels. Add at least one before publishing.',
+            message:
+              'This draft has no target channels. Add at least one before publishing.',
           };
         }
 
         if (!isConfirmed(confirmBeforeSend, args)) {
           return confirmCard(
+            // displayCaption, not post.content: a YouTube/Pinterest post keeps
+            // its title in platformContent, and confirming an empty quotation
+            // gives the user nothing to recognise the post by.
             `Publish this post now to ${platformsOf(post).join(', ')}?\n\n"${excerpt(
-              post.content,
+              displayCaption(post),
             )}"`,
             'Yes, publish',
           );
         }
 
         const result = await posts.publishPost(
-          String(args.postId),
+          postIdArg(args),
           ctx.workspaceId,
           ctx.userId,
           { triggeredBy: 'user' },
         );
 
-        return {
-          kind: 'post' as const,
-          ok: true,
-          action: 'published',
-          status: result.status,
-          results: targetsOf(result).map((t) => ({
-            platform: t.platform,
-            status: t.status,
-            url: t.platformPostUrl,
-            error: t.errorMessage,
-          })),
-        };
+        return withReferences(
+          {
+            kind: 'post' as const,
+            ok: true,
+            action: 'published',
+            status: result.status,
+            results: targetsOf(result).map((t) => ({
+              platform: t.platform,
+              status: t.status,
+              url: t.platformPostUrl,
+              error: t.errorMessage,
+            })),
+          },
+          // The reference carries the POST-publish row, so the chip shows the
+          // status the publish actually reached (published, or partial when a
+          // platform failed) rather than the draft state it started in.
+          [referenceFor(result)],
+        );
       },
     },
   ];

--- a/src/maestro/tools/references.spec.ts
+++ b/src/maestro/tools/references.spec.ts
@@ -1,0 +1,137 @@
+import {
+  isEntityReference,
+  isReferencePayload,
+  mergeReferences,
+  referenceMarker,
+  withReferences,
+  type EntityReference,
+} from './references';
+
+const channel = (id: string, label = `Channel ${id}`): EntityReference => ({
+  kind: 'channel',
+  id,
+  label,
+});
+
+describe('references', () => {
+  describe('withReferences', () => {
+    it('wraps data with its entities', () => {
+      const payload = withReferences({ total: 2 }, [
+        channel('a'),
+        channel('b'),
+      ]);
+
+      expect(payload.kind).toBe('refs');
+      expect(payload.data).toEqual({ total: 2 });
+      expect(payload.refs.map((r) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('keeps a status when the entity has one', () => {
+      const payload = withReferences(null, [
+        { kind: 'post', id: 'p1', label: 'Launch post', status: 'scheduled' },
+      ]);
+
+      expect(payload.refs[0].status).toBe('scheduled');
+    });
+
+    it('drops duplicate ids so one entity yields one link', () => {
+      const payload = withReferences(null, [
+        channel('a', 'First label'),
+        channel('a', 'Second label'),
+      ]);
+
+      expect(payload.refs).toHaveLength(1);
+      expect(payload.refs[0].label).toBe('First label');
+    });
+
+    it('drops malformed entries rather than passing them through', () => {
+      const payload = withReferences(null, [
+        channel('good'),
+        { kind: 'channel', id: '', label: 'no id' } as EntityReference,
+        { kind: 'nonsense', id: 'x', label: 'bad kind' } as never,
+      ]);
+
+      expect(payload.refs.map((r) => r.id)).toEqual(['good']);
+    });
+
+    it('strips keys outside the documented shape', () => {
+      const payload = withReferences(null, [
+        { ...channel('a'), secret: 'internal' } as never,
+      ]);
+
+      expect(payload.refs[0]).toEqual({
+        kind: 'channel',
+        id: 'a',
+        label: 'Channel a',
+      });
+    });
+
+    it('produces an empty list, not an absent one, when nothing was found', () => {
+      const payload = withReferences({ items: [] }, []);
+
+      expect(payload.refs).toEqual([]);
+      expect(isReferencePayload(payload)).toBe(true);
+    });
+  });
+
+  describe('mergeReferences', () => {
+    // Two tools in one turn must both stay clickable — unlike media and
+    // questions, where a later result replaces an earlier one.
+    it('accumulates across tool calls instead of replacing', () => {
+      const merged = mergeReferences(
+        [channel('a')],
+        [{ kind: 'campaign', id: 'c1', label: 'Summer push' }],
+      );
+
+      expect(merged.map((r) => r.id)).toEqual(['a', 'c1']);
+    });
+
+    it('does not re-add an entity already referenced', () => {
+      const merged = mergeReferences([channel('a')], [channel('a', 'Renamed')]);
+
+      expect(merged).toHaveLength(1);
+      expect(merged[0].label).toBe('Channel a');
+    });
+
+    it('ignores malformed incoming entries', () => {
+      const merged = mergeReferences(
+        [channel('a')],
+        [null, 'nope', { id: 'b' }],
+      );
+
+      expect(merged.map((r) => r.id)).toEqual(['a']);
+    });
+  });
+
+  describe('isEntityReference', () => {
+    it.each([
+      ['null', null],
+      ['a string', 'channel'],
+      ['a missing id', { kind: 'channel', label: 'x' }],
+      ['an empty id', { kind: 'channel', id: '', label: 'x' }],
+      ['an empty label', { kind: 'channel', id: 'a', label: '' }],
+      ['an unknown kind', { kind: 'invoice', id: 'a', label: 'x' }],
+      ['a non-string status', { kind: 'post', id: 'a', label: 'x', status: 3 }],
+    ])('rejects %s', (_name, value) => {
+      expect(isEntityReference(value)).toBe(false);
+    });
+
+    it('accepts a well-formed reference', () => {
+      expect(isEntityReference(channel('a'))).toBe(true);
+    });
+  });
+
+  describe('referenceMarker', () => {
+    it('is the exact form the model is told to write', () => {
+      expect(referenceMarker('abc-123')).toBe('[[ref:abc-123]]');
+    });
+  });
+
+  describe('isReferencePayload', () => {
+    it('rejects other tool payload kinds', () => {
+      expect(isReferencePayload({ kind: 'media', items: [] })).toBe(false);
+      expect(isReferencePayload({ kind: 'refs' })).toBe(false);
+      expect(isReferencePayload(null)).toBe(false);
+    });
+  });
+});

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -48,6 +48,12 @@ export interface EntityReference {
    * "needs reconnect"). Omitted for entities that have no meaningful state.
    */
   status?: string;
+  /**
+   * Platform id (e.g. "instagram") when the entity has a brand logo, so the
+   * chip can show it. Lives here rather than being dug out of the tool's data,
+   * whose shape differs per tool.
+   */
+  platform?: string;
 }
 
 /** A tool result carrying linkable entities. */
@@ -75,8 +81,14 @@ export function referenceMarker(id: string): string {
  */
 export const REFERENCE_USAGE_HINT =
   ' When you mention any of the returned items in your reply, cite it by writing ' +
-  `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} inline — the UI turns that into a link. ` +
-  'Use the exact id from the result; never invent one, and never write a URL yourself.';
+  `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} inline. ` +
+  'Use the exact id from the result; never invent one, and never write a URL yourself. ' +
+  'IMPORTANT: the marker renders as a chip that ALREADY SHOWS the item's name, its icon, ' +
+  'and its status — so do NOT repeat the name or the status next to it, and do not add ' +
+  'check marks or warning emoji for status. Write the marker where the name would go: ' +
+  `"${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} hasn't posted in a week", ` +
+  `not "${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} — Name (connected)". ` +
+  'Keep the surrounding prose short and plain; the chips carry the detail.';
 
 /** True when `value` is a well-formed reference (used on the read-back path). */
 export function isEntityReference(value: unknown): value is EntityReference {
@@ -89,8 +101,20 @@ export function isEntityReference(value: unknown): value is EntityReference {
     r.label.length > 0 &&
     typeof r.kind === 'string' &&
     (REFERENCE_KINDS as readonly string[]).includes(r.kind) &&
-    (r.status === undefined || typeof r.status === 'string')
+    (r.status === undefined || typeof r.status === 'string') &&
+    (r.platform === undefined || typeof r.platform === 'string')
   );
+}
+
+/** Strip a reference down to exactly the documented shape. */
+function normalize(ref: EntityReference): EntityReference {
+  return {
+    kind: ref.kind,
+    id: ref.id,
+    label: ref.label,
+    ...(ref.status === undefined ? {} : { status: ref.status }),
+    ...(ref.platform === undefined ? {} : { platform: ref.platform }),
+  };
 }
 
 /**
@@ -108,13 +132,9 @@ export function withReferences(
   for (const ref of refs) {
     if (!isEntityReference(ref) || seen.has(ref.id)) continue;
     seen.add(ref.id);
-    unique.push(
-      // Normalize away extra keys a caller might have spread in, so what the
-      // frontend receives is exactly the documented shape.
-      ref.status === undefined
-        ? { kind: ref.kind, id: ref.id, label: ref.label }
-        : { kind: ref.kind, id: ref.id, label: ref.label, status: ref.status },
-    );
+    // Normalize away extra keys a caller might have spread in, so what the
+    // frontend receives is exactly the documented shape.
+    unique.push(normalize(ref));
   }
   return { kind: 'refs', refs: unique, data };
 }
@@ -142,11 +162,7 @@ export function mergeReferences(
   for (const ref of incoming) {
     if (!isEntityReference(ref) || seen.has(ref.id)) continue;
     seen.add(ref.id);
-    merged.push(
-      ref.status === undefined
-        ? { kind: ref.kind, id: ref.id, label: ref.label }
-        : { kind: ref.kind, id: ref.id, label: ref.label, status: ref.status },
-    );
+    merged.push(normalize(ref));
   }
   return merged;
 }

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -54,6 +54,17 @@ export interface EntityReference {
    * whose shape differs per tool.
    */
   platform?: string;
+  /**
+   * The entity's sub-type, when its kind has several and the app draws each
+   * with its own icon — a campaign is "bulk", "drip", or "evergreen", and the
+   * Campaigns page gives those three different glyphs.
+   *
+   * Separate from `platform` because they answer different questions: platform
+   * is which network this belongs to, variant is which KIND of this thing it
+   * is. A chip that wore one generic icon for every campaign would look less
+   * like the card it links to.
+   */
+  variant?: string;
 }
 
 /** A tool result carrying linkable entities. */
@@ -95,8 +106,11 @@ HOW TO WRITE THE ANSWER — this matters as much as being correct:
 - Do not restate the status as the sentence's verb either. Instead of "${REF} is paused — you'll need to unpause it", write "${REF} needs unpausing before it will send." Say what the state MEANS for the user, or what to do about it; the pill already says what the state IS.
 - Do NOT prefix an item with its platform or type followed by a dash. Let several flow in one sentence, separated by commas.
 - NEVER use a numbered list (1. 2. 3.) for items. Prefer one flowing sentence; if a list genuinely helps, use "- " bullets, several items per line.
-- Lead with the answer, not a preamble.
+- Lead with the CONCLUSION, not a census. When the user asks which things need attention, open with how many do and name those first — never walk through every item in list order and leave the point for the end. And do not open by counting what the screen already shows: "You have 3 campaigns" tells the user nothing they cannot see.
+- Do not close by summarising what you just said. If a closing line adds nothing new, leave it out; the answer ends when the last useful fact does.
 - Bold only facts that are NOT chips — a count, or a bare state. Never bold a chip or the words beside it. Bold is quiet emphasis, so never bold a whole sentence.
+- One clause per item. Say the thing the user would not have known from the chip — a date, a blocker, the next step — and stop. No mini-narratives.
+- Use the product's own words for things. If a tool gives you a label, use it verbatim; never substitute an internal-sounding synonym.
 - Keep it short. The chips carry the detail.
 
 Write it like this:
@@ -105,13 +119,20 @@ Write it like this:
 And on a follow-up, still like this:
   Only ${REFERENCE_MARKER_PREFIX}10${REFERENCE_MARKER_SUFFIX} needs attention — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} and ${REFERENCE_MARKER_PREFIX}2${REFERENCE_MARKER_SUFFIX} are healthy.
 
+And when some items need the user and others do not, group them — conclusion first:
+  **2 of 3** need you:
+  - ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (Evergreen) — finish setup and launch it.
+  - ${REFERENCE_MARKER_PREFIX}c2${REFERENCE_MARKER_SUFFIX} (Drip) — resume it to start posting again.
+
+  On track: ${REFERENCE_MARKER_PREFIX}c3${REFERENCE_MARKER_SUFFIX} (Simple), next post Sep 1.
+
 Never like this:
   1. Discord — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} — "Asad's server" — ✅ Connected
   Your **Threads** account needs reconnecting; **Discord** and **Slack** are fine.
   ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (evergreen, draft) is in draft — it hasn't started yet.
+  You have **3 campaigns**: ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (Evergreen) — still in draft and hasn't started. ${REFERENCE_MARKER_PREFIX}c2${REFERENCE_MARKER_SUFFIX} (Drip) — paused, on hold right now. ${REFERENCE_MARKER_PREFIX}c3${REFERENCE_MARKER_SUFFIX} (Simple) — active and on track. The two that need attention are the draft and the paused one.
 
-Say that last one like this instead:
-  ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (evergreen) hasn't started yet — launch it when you're ready.
+That last one is wrong three times over: it counts what the screen shows, it restates every pill in prose, and it buries the answer in a closing line.
 `;
 
 /** True when `value` is a well-formed reference (used on the read-back path). */
@@ -126,7 +147,8 @@ export function isEntityReference(value: unknown): value is EntityReference {
     typeof r.kind === 'string' &&
     (REFERENCE_KINDS as readonly string[]).includes(r.kind) &&
     (r.status === undefined || typeof r.status === 'string') &&
-    (r.platform === undefined || typeof r.platform === 'string')
+    (r.platform === undefined || typeof r.platform === 'string') &&
+    (r.variant === undefined || typeof r.variant === 'string')
   );
 }
 
@@ -138,6 +160,7 @@ function normalize(ref: EntityReference): EntityReference {
     label: ref.label,
     ...(ref.status === undefined ? {} : { status: ref.status }),
     ...(ref.platform === undefined ? {} : { platform: ref.platform }),
+    ...(ref.variant === undefined ? {} : { variant: ref.variant }),
   };
 }
 

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -84,21 +84,29 @@ const REF = `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX}`;
 export const REFERENCE_USAGE_HINT = `
 When you mention any of the returned items in your reply, cite it by writing ${REF} inline. Use the exact id from the result; never invent one, and never write a URL yourself.
 
+THE RULE — every real thing gets a marker:
+Any channel, post, campaign, conversation, or media item you NAME must be written as its ${REF} marker, never as plain text and never in bold. This holds every time you mention it, including later turns in the conversation and including when you refer to it by platform ("the Threads account", "your Discord server") — cite the marker instead. If you name a real thing without its marker, the user cannot click it, and the reply is wrong.
+
+The only exceptions: an item with no marker in any result (say the name plainly), and a name you are quoting rather than pointing at, which goes in double quotes and bold — **"Launch week"**.
+
 HOW TO WRITE THE ANSWER — this matters as much as being correct:
 - ${REF} renders as an inline chip that ALREADY SHOWS the item's name, its icon, and its status. Never repeat any of those beside it, and never add a status emoji (no check marks, no warning signs).
 - Put the marker where the NAME would go, inside an ordinary sentence.
 - Do NOT prefix an item with its platform or type followed by a dash. Let several flow in one sentence, separated by commas.
 - NEVER use a numbered list (1. 2. 3.) for items. Prefer one flowing sentence; if a list genuinely helps, use "- " bullets, several items per line.
 - Lead with the answer, not a preamble.
-- Bold only the facts that carry weight — a count, a state, or a name that is not a chip. Leave connective prose unbolded. Bold is quiet emphasis, so never bold a whole sentence.
-- Put a name you are quoting rather than linking in double quotes, and bold it: **"Launch week"**.
+- Bold only facts that are NOT chips — a count, or a bare state. Never bold a chip or the words beside it. Bold is quiet emphasis, so never bold a whole sentence.
 - Keep it short. The chips carry the detail.
 
 Write it like this:
   You have **3 channels** connected: ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX}, ${REFERENCE_MARKER_PREFIX}2${REFERENCE_MARKER_SUFFIX}, and ${REFERENCE_MARKER_PREFIX}3${REFERENCE_MARKER_SUFFIX}. The last one needs reconnecting.
 
+And on a follow-up, still like this:
+  Only ${REFERENCE_MARKER_PREFIX}10${REFERENCE_MARKER_SUFFIX} needs attention — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} and ${REFERENCE_MARKER_PREFIX}2${REFERENCE_MARKER_SUFFIX} are healthy.
+
 Never like this:
   1. Discord — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} — "Asad's server" — ✅ Connected
+  Your **Threads** account needs reconnecting; **Discord** and **Slack** are fine.
 `;
 
 /** True when `value` is a well-formed reference (used on the read-back path). */

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -79,16 +79,27 @@ export function referenceMarker(id: string): string {
  * the model learns the convention from the tool it is about to call rather than
  * from a distant line in the system prompt.
  */
-export const REFERENCE_USAGE_HINT =
-  ' When you mention any of the returned items in your reply, cite it by writing ' +
-  `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} inline. ` +
-  'Use the exact id from the result; never invent one, and never write a URL yourself. ' +
-  'IMPORTANT: the marker renders as a chip that ALREADY SHOWS the item's name, its icon, ' +
-  'and its status — so do NOT repeat the name or the status next to it, and do not add ' +
-  'check marks or warning emoji for status. Write the marker where the name would go: ' +
-  `"${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} hasn't posted in a week", ` +
-  `not "${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} — Name (connected)". ` +
-  'Keep the surrounding prose short and plain; the chips carry the detail.';
+const REF = `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX}`;
+
+export const REFERENCE_USAGE_HINT = `
+When you mention any of the returned items in your reply, cite it by writing ${REF} inline. Use the exact id from the result; never invent one, and never write a URL yourself.
+
+HOW TO WRITE THE ANSWER — this matters as much as being correct:
+- ${REF} renders as an inline chip that ALREADY SHOWS the item's name, its icon, and its status. Never repeat any of those beside it, and never add a status emoji (no check marks, no warning signs).
+- Put the marker where the NAME would go, inside an ordinary sentence.
+- Do NOT prefix an item with its platform or type followed by a dash. Let several flow in one sentence, separated by commas.
+- NEVER use a numbered list (1. 2. 3.) for items. Prefer one flowing sentence; if a list genuinely helps, use "- " bullets, several items per line.
+- Lead with the answer, not a preamble.
+- Bold only the facts that carry weight — a count, a state, or a name that is not a chip. Leave connective prose unbolded. Bold is quiet emphasis, so never bold a whole sentence.
+- Put a name you are quoting rather than linking in double quotes, and bold it: **"Launch week"**.
+- Keep it short. The chips carry the detail.
+
+Write it like this:
+  You have **3 channels** connected: ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX}, ${REFERENCE_MARKER_PREFIX}2${REFERENCE_MARKER_SUFFIX}, and ${REFERENCE_MARKER_PREFIX}3${REFERENCE_MARKER_SUFFIX}. The last one needs reconnecting.
+
+Never like this:
+  1. Discord — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} — "Asad's server" — ✅ Connected
+`;
 
 /** True when `value` is a well-formed reference (used on the read-back path). */
 export function isEntityReference(value: unknown): value is EntityReference {

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -1,0 +1,152 @@
+/**
+ * Entity references — the mechanism that turns an agent's answer into something
+ * you can click.
+ *
+ * When a tool names real things (channels, posts, campaigns), the answer should
+ * link back into the app rather than reading as dead text. The problem is that
+ * the model knows entity IDs only because a tool handed them over; it does not
+ * know our routing and must never invent a URL.
+ *
+ * So references travel as DATA, never as links:
+ *
+ *   1. A tool returns the entities it found, each with a kind, an id, a label,
+ *      and optionally a status.
+ *   2. The tool ALSO tells the model how to point at one: a marker of the form
+ *      `[[ref:<id>]]` written inline in its prose.
+ *   3. The frontend resolves each marker against the reference list and builds
+ *      the href from the route table it already owns.
+ *
+ * A marker with no matching reference renders as plain text. That degradation
+ * is deliberate: a link to the wrong place is worse than no link at all, and
+ * the model WILL occasionally emit a marker it made up.
+ */
+
+/** Entity kinds that can be linked. Each maps to a route on the frontend. */
+export const REFERENCE_KINDS = [
+  'channel',
+  'post',
+  'campaign',
+  'conversation',
+  'media',
+  'draft',
+] as const;
+
+export type ReferenceKind = (typeof REFERENCE_KINDS)[number];
+
+/**
+ * One linkable entity. Deliberately NOT a URL: the backend does not own
+ * frontend routing, and the model owning it would be worse still.
+ */
+export interface EntityReference {
+  kind: ReferenceKind;
+  /** The entity's real id — what the frontend routes on. */
+  id: string;
+  /** Human-readable name shown as the link text. */
+  label: string;
+  /**
+   * Short state shown beside the label as a pill (e.g. "scheduled",
+   * "needs reconnect"). Omitted for entities that have no meaningful state.
+   */
+  status?: string;
+}
+
+/** A tool result carrying linkable entities. */
+export interface ReferencePayload {
+  kind: 'refs';
+  refs: EntityReference[];
+  /** The tool's own data, whatever shape it needs. */
+  data: unknown;
+}
+
+/** How the model is told to cite an entity. Kept in one place so the prompt, the
+ *  tool descriptions, and the frontend parser cannot drift apart. */
+export const REFERENCE_MARKER_PREFIX = '[[ref:';
+export const REFERENCE_MARKER_SUFFIX = ']]';
+
+/** Build the marker for one reference, e.g. `[[ref:abc-123]]`. */
+export function referenceMarker(id: string): string {
+  return `${REFERENCE_MARKER_PREFIX}${id}${REFERENCE_MARKER_SUFFIX}`;
+}
+
+/**
+ * The instruction appended to every reference-returning tool's description, so
+ * the model learns the convention from the tool it is about to call rather than
+ * from a distant line in the system prompt.
+ */
+export const REFERENCE_USAGE_HINT =
+  ' When you mention any of the returned items in your reply, cite it by writing ' +
+  `${REFERENCE_MARKER_PREFIX}<id>${REFERENCE_MARKER_SUFFIX} inline — the UI turns that into a link. ` +
+  'Use the exact id from the result; never invent one, and never write a URL yourself.';
+
+/** True when `value` is a well-formed reference (used on the read-back path). */
+export function isEntityReference(value: unknown): value is EntityReference {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.id === 'string' &&
+    r.id.length > 0 &&
+    typeof r.label === 'string' &&
+    r.label.length > 0 &&
+    typeof r.kind === 'string' &&
+    (REFERENCE_KINDS as readonly string[]).includes(r.kind) &&
+    (r.status === undefined || typeof r.status === 'string')
+  );
+}
+
+/**
+ * Wrap a tool's data with the entities it named.
+ *
+ * Duplicate ids are dropped (first wins) so a tool that mentions the same
+ * entity twice does not produce two competing labels for one link.
+ */
+export function withReferences(
+  data: unknown,
+  refs: EntityReference[],
+): ReferencePayload {
+  const seen = new Set<string>();
+  const unique: EntityReference[] = [];
+  for (const ref of refs) {
+    if (!isEntityReference(ref) || seen.has(ref.id)) continue;
+    seen.add(ref.id);
+    unique.push(
+      // Normalize away extra keys a caller might have spread in, so what the
+      // frontend receives is exactly the documented shape.
+      ref.status === undefined
+        ? { kind: ref.kind, id: ref.id, label: ref.label }
+        : { kind: ref.kind, id: ref.id, label: ref.label, status: ref.status },
+    );
+  }
+  return { kind: 'refs', refs: unique, data };
+}
+
+/** True when a parsed tool payload carries references. */
+export function isReferencePayload(value: unknown): value is ReferencePayload {
+  if (!value || typeof value !== 'object') return false;
+  const p = value as Record<string, unknown>;
+  return p.kind === 'refs' && Array.isArray(p.refs);
+}
+
+/**
+ * Merge references from several tool calls in one turn.
+ *
+ * Unlike media and questions — where a later tool result replaces an earlier one
+ * — references ACCUMULATE: asking about channels and campaigns in one turn must
+ * leave every named entity clickable, not just the last tool's.
+ */
+export function mergeReferences(
+  existing: EntityReference[],
+  incoming: unknown[],
+): EntityReference[] {
+  const merged = [...existing];
+  const seen = new Set(existing.map((r) => r.id));
+  for (const ref of incoming) {
+    if (!isEntityReference(ref) || seen.has(ref.id)) continue;
+    seen.add(ref.id);
+    merged.push(
+      ref.status === undefined
+        ? { kind: ref.kind, id: ref.id, label: ref.label }
+        : { kind: ref.kind, id: ref.id, label: ref.label, status: ref.status },
+    );
+  }
+  return merged;
+}

--- a/src/maestro/tools/references.ts
+++ b/src/maestro/tools/references.ts
@@ -90,8 +90,9 @@ Any channel, post, campaign, conversation, or media item you NAME must be writte
 The only exceptions: an item with no marker in any result (say the name plainly), and a name you are quoting rather than pointing at, which goes in double quotes and bold — **"Launch week"**.
 
 HOW TO WRITE THE ANSWER — this matters as much as being correct:
-- ${REF} renders as an inline chip that ALREADY SHOWS the item's name, its icon, and its status. Never repeat any of those beside it, and never add a status emoji (no check marks, no warning signs).
+- ${REF} renders as an inline chip that ALREADY SHOWS the item's name, its icon, and its status. Never repeat any of those beside it — not in prose and not in a parenthetical afterwards — and never add a status emoji (no check marks, no warning signs). An aside may carry something NEW, like a campaign's type: write "(evergreen)", never "(evergreen, draft)" when the pill already reads draft.
 - Put the marker where the NAME would go, inside an ordinary sentence.
+- Do not restate the status as the sentence's verb either. Instead of "${REF} is paused — you'll need to unpause it", write "${REF} needs unpausing before it will send." Say what the state MEANS for the user, or what to do about it; the pill already says what the state IS.
 - Do NOT prefix an item with its platform or type followed by a dash. Let several flow in one sentence, separated by commas.
 - NEVER use a numbered list (1. 2. 3.) for items. Prefer one flowing sentence; if a list genuinely helps, use "- " bullets, several items per line.
 - Lead with the answer, not a preamble.
@@ -107,6 +108,10 @@ And on a follow-up, still like this:
 Never like this:
   1. Discord — ${REFERENCE_MARKER_PREFIX}1${REFERENCE_MARKER_SUFFIX} — "Asad's server" — ✅ Connected
   Your **Threads** account needs reconnecting; **Discord** and **Slack** are fine.
+  ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (evergreen, draft) is in draft — it hasn't started yet.
+
+Say that last one like this instead:
+  ${REFERENCE_MARKER_PREFIX}c1${REFERENCE_MARKER_SUFFIX} (evergreen) hasn't started yet — launch it when you're ready.
 `;
 
 /** True when `value` is a well-formed reference (used on the read-back path). */


### PR DESCRIPTION
Layer 1 of Maestro platform parity: the agent can now read the workspace's channels and campaigns, and every entity it names is a chip the user can click through to.

## What's here

**Channels** — `list_channels`, `get_channel_stats`, `connect_channel`.
**Campaigns** — `list_campaigns`, `get_campaign` (new module; campaigns were entirely absent from Maestro).
**Posts** — `list_posts` / `get_post` predated the reference system, so posts came out as plain text. They now return references too.

## The reference contract

References travel as **data, never URLs**. A tool returns the entities it found (kind, id, label, status, platform, variant); the model cites one inline as `[[ref:<id>]]`; the frontend resolves the marker and builds the href from the route table it already owns. The model knows ids only because a tool handed them over — a model that writes its own links writes broken ones. An unresolvable marker degrades to plain text rather than a dead link.

## Bugs this found and fixed

- **Google Drive listed as a connected channel.** The tool read every row in the channels table. Now derived from the PLATFORM via `CHANNEL_CATEGORY`, not the stored `category` column, which defaults to 'social' and is only correct where the backfill ran.
- **"bulk" leaking into user-facing text.** Every screen calls that campaign type "Simple"; `bulk` is the database's word and the user has never seen it. Found by showing a screenshot to three AI assistants — all three led with it, ahead of any wording issue.
- **`String(args.postId || '')`** turns an object argument into the string `"[object Object]"` and then looks up a post by that id. The approval path can reach a handler with stored args, so it coerces defensively now.

## Answer shape

`list_campaigns` returns `needsAttention` and `onTrack` already split, with counts, so the model leads with the conclusion instead of walking every campaign in list order and leaving the point for a trailing sentence. Each campaign carries the `suggestedAction` its status implies, so the prose says what to DO rather than restating what the status pill already shows.

## Verification

- 167 Maestro tests (all suites green), `nest build` clean, changed files lint clean.
- Tests were confirmed to bite by injecting the defects they guard. One tenant-boundary test passed against a real workspace-id leak, so it was rewritten until it failed, then the leak was reverted.
- Verified live in a browser against a running backend, not only in tests: post ids checked against the database row by row, campaign chips compared side by side with the Campaigns page, and the connect card clicked through to a real `POST /oauth/initiate` (200) landing on Instagram's own OAuth endpoint.

Frontend counterpart: asad00712/schedura-frontend `feat/maestro-platform-tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)